### PR TITLE
Voll-Akku-PV-Passthrough für Geräte mit MPPT-Abregelung (#189)

### DIFF
--- a/custom_components/battery_smartflow_ai/config_flow.py
+++ b/custom_components/battery_smartflow_ai/config_flow.py
@@ -794,6 +794,24 @@ class ZendureSmartFlowOptionsFlow(config_entries.OptionsFlow):
                         unit_of_measurement="%",
                     )
                 ),
+                vol.Optional("PV_HOUSELOAD_PASSTHROUGH_MIN_PV_W"): selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=20.0,
+                        max=300.0,
+                        step=5.0,
+                        mode=selector.NumberSelectorMode.BOX,
+                        unit_of_measurement="W",
+                    )
+                ),
+                vol.Optional("PV_HOUSELOAD_PASSTHROUGH_MIN_HOUSE_LOAD_W"): selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=20.0,
+                        max=300.0,
+                        step=5.0,
+                        mode=selector.NumberSelectorMode.BOX,
+                        unit_of_measurement="W",
+                    )
+                ),
             }
         )
 
@@ -824,6 +842,14 @@ class ZendureSmartFlowOptionsFlow(config_entries.OptionsFlow):
             "SOC_DISCHARGE_RESUME_MARGIN": current_overrides.get(
                 "SOC_DISCHARGE_RESUME_MARGIN",
                 profile.get("SOC_DISCHARGE_RESUME_MARGIN", 3.0),
+            ),
+            "PV_HOUSELOAD_PASSTHROUGH_MIN_PV_W": current_overrides.get(
+                "PV_HOUSELOAD_PASSTHROUGH_MIN_PV_W",
+                profile.get("PV_HOUSELOAD_PASSTHROUGH_MIN_PV_W", 120.0),
+            ),
+            "PV_HOUSELOAD_PASSTHROUGH_MIN_HOUSE_LOAD_W": current_overrides.get(
+                "PV_HOUSELOAD_PASSTHROUGH_MIN_HOUSE_LOAD_W",
+                profile.get("PV_HOUSELOAD_PASSTHROUGH_MIN_HOUSE_LOAD_W", 120.0),
             ),
         }
 

--- a/custom_components/battery_smartflow_ai/coordinator.py
+++ b/custom_components/battery_smartflow_ai/coordinator.py
@@ -1085,6 +1085,18 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         reason = str(decision.reason or "idle")
         now_utc = dt_util.as_utc(now)
 
+        # MPPT_CLIPS_WITHOUT_OUTPUT: Der Voll-Akku-Passthrough darf nicht von
+        # einer Ladebindung verdrängt werden. Er ist nur aktiv, wenn der Akku
+        # praktisch voll ist (>= soc_max - 1), die Bindung kann dann ohnehin
+        # nichts laden (BMS nimmt nichts mehr an), würde aber im Input-Modus
+        # den Output schließen und damit die PV abregeln. Die Bindung bleibt
+        # bestehen und übernimmt wieder, sobald der Passthrough loslässt.
+        if (
+            reason == "pv_house_load_passthrough"
+            and bool(self._persist.get("pv_houseload_passthrough_forced", False))
+        ):
+            return decision
+
         commit = self._get_charge_commit()
         
         (
@@ -2464,6 +2476,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         profile: dict[str, Any],
         soc: float,
         soc_min: float,
+        soc_max: float,
         pv_w: float,
         house_load_w: float,
         grid_import_w: float,
@@ -2498,6 +2511,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         stop_reason = "none"
         target_w = 0.0
+        forced = False
 
         protection_active = bool(
             discharge_blocked_by_soc_min
@@ -2532,6 +2546,42 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             import_val = max(0.0, float(grid_import_w or 0.0))
             pv_charge_latched = bool(self._persist.get("sf800_pv_charge_latched", False))
 
+            # MPPT_CLIPS_WITHOUT_OUTPUT: Geräte wie der SF800Pro regeln den
+            # MPPT auf 0 W ab, sobald weder Akku noch Output den PV-Strom
+            # abnehmen (Akku voll + Einspeiseverbot). Der Messwert ist dann
+            # dauerhaft 0, obwohl das Panel liefern könnte. Deshalb bleibt
+            # der Passthrough bei vollem Akku während des Tages dauerhaft
+            # offen (Output = Hauslast), statt auf gemessene PV zu warten.
+            forced_prev = bool(
+                self._persist.get("pv_houseload_passthrough_forced", False)
+            )
+            forced = False
+            if bool(profile.get("MPPT_CLIPS_WITHOUT_OUTPUT", False)):
+                sun_up = False
+                sun_state = self.hass.states.get("sun.sun")
+                if sun_state is not None:
+                    try:
+                        sun_up = (
+                            float(sun_state.attributes.get("elevation", -90.0))
+                            > 0.0
+                        )
+                    except (TypeError, ValueError):
+                        sun_up = False
+
+                # Ab soc_max - 1 gilt der Akku als voll (BMS nimmt dort
+                # bereits nichts mehr an und das Gerät regelt die PV ab).
+                soc_full = float(soc) >= float(soc_max) - 1.0
+                # Hysterese: einmal aktiviert, erst unter soc_max - 2 %
+                # wieder loslassen, sonst pendeln Laden/Passthrough.
+                soc_holds = float(soc) >= float(soc_max) - 2.0
+
+                forced = (
+                    sun_up
+                    and not pv_charge_latched
+                    and min(house_val, float(max_output_w or 0.0)) >= 60.0
+                    and (soc_full or (forced_prev and soc_holds))
+                )
+
             raw_target_w = min(
                 pv_val,
                 house_val,
@@ -2565,7 +2615,35 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 except Exception:
                     hold_active = False
 
-            if active:
+            if forced:
+                # Dauer-Passthrough bei vollem Akku: Output auf Hauslast
+                # halten, damit die PV jederzeit sofort liefern kann. Die
+                # normalen Exit-Prüfungen (pv_low, Export-Handover) greifen
+                # hier bewusst nicht, denn die PV-Ladung kann bei vollem Akku
+                # nichts übernehmen, ein Handover würde den MPPT wieder
+                # abregeln.
+                if not active:
+                    self._persist["pv_houseload_passthrough_started_ts"] = (
+                        dt_util.as_utc(now).isoformat()
+                    )
+                active = True
+                # Output folgt der gemessenen PV (+20 W Luft, damit der MPPT
+                # hochklettern kann), mit einem kleinen Sockel, der ihn wach
+                # hält. So liefert die PV immer sofort, aber der Akku speist
+                # nicht die Hauslast, während der Strompreis billig ist;
+                # das Defizit deckt bewusst das Netz.
+                floor_w = float(
+                    profile.get("PV_HOUSELOAD_PASSTHROUGH_MIN_OUTPUT_W", 80.0)
+                    or 80.0
+                )
+                target_w = min(
+                    house_val,
+                    float(max_output_w or 0.0),
+                    max(pv_val + 20.0, floor_w),
+                )
+                stop_reason = "full_battery_pv_passthrough"
+
+            elif active:
                 if not enough_pv:
                     if hold_active:
                         stop_reason = "hold_pv_low"
@@ -2640,6 +2718,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             )
 
         self._persist["pv_houseload_passthrough_active"] = bool(active)
+        self._persist["pv_houseload_passthrough_forced"] = bool(forced)
         self._persist["pv_houseload_passthrough_export_counter"] = int(export_counter)
         self._persist["pv_houseload_passthrough_target_w"] = float(target_w or 0.0)
         self._persist["pv_houseload_passthrough_stop_reason"] = str(stop_reason)
@@ -3808,6 +3887,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         profile=profile,
                         soc=float(soc),
                         soc_min=float(soc_min),
+                        soc_max=float(soc_max),
                         pv_w=float(pv_w),
                         house_load_w=float(house_load),
                         grid_import_w=float(grid_import or 0.0),

--- a/custom_components/battery_smartflow_ai/device_profiles.py
+++ b/custom_components/battery_smartflow_ai/device_profiles.py
@@ -57,6 +57,22 @@ PROFILE_OVERRIDE_FIELDS = {
         "unit": "%",
         "icon": "mdi:battery-sync",
     },
+    "PV_HOUSELOAD_PASSTHROUGH_MIN_PV_W": {
+        "label": "Passthrough Mindest-PV",
+        "min": 20.0,
+        "max": 300.0,
+        "step": 5.0,
+        "unit": "W",
+        "icon": "mdi:solar-power-variant-outline",
+    },
+    "PV_HOUSELOAD_PASSTHROUGH_MIN_HOUSE_LOAD_W": {
+        "label": "Passthrough Mindest-Hauslast",
+        "min": 20.0,
+        "max": 300.0,
+        "step": 5.0,
+        "unit": "W",
+        "icon": "mdi:home-lightning-bolt-outline",
+    },
     "CHARGE_DEADBAND_W": {
         "label": "Laden Deadband",
         "min": 0.0,
@@ -198,6 +214,10 @@ V42_LATCH_HOLD_DEFAULTS = {
 
 V42_DEFAULT_CAPABILITIES = {
     "SUPPORTS_PASSTHROUGH": False,
+    # Device quirk: MPPT regelt auf 0 W ab, sobald weder Akku noch Output
+    # den PV-Strom abnehmen können (z. B. Akku voll + Einspeiseverbot).
+    # Der MPPT läuft erst wieder an, wenn der Output geöffnet wird.
+    "MPPT_CLIPS_WITHOUT_OUTPUT": False,
     "OUTPUT_ZERO_IS_NEUTRAL": True,
     "INPUT_KEEPALIVE_SAFE": True,
     "REQUIRES_STABLE_EXPORT_FOR_INPUT": False,
@@ -207,6 +227,7 @@ V42_DEFAULT_CAPABILITIES = {
 
 V42_SF800PRO_CAPABILITIES = {
     "SUPPORTS_PASSTHROUGH": True,
+    "MPPT_CLIPS_WITHOUT_OUTPUT": True,
     "OUTPUT_ZERO_IS_NEUTRAL": True,
     "INPUT_KEEPALIVE_SAFE": False,
     "REQUIRES_STABLE_EXPORT_FOR_INPUT": True,


### PR DESCRIPTION
Wie in #189 besprochen, hier der Fix als PR statt nur als Fehlerbeschreibung. Läuft seit dem 19.07. produktiv auf meinem SF800 Pro 2, Basis ist euer aktueller main (dev5.7).

Kern ist das Profil-Flag MPPT_CLIPS_WITHOUT_OUTPUT, also die true/false-Geschichte, die du im Issue angekündigt hattest. Es beschreibt die Geraete-Eigenheit, dass der MPPT auf 0 W abregelt, sobald weder Akku noch Output den PV-Strom abnehmen. Gesetzt ist es nur bei SF800Pro und SF800Pro2, alle anderen Profile verhalten sich exakt wie vorher.

Solange der Akku praktisch voll ist (SoC >= soc_max - 1, Hysterese bis soc_max - 2) und die Sonne ueber dem Horizont steht, bleibt der vorhandene PV-Hauslast-Passthrough dauerhaft offen. Der Output folgt dabei der gemessenen PV plus 20 W Luft (Sockel 80 W ueber PV_HOUSELOAD_PASSTHROUGH_MIN_OUTPUT_W), so kann der MPPT jederzeit hochklettern, aber der Akku speist nicht die Hauslast, während der Strompreis unter der Entladeschwelle liegt. Grund im Status: full_battery_pv_passthrough.

Nettes Detail am Rande: ich habe testweise smartMode 1 ohne Messwert-Kopplung laufen lassen, und die Firmware macht im Leerlauf fast exakt dasselbe (Output = PV + ~20 W, Akku-Beteiligung einstellig). Der Patch repliziert also das native Verhalten, nur eben unter Kontrolle der Integration.

Nebenbei sind PV_HOUSELOAD_PASSTHROUGH_MIN_PV_W und _MIN_HOUSE_LOAD_W jetzt in PROFILE_OVERRIDE_FIELDS und im general-Optionsformular. Meine Grundlast liegt bei 90-140 W, mit den festen 120 W konnte der Passthrough hier sonst kaum halten.

Messdaten:

Ohne Fix am 18.07.: Akku voll um 13:18, MPPT binnen Sekunden auf 0 (vorher 524 W Maximum), PV bis 18:30 komplett tot trotz Sonne, geerntet 0,76 kWh. Erst die Abendentladung hat den MPPT geweckt.

Mit Fix am 19.07. um 18:50: Aktivierung bei SoC 99, Output ging auf, die PV lieferte sofort wieder (31 W Abendsonne nach Stunden Abregelung). Am 20.07. um 13:49 bei vollem Akku: PV 107 W fließen durch, Output 128 W, Akku-Beteiligung 21 W, Netz nahe 0.

Ein Punkt für dich: PvHouseLoadPassthroughRule deaktiviert sich bei season = summer. Bei mir steht der Saisonkontext auf winter_like, daher greift der Fix. Falls Sommer-Nutzer denselben MPPT-Effekt haben, müsste der Summer-Zweig das Flag ebenfalls berücksichtigen, das wollte ich aber nicht ungetestet anfassen.

Bewusst klein gehalten und rein additiv, damit es in deine laufende V4.3-Arbeit passt. Wenn du es anders integrieren willst, nimm es als Vorlage.
