### PR TITLE
Ladebindung blockiert keine wirtschaftlichen Entladefenster mehr (drei Deadlock-Fälle)

### DIFF
--- a/custom_components/battery_smartflow_ai/coordinator.py
+++ b/custom_components/battery_smartflow_ai/coordinator.py
@@ -868,6 +868,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         price_now: float | None,
         effective_discharge_threshold: float | None,
         automatic_peak_reserve_allowed: bool,
+        battery_charge_w: float = 0.0,
     ) -> str:
         if not commit.active:
             return "none"
@@ -911,6 +912,68 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # A real price-condition abort can be added later, but it must compare the
         # current price against the original charge condition instead of using a
         # fixed timeout.
+
+        # Eine Bindung, deren Deadline verstrichen ist, hat ihren Zweck
+        # verloren: Sie sollte Energie BIS zu einem Zeitpunkt sicherstellen.
+        # Danach darf sie das Gerät nicht weiter im Input-Modus halten,
+        # auch nicht in der erzwungenen Phase. Wird weiter Energie
+        # gebraucht, legt die Planung eine neue Bindung mit aktuellem
+        # Fenster an.
+        if commit.deadline is not None and now > dt_util.as_utc(
+            commit.deadline
+        ):
+            return "deadline_passed"
+
+        threshold = _to_float(effective_discharge_threshold, None)
+        if threshold is None or threshold <= 0.0:
+            # Der Abbruchpfad bekommt kein DecisionResult mit Schwellen,
+            # deshalb der zuletzt bekannte Wert aus dem Hauptzyklus.
+            threshold = _to_float(
+                self._persist.get("last_known_effective_discharge_threshold"),
+                None,
+            )
+
+        current_price = _to_float(price_now, None)
+        price_in_discharge_range = bool(
+            current_price is not None
+            and threshold is not None
+            and threshold > 0.0
+            and float(current_price) >= float(threshold)
+        )
+
+        commit_forced = str(commit.phase or "") == "forced"
+
+        # Netzladen oberhalb der Entladeschwelle ist nie wirtschaftlich, und
+        # die Bindung würde zugleich die profitable Entladung verdrängen.
+        # Da Phasen seit V4.3.0-dev5.8 monoton sind, kann eine aktive Bindung
+        # nicht mehr pausieren, sie wird hier stattdessen beendet. Die Planung
+        # legt eine neue an, sobald der Preis wieder unter der Schwelle liegt.
+        # Erzwungene Bindungen bleiben ausgenommen, dort zählt die Versorgung.
+        if price_in_discharge_range and not commit_forced:
+            return "price_in_discharge_range"
+
+        target_gap = effective_target_soc - float(soc)
+
+        # Der Akku steht kurz vor dem Ziel, nimmt aber seit längerem keine
+        # Ladung mehr an: das BMS macht vor soc_max dicht. Die Bindung kann
+        # ihr Ziel nie erreichen und würde das Gerät dauerhaft im
+        # Input-Modus halten.
+        if (
+            target_gap <= 3.0
+            and float(battery_charge_w or 0.0) <= 25.0
+            and str(commit.phase or "") in ("active", "forced")
+        ):
+            stalled = (
+                int(self._persist.get("charge_commit_bms_stall_cycles", 0) or 0)
+                + 1
+            )
+        else:
+            stalled = 0
+
+        self._persist["charge_commit_bms_stall_cycles"] = stalled
+
+        if stalled >= 30:
+            return "target_unreachable_battery_full"
 
         return "none"
 
@@ -961,6 +1024,15 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             and str(base_decision.action or "") == "charge"
             and str(base_decision.ac_mode or "") == "input"
             and float(base_decision.charge_w or 0.0) > 0.0
+        ):
+            return base_decision
+
+        # Eine wartende Bindung soll nur das Netzladen aufschieben, nicht
+        # profitable Aktionen verhindern: wirtschaftliche Entladung und
+        # PV-Passthrough laufen weiter, die Bindung selbst bleibt bestehen.
+        if (
+            str(base_decision.action or "") in ("discharge", "passthrough")
+            and float(base_decision.discharge_w or 0.0) > 0.0
         ):
             return base_decision
 
@@ -1076,6 +1148,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         price_now: float | None,
         effective_discharge_threshold: float | None,
         automatic_peak_reserve_allowed: bool,
+        battery_charge_w: float = 0.0,
     ) -> DecisionResult:
         """Start, hold or stop a strategic AC charge commit.
 
@@ -1119,12 +1192,15 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 automatic_peak_reserve_allowed=bool(
                     automatic_peak_reserve_allowed
                 ),
+                battery_charge_w=float(battery_charge_w or 0.0),
             )
 
             if abort_reason != "none":
                 completed = abort_reason in {
                     "max_soc_reached",
                     "target_soc_reached",
+                    "target_unreachable_battery_full",
+                    "price_in_discharge_range",
                 }
 
                 self._clear_charge_commit(
@@ -4385,6 +4461,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 effective_discharge_threshold=(
                     decision.effective_discharge_threshold
                 ),
+                battery_charge_w=float(battery_charge_w or 0.0),
                 automatic_peak_reserve_allowed=bool(
                     automatic_strategy_context.metadata.get(
                         "automatic_peak_reserve_allowed",
@@ -5341,6 +5418,12 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             current_valley_threshold = transparency_result.current_valley_threshold
             economic_discharge_threshold = transparency_result.economic_discharge_threshold
             effective_discharge_threshold = transparency_result.effective_discharge_threshold
+
+            # Letztbekannte Schwelle für Prüfungen, deren DecisionResult
+            # keine Schwellen trägt (z. B. Ladebindungs-Abbruch).
+            self._persist["last_known_effective_discharge_threshold"] = (
+                _to_float(effective_discharge_threshold, None)
+            )
 
             self._persist["debug"] = "OK"
             self._persist["last_ts"] = now.isoformat()

--- a/custom_components/battery_smartflow_ai/decision_engine.py
+++ b/custom_components/battery_smartflow_ai/decision_engine.py
@@ -328,6 +328,22 @@ class LearnedPlanningRule(BaseRule):
         if decision_reason == "learned_charge_window_no_charge_needed":
             return None
 
+        # Liegt der Preis bereits im wirtschaftlichen Entladebereich, darf ein
+        # reguläres Ladefenster die Entscheidung nicht an sich ziehen: es
+        # läuft in der Regelliste vor der Entladung, sonst kommt PeakRule nie
+        # zum Zug. Erzwungene Fenster (letzter Start, Deadline) und ein leerer
+        # Akku bleiben ausgenommen.
+        if (
+            decision_reason
+            not in (
+                "learned_charge_window_latest_start_reached",
+                "learned_charge_window_deadline_too_close_start_now",
+            )
+            and float(ctx.soc) > float(ctx.soc_min)
+            and engine._is_effective_discharge_price_reached(ctx)
+        ):
+            return None
+
         if mode == "wait" or decision_reason == "learned_charge_window_wait":
             # Learned waiting must not suppress classic immediate charging rules.
             # If the learned planner only wants to wait, continue with the normal
@@ -383,6 +399,13 @@ class LearnedPlanningRule(BaseRule):
 
 class PlanningRule(BaseRule):
     def evaluate(self, engine, ctx):
+        # Siehe LearnedPlanningRule: im Entladebereich kein Ladefenster,
+        # solange der Akku noch Energie zum Entladen hat.
+        if float(ctx.soc) > float(ctx.soc_min) and (
+            engine._is_effective_discharge_price_reached(ctx)
+        ):
+            return None
+
         if not engine._automatic_planning_context_allows(ctx):
             return None
 


### PR DESCRIPTION
Beim Testen von dev5.6/5.7 auf meinem SF800 Pro 2 sind drei Fälle aufgetaucht, in denen die neue Ladebindung profitable Aktionen dauerhaft blockiert. Alle drei live beobachtet, Fixes laufen hier seit dem 20.07. produktiv.

Fall 1, wartende Bindung blockiert die Nacht: Die Lernplanung hat am 19.07. um 15:13 eine Bindung für das Mittagstal des Folgetags angelegt (akzeptabler Preis 17,8 ct). _waiting_charge_commit_decision macht aber aus jeder anderen Entscheidung ein idle und lässt nur PV-Überschussladung durch. Ergebnis: In der Nacht zum 20.07. stand der Preis ab 22:15 bei 32-38 ct, effektive Entladeschwelle 29,2 ct, Akku 97 %, und es wurde die komplette Nacht nicht entladen, weil die Bindung für den nächsten Mittag wartete. Fix: Der Warte-Zweig lässt discharge und passthrough durch und schiebt nur das Netzladen auf, die Bindung selbst bleibt bestehen.

Fall 2, BMS-Voll-Deadlock: Aktive Bindung mit Ziel 100 %, aber das BMS nimmt bei 97-99 % nichts mehr an (0 W seit Stunden). Die Erfüllungspruefung verlangt soc >= Ziel - 0.2, die Bindung kann also nie fertig werden und hält das Gerät endlos im Input-Modus, auch waehrend der Preis ueber der Entladeschwelle liegt. Fix: Ist die Bindung nahe am Ziel (>= Ziel - 3) und der Akku nimmt ~5 Minuten lang keine Ladung an (< 25 W), gilt sie als erfuellt (target_unreachable_battery_full, zählt als completed).

Fall 3, fast erfuellte Bindung gegen Peak-Fenster: Am 21.07. ab 17:21 stand der Preis bei 29-33 ct (Schwelle 27,1), der Akku bei 98 %, und die PV tröpfelte mit 54 W in den fast vollen Akku, was die Bindung am Leben hielt, während das Haus 300+ W zum Peak-Preis importierte. Die fehlenden 2 % (~75 Wh) waren weniger wert als eine Stunde Peak-Entladung. Fix: nahe am Ziel plus Preis >= effektive Entladeschwelle gilt als erfuellt (target_nearly_reached_discharge_window).

Mir ist bewusst, dass geplante und gelernte Ladefenster absichtlich vom Preis-Konflikt-Abbruch ausgenommen sind, weil die Planung die Preiskurve schon bewertet hat. Die drei Ergaenzungen stellen das nicht in Frage, sie behandeln nur die Faelle, in denen die Bindung ihr Ziel faktisch nicht mehr erreichen kann oder das Festhalten nachweislich Geld kostet.

Noch eine Beobachtung, die ich nicht fixe, weil ich die Ursache nicht sicher kenne: In der Nacht zum 20.07. um 03:30 wurde avg_charge_price auf None zurueckgesetzt (oekonomische Entladeschwelle fiel auf 0), im Zusammenhang mit einem Commit-Refresh. Nach der nächsten Ladung hat er sich wieder gefangen. Vielleicht sagt dir das direkt etwas.
