### PR TITLE
Releasevertrag auf V4.4.2 aktualisieren

### DIFF
--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -13,7 +13,7 @@ COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
 
 
 class DebugIntegrationContractTests(unittest.TestCase):
-    def test_manifest_and_runtime_version_match_v441_release(self) -> None:
+    def test_manifest_and_runtime_version_match_v442_release(self) -> None:
         manifest_version = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )["version"]
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "4.4.1")
+        self.assertEqual(manifest_version, "4.4.2")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:


### PR DESCRIPTION
## Änderung

- aktualisiert den statischen Versionsvertrag von 4.4.1 auf die bereits in `manifest.json` und `const.py` gesetzte Releaseversion 4.4.2
- benennt den Test passend zur V4.4.2-Freigabe

## Hintergrund

Der Fix für Issue #231 und die Versionsanhebung auf 4.4.2 sind bereits auf `main`. Beim Versionssprung blieb lediglich die explizite Erwartung im lokalen Integrationstest auf 4.4.1 stehen. Der Produktivcode ist davon nicht betroffen; dieser Commit stellt eine vollständig grüne Release-Testsuite her.

## Prüfung

- 130 von 130 Unit- und Vertragstests erfolgreich
- Python-Kompilierung erfolgreich
- `git diff --check` erfolgreich
- Hassfest- und HACS-Workflow für den 4.4.2-`main`-Stand erfolgreich
