### PR TITLE
V4.5.0-Beta1: Internationale Preiswährungen

### DIFF
--- a/custom_components/battery_smartflow_ai/automatic_strategy.py
+++ b/custom_components/battery_smartflow_ai/automatic_strategy.py
@@ -94,14 +94,15 @@ class AutomaticStrategy:
             or price_max is None
             or float(price_max) <= float(price_min)
         ):
-            if price_average is None or float(price_average) <= 0.0:
+            if price_average is None:
                 return 0.35, "price_range_missing"
 
-            deviation = abs(current - float(price_average))
-            relative_deviation = deviation / max(
-                0.01,
-                float(price_average),
-            )
+            average = float(price_average)
+            deviation = abs(current - average)
+            magnitude = max(abs(current), abs(average))
+            if magnitude <= 0.0:
+                return 0.35, "price_range_missing"
+            relative_deviation = deviation / magnitude
 
             return (
                 _clamp01(0.30 + relative_deviation),
@@ -110,7 +111,7 @@ class AutomaticStrategy:
 
         low = float(price_min)
         high = float(price_max)
-        span = max(0.001, high - low)
+        span = high - low
         position = _clamp01((current - low) / span)
 
         # Distance from the center:

--- a/custom_components/battery_smartflow_ai/charge_economics.py
+++ b/custom_components/battery_smartflow_ai/charge_economics.py
@@ -7,6 +7,36 @@ from datetime import datetime
 from typing import Any, Mapping
 
 
+TRADE_SOC_MIN_RESET_CONFIRM_CYCLES = 3
+
+
+def trade_soc_min_reset_state(
+    *,
+    soc: float,
+    soc_min: float,
+    previous_count: int,
+    previously_confirmed: bool,
+    required_cycles: int = TRADE_SOC_MIN_RESET_CONFIRM_CYCLES,
+) -> tuple[int, bool]:
+    """Confirm a real SoC-min event without trusting one transient sample.
+
+    Some battery integrations briefly expose 0 percent while their entities
+    refresh. Clearing the economic charge ledger on that single sample loses
+    the average charge price permanently. A real low-SoC condition remains
+    eligible after a short sequence of consecutive update cycles.
+    """
+
+    if float(soc) > float(soc_min):
+        return 0, False
+
+    required = max(1, int(required_cycles))
+    if previously_confirmed:
+        return required, True
+
+    count = min(required, max(0, int(previous_count)) + 1)
+    return count, count >= required
+
+
 def resolve_feed_in_tariff(
     *,
     data: Mapping[str, Any],
@@ -34,7 +64,7 @@ class ChargePricing:
 
     active: bool
     is_grid_charge: bool
-    price_eur_kwh: float
+    price_per_kwh: float
     source: str
     grid_part_w: float
     pv_part_w: float
@@ -50,7 +80,7 @@ def inactive_charge_pricing(source: str = "no_charge_command") -> ChargePricing:
     return ChargePricing(
         active=False,
         is_grid_charge=False,
-        price_eur_kwh=0.0,
+        price_per_kwh=0.0,
         source=str(source),
         grid_part_w=0.0,
         pv_part_w=0.0,
@@ -106,7 +136,7 @@ def classify_charge_pricing(
         return ChargePricing(
             active=True,
             is_grid_charge=False,
-            price_eur_kwh=pv_price,
+            price_per_kwh=pv_price,
             source="pv_surplus_export",
             grid_part_w=0.0,
             pv_part_w=charge_w,
@@ -130,7 +160,7 @@ def classify_charge_pricing(
         return ChargePricing(
             active=True,
             is_grid_charge=False,
-            price_eur_kwh=pv_price,
+            price_per_kwh=pv_price,
             source="pv_or_free_low_import",
             grid_part_w=0.0,
             pv_part_w=charge_w,
@@ -140,7 +170,7 @@ def classify_charge_pricing(
         return ChargePricing(
             active=True,
             is_grid_charge=False,
-            price_eur_kwh=pv_price,
+            price_per_kwh=pv_price,
             source="price_missing_assume_pv_opportunity",
             grid_part_w=0.0,
             pv_part_w=charge_w,
@@ -166,7 +196,7 @@ def classify_charge_pricing(
     return ChargePricing(
         active=True,
         is_grid_charge=grid_part_w > max(60.0, charge_w * 0.10),
-        price_eur_kwh=float(mixed_price),
+        price_per_kwh=float(mixed_price),
         source=str(source),
         grid_part_w=float(grid_part_w),
         pv_part_w=float(pv_part_w),
@@ -202,7 +232,10 @@ def recent_charge_evidence(
     try:
         age_seconds = (now - updated_at).total_seconds()
         energy_wh = max(0.0, float(raw.get("energy_wh", 0.0) or 0.0))
-        cost_eur = float(raw.get("cost_eur", 0.0) or 0.0)
+        # V4.5.0 reads the former EUR-named field so pending evidence created
+        # before the update remains usable. Numeric values are preserved as-is;
+        # there is no exchange-rate conversion.
+        cost = float(raw.get("cost", raw.get("cost_eur", 0.0)) or 0.0)
         grid_energy_wh = max(
             0.0,
             float(raw.get("grid_energy_wh", 0.0) or 0.0),
@@ -225,7 +258,7 @@ def recent_charge_evidence(
 
     return {
         "energy_wh": energy_wh,
-        "cost_eur": cost_eur,
+        "cost": cost,
         "grid_energy_wh": min(grid_energy_wh, energy_wh),
         "pv_energy_wh": min(pv_energy_wh, energy_wh),
         "duration_seconds": duration_seconds,
@@ -249,7 +282,7 @@ def add_charge_evidence(
     duration_seconds = max(1.0, min(float(duration_seconds), 30.0))
     existing = recent_charge_evidence(raw, now=now) or {
         "energy_wh": 0.0,
-        "cost_eur": 0.0,
+        "cost": 0.0,
         "grid_energy_wh": 0.0,
         "pv_energy_wh": 0.0,
         "duration_seconds": 0.0,
@@ -263,8 +296,8 @@ def add_charge_evidence(
 
     return {
         "energy_wh": float(existing["energy_wh"]) + energy_wh,
-        "cost_eur": float(existing["cost_eur"])
-        + (energy_wh / 1000.0) * float(pricing.price_eur_kwh),
+        "cost": float(existing["cost"])
+        + (energy_wh / 1000.0) * float(pricing.price_per_kwh),
         "grid_energy_wh": float(existing["grid_energy_wh"]) + grid_energy_wh,
         "pv_energy_wh": float(existing["pv_energy_wh"]) + pv_energy_wh,
         "duration_seconds": float(existing["duration_seconds"]) + duration_seconds,
@@ -289,7 +322,7 @@ def pricing_from_charge_evidence(
     grid_energy_wh = float(evidence["grid_energy_wh"])
     pv_energy_wh = float(evidence["pv_energy_wh"])
 
-    price = float(evidence["cost_eur"]) / (energy_wh / 1000.0)
+    price = float(evidence["cost"]) / (energy_wh / 1000.0)
     grid_part_w = grid_energy_wh / duration_hours
     pv_part_w = pv_energy_wh / duration_hours
     total_power_w = grid_part_w + pv_part_w
@@ -302,7 +335,7 @@ def pricing_from_charge_evidence(
     return ChargePricing(
         active=True,
         is_grid_charge=grid_part_w > max(60.0, total_power_w * 0.10),
-        price_eur_kwh=float(price),
+        price_per_kwh=float(price),
         source=source,
         grid_part_w=float(grid_part_w),
         pv_part_w=float(pv_part_w),

--- a/custom_components/battery_smartflow_ai/config_flow.py
+++ b/custom_components/battery_smartflow_ai/config_flow.py
@@ -58,6 +58,7 @@ from .const import (
 )
 
 from .device_profiles import DEVICE_PROFILES
+from .price_currency import price_input_profile, resolve_price_currency
 
 EMPTY_ENTITY_VALUES = {
     "",
@@ -274,6 +275,10 @@ class ZendureSmartFlowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return value
 
         schema: dict[Any, Any] = {}
+        currency = resolve_price_currency(
+            getattr(self.hass.config, "currency", None)
+        )
+        price_profile = price_input_profile(currency)
 
         schema[
             vol.Required(
@@ -356,9 +361,14 @@ class ZendureSmartFlowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     DEFAULT_FEED_IN_TARIFF,
                 ),
             )
-        ] = vol.All(
-            vol.Coerce(float),
-            vol.Range(min=0.0, max=1.0),
+        ] = selector.NumberSelector(
+            selector.NumberSelectorConfig(
+                min=0.0,
+                max=price_profile.maximum,
+                step=price_profile.step,
+                mode=selector.NumberSelectorMode.BOX,
+                unit_of_measurement=currency.price_unit,
+            )
         )
 
         pv_forecast_today_val = _val(CONF_PV_FORECAST_TODAY_ENTITY)

--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -10,7 +10,7 @@ DOMAIN = "battery_smartflow_ai"
 INTEGRATION_NAME = "Battery SmartFlow AI"
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "4.4.2"
+INTEGRATION_VERSION = "4.5.0-Beta1"
 
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,
@@ -28,7 +28,7 @@ CONF_SOC_LIMIT_ENTITY = "soc_limit_entity"
 
 # Preis ist optional (Sommer/PV-only Nutzer)
 CONF_PRICE_EXPORT_ENTITY = "price_export_entity"  # Tibber Export (attributes.data)
-CONF_PRICE_NOW_ENTITY = "price_now_entity"        # direkter Preis-Sensor (€/kWh)
+CONF_PRICE_NOW_ENTITY = "price_now_entity"        # direct price sensor (currency/kWh)
 
 CONF_ADDITIONAL_BATTERY_CHARGE_ENTITY = "additional_battery_charge_entity"
 CONF_ADDITIONAL_BATTERY_DISCHARGE_ENTITY = "additional_battery_discharge_entity"
@@ -214,8 +214,6 @@ DEFAULT_SOC_MAX = 100.0  # Herstellerempfehlung ✔
 DEFAULT_MAX_CHARGE = 2400.0
 DEFAULT_MAX_DISCHARGE = 700.0
 
-DEFAULT_PRICE_THRESHOLD = 0.35
-DEFAULT_VERY_EXPENSIVE_THRESHOLD = 0.49
 
 DEFAULT_EMERGENCY_SOC = 8.0
 DEFAULT_EMERGENCY_CHARGE = 1200.0

--- a/custom_components/battery_smartflow_ai/coordinator.py
+++ b/custom_components/battery_smartflow_ai/coordinator.py
@@ -71,8 +71,6 @@ from .const import (
     DEFAULT_SOC_MAX,
     DEFAULT_MAX_CHARGE,
     DEFAULT_MAX_DISCHARGE,
-    DEFAULT_PRICE_THRESHOLD,
-    DEFAULT_VERY_EXPENSIVE_THRESHOLD,
     DEFAULT_EMERGENCY_SOC,
     DEFAULT_EMERGENCY_CHARGE,
     DEFAULT_PROFIT_MARGIN_PCT,
@@ -155,6 +153,7 @@ from .charge_economics import (
     pricing_from_charge_evidence,
     recent_charge_evidence,
     resolve_feed_in_tariff,
+    trade_soc_min_reset_state,
 )
 from .automatic_strategy import AutomaticStrategy
 from .strategy_adapter import decision_to_strategy_intent
@@ -175,6 +174,13 @@ from .command_effectiveness import (
 from .debug_recorder import DebugRecorder
 from .debug_exporter import DebugExportError, export_debug_package
 from .debug_sample_builder import build_debug_sample
+from .price_currency import (
+    PriceCurrency,
+    migrate_legacy_price_fields,
+    price_input_profile,
+    resolve_price_currency,
+)
+from .price_math import comparison_tolerance
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -182,11 +188,6 @@ STORE_VERSION = 1
 ACTIVE_STATUS_DISPLAY_HOLD_S = 60
 
 CHARGE_COMMIT_PRICE_VALID_MINUTES = 20
-
-# V4.3.0-dev5.0.1:
-# Small hysteresis for the strategic AC-charge price guard.
-# Prevents a charge binding from flickering exactly at the discharge threshold.
-STRATEGIC_AC_CHARGE_PRICE_GUARD_MARGIN_EUR_KWH = 0.005
 
 # V4.3.0-dev5.8.3:
 # Treat a strategic AC charge target as practically reached when the battery
@@ -298,6 +299,19 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
         self.hass = hass
         self.entry = entry
+        self.price_currency: PriceCurrency = resolve_price_currency(
+            getattr(hass.config, "currency", None)
+        )
+
+        if self.price_currency.used_fallback:
+            _LOGGER.warning(
+                "Home Assistant has no valid system currency; using %s for "
+                "Battery SmartFlow AI price units",
+                self.price_currency.code,
+            )
+        self.price_comparison_tolerance = comparison_tolerance(
+            price_input_profile(self.price_currency).step
+        )
 
         self.device_profile_key = (
             entry.options.get(CONF_DEVICE_PROFILE)
@@ -361,7 +375,10 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         )
         
         self._regulation_power_controller = RegulationPowerController(
-            build_regulation_power_config(self._get_active_profile())
+            build_regulation_power_config(
+                self._get_active_profile(),
+                price_step=price_input_profile(self.price_currency).step,
+            )
         )
         
         self._device_command_builder = DeviceCommandBuilder()
@@ -388,13 +405,14 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "trade_avg_charge_price": None,
             "trade_charged_kwh": 0.0,
             "trade_cycle_below_soc_min": False,
+            "trade_soc_min_reset_count": 0,
             "prev_soc": None,
             "pending_charge_price_evidence": None,
 
             "avg_charge_price": None,
             "charged_kwh": 0.0,
             "discharged_kwh": 0.0,
-            "profit_eur": 0.0,
+            "profit": 0.0,
             "last_ts": None,
 
             # season detection
@@ -487,12 +505,12 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "charge_commit_optimal_start": None,
             "charge_commit_latest_start": None,
             "charge_commit_deadline": None,
-            "charge_commit_acceptable_price_eur_kwh": None,
+            "charge_commit_acceptable_price_per_kwh": None,
 
             "charge_commit_requested_power_w": 0.0,
             "charge_commit_allow_pv_blend": True,
             "charge_commit_abort_reason": "none",
-            "charge_commit_price_eur_kwh": None,
+            "charge_commit_price_per_kwh": None,
 
             # V4.3.0-dev5.8.3:
             # Start time of a continuously detected BMS/full-charge stall.
@@ -513,6 +531,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         data = await self._store.async_load()
         if isinstance(data, dict):
             self._persist.update(data)
+            migrate_legacy_price_fields(self._persist)
 
             # V4.2.2:
             # Normalize old persisted extreme values. Previous versions could let
@@ -704,9 +723,9 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     "charge_commit_deadline",
                 )
             ),
-            acceptable_price_eur_kwh=_to_float(
+            acceptable_price_per_kwh=_to_float(
                 self._persist.get(
-                    "charge_commit_acceptable_price_eur_kwh",
+                    "charge_commit_acceptable_price_per_kwh",
                 ),
                 None,
             ),
@@ -791,8 +810,8 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         )
 
         self._persist[
-            "charge_commit_acceptable_price_eur_kwh"
-        ] = commit.acceptable_price_eur_kwh
+            "charge_commit_acceptable_price_per_kwh"
+        ] = commit.acceptable_price_per_kwh
 
         self._persist["charge_commit_requested_power_w"] = float(
             commit.requested_power_w or 0.0
@@ -833,7 +852,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._persist["charge_commit_latest_start"] = None
         self._persist["charge_commit_deadline"] = None
         self._persist[
-            "charge_commit_acceptable_price_eur_kwh"
+            "charge_commit_acceptable_price_per_kwh"
         ] = None
 
         self._persist["charge_commit_requested_power_w"] = 0.0
@@ -841,7 +860,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._persist["charge_commit_abort_reason"] = str(
             abort_reason or "none"
         )
-        self._persist["charge_commit_price_eur_kwh"] = None
+        self._persist["charge_commit_price_per_kwh"] = None
         self._persist["charge_commit_bms_stall_started_at"] = None
 
 
@@ -898,7 +917,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         margin = max(
             0.0,
-            float(STRATEGIC_AC_CHARGE_PRICE_GUARD_MARGIN_EUR_KWH),
+            float(self.price_comparison_tolerance),
         )
 
         return float(current_price) >= (
@@ -1222,7 +1241,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         acceptable_price = _to_float(
             getattr(
                 learned_charge_plan,
-                "acceptable_charge_price_eur_kwh",
+                "acceptable_charge_price_per_kwh",
                 None,
             ),
             None,
@@ -1370,7 +1389,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
                 else:
                     acceptable_price = _to_float(
-                        commit.acceptable_price_eur_kwh,
+                        commit.acceptable_price_per_kwh,
                         None,
                     )
                     current_price = _to_float(
@@ -1385,7 +1404,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         > (
                             float(acceptable_price)
                             + float(
-                                STRATEGIC_AC_CHARGE_PRICE_GUARD_MARGIN_EUR_KWH
+                                self.price_comparison_tolerance
                             )
                         )
                     )
@@ -1453,7 +1472,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 if refreshed_until is not None:
                     commit.valid_until = refreshed_until
                 if price_now is not None:
-                    self._persist["charge_commit_price_eur_kwh"] = float(price_now)
+                    self._persist["charge_commit_price_per_kwh"] = float(price_now)
                 self._store_charge_commit(commit)
                 
             return self._committed_charge_decision(
@@ -1536,7 +1555,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         > (
                             float(acceptable_price)
                             + float(
-                                STRATEGIC_AC_CHARGE_PRICE_GUARD_MARGIN_EUR_KWH
+                                self.price_comparison_tolerance
                             )
                         )
                     ):
@@ -1576,7 +1595,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     if commit_type == "learned"
                     else None
                 ),
-                acceptable_price_eur_kwh=(
+                acceptable_price_per_kwh=(
                     learned_acceptable_price
                     if commit_type == "learned"
                     else None
@@ -1591,9 +1610,9 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self._store_charge_commit(new_commit)
             
             if price_now is not None:
-                self._persist["charge_commit_price_eur_kwh"] = float(price_now)
+                self._persist["charge_commit_price_per_kwh"] = float(price_now)
             else:
-                self._persist["charge_commit_price_eur_kwh"] = None
+                self._persist["charge_commit_price_per_kwh"] = None
                 
             if new_commit.phase == "waiting":
                 return self._waiting_charge_commit_decision(
@@ -3849,10 +3868,14 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 and float(profile_max_out) > 0.0
             )
 
-            expensive = self._get_setting(SETTING_PRICE_THRESHOLD, DEFAULT_PRICE_THRESHOLD)
+            price_profile = price_input_profile(self.price_currency)
+            expensive = self._get_setting(
+                SETTING_PRICE_THRESHOLD,
+                price_profile.default_expensive_threshold,
+            )
             very_expensive = self._get_setting(
                 SETTING_VERY_EXPENSIVE_THRESHOLD,
-                DEFAULT_VERY_EXPENSIVE_THRESHOLD,
+                price_profile.default_very_expensive_threshold,
             )
             emergency_soc = self._get_setting(SETTING_EMERGENCY_SOC, DEFAULT_EMERGENCY_SOC)
             emergency_w = self._get_setting(SETTING_EMERGENCY_CHARGE, DEFAULT_EMERGENCY_CHARGE)
@@ -4191,7 +4214,24 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 resume_margin=float(resume_margin),
             )
 
-            if float(soc) <= float(soc_min):
+            (
+                trade_soc_min_reset_count,
+                trade_cycle_below_soc_min,
+            ) = trade_soc_min_reset_state(
+                soc=float(soc),
+                soc_min=float(soc_min),
+                previous_count=int(
+                    self._persist.get("trade_soc_min_reset_count", 0) or 0
+                ),
+                previously_confirmed=bool(
+                    self._persist.get("trade_cycle_below_soc_min", False)
+                ),
+            )
+            self._persist["trade_soc_min_reset_count"] = (
+                trade_soc_min_reset_count
+            )
+
+            if trade_cycle_below_soc_min:
                 self._persist["trade_avg_charge_price"] = 0.0
                 self._persist["trade_charged_kwh"] = 0.0
                 self._persist["trade_cycle_below_soc_min"] = True
@@ -4767,7 +4807,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             charge_pricing_reason = self._charge_pricing_reason(decision.reason)
 
             stored_commit_price = _to_float(
-                self._persist.get("charge_commit_price_eur_kwh"),
+                self._persist.get("charge_commit_price_per_kwh"),
                 None,
             )
             pricing_price_now = (
@@ -4829,7 +4869,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         delta_charge_pricing.is_grid_charge
                     )
                     charge_price_applied = float(
-                        delta_charge_pricing.price_eur_kwh
+                        delta_charge_pricing.price_per_kwh
                     )
                     charge_source = str(delta_charge_pricing.source)
                     charge_grid_part_w = float(
@@ -4848,7 +4888,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                             "trade_avg_charge_price"
                         )
                         applied_price = float(
-                            delta_charge_pricing.price_eur_kwh
+                            delta_charge_pricing.price_per_kwh
                         )
                         new_total_kwh = charged_kwh + float(delta_kwh)
 
@@ -4879,7 +4919,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 # economic energy ledger still waits for a real SoC increase.
                 is_grid_charge = bool(current_charge_pricing.is_grid_charge)
                 charge_price_applied = float(
-                    current_charge_pricing.price_eur_kwh
+                    current_charge_pricing.price_per_kwh
                 )
                 charge_source = str(current_charge_pricing.source)
                 charge_grid_part_w = float(current_charge_pricing.grid_part_w)
@@ -4896,7 +4936,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             #
             # The real energy ledger is still updated only by delta_kwh > 0.
             # This fallback only prevents the average charge price from staying
-            # at 0.00 €/kWh throughout a real AC charge because of coarse or
+            # at a zero price throughout a real AC charge because of coarse or
             # delayed SoC updates.
             current_trade_avg_price = _to_float(
                 self._persist.get("trade_avg_charge_price"),
@@ -4982,8 +5022,8 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         float(price_now) - float(avg_price)
                     ) * float(accounted_sold_kwh)
 
-                    self._persist["profit_eur"] = (
-                        float(self._persist.get("profit_eur", 0.0))
+                    self._persist["profit"] = (
+                        float(self._persist.get("profit", 0.0))
                         + float(profit)
                     )
 
@@ -5287,14 +5327,14 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 or CONF_FEED_IN_TARIFF in self.entry.data
             )
 
-            battery_value_eur_kwh = _to_float(
+            battery_value_per_kwh = _to_float(
                 self._persist.get("trade_avg_charge_price"),
                 None,
             )
 
             # Compatibility fallback for older persisted installations.
-            if battery_value_eur_kwh is None:
-                battery_value_eur_kwh = _to_float(
+            if battery_value_per_kwh is None:
+                battery_value_per_kwh = _to_float(
                     self._persist.get("avg_charge_price"),
                     None,
                 )
@@ -5304,10 +5344,10 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     "feed_in_tariff_configured": bool(
                         feed_in_tariff_configured
                     ),
-                    "feed_in_tariff_eur_kwh": float(
+                    "feed_in_tariff_per_kwh": float(
                         feed_in_tariff or 0.0
                     ),
-                    "battery_value_eur_kwh": battery_value_eur_kwh,
+                    "battery_value_per_kwh": battery_value_per_kwh,
                 }
             )
 
@@ -6016,7 +6056,10 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 "avg_charge_price": self._persist.get("trade_avg_charge_price"),
                 "economic_discharge_threshold": economic_discharge_threshold,
                 "effective_discharge_threshold": effective_discharge_threshold,
-                "profit_eur": float(self._persist.get("profit_eur") or 0.0),
+                # Keep the existing entity runtime key stable so Home Assistant
+                # does not create a replacement entity during the update. The
+                # displayed monetary unit is supplied dynamically by sensor.py.
+                "profit_eur": float(self._persist.get("profit") or 0.0),
                 "delta_kwh": float(delta_kwh),
                 "is_grid_charge": is_grid_charge,
                 "charge_source": charge_source,
@@ -6533,8 +6576,8 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 "charge_commit_deadline_debug": self._persist.get(
                     "charge_commit_deadline"
                 ),
-                "charge_commit_acceptable_price_eur_kwh_debug": self._persist.get(
-                    "charge_commit_acceptable_price_eur_kwh"
+                "charge_commit_acceptable_price_per_kwh_debug": self._persist.get(
+                    "charge_commit_acceptable_price_per_kwh"
                 ),
 
                 # SF800Pro passthrough / arbiter debug

--- a/custom_components/battery_smartflow_ai/decision_engine.py
+++ b/custom_components/battery_smartflow_ai/decision_engine.py
@@ -7,6 +7,7 @@ from typing import Any, List, Literal, Optional
 
 from .const import MANUAL_CONST_DISCHARGE
 from .forecast import ForecastSummary
+from .price_math import peak_threshold
 from .power_controller import PowerController, PowerContext
 
 
@@ -1700,8 +1701,7 @@ class DecisionEngine:
         return sum(prices) / len(prices)
 
     def _compute_peak_threshold(self, prices: List[float], peak_factor: float) -> float:
-        base_price = self._compute_base_price(prices)
-        return max(base_price * peak_factor, base_price + 0.03)
+        return peak_threshold(prices, peak_factor)
 
     def _compute_valley_threshold(self, prices: List[float], valley_factor: float) -> float:
         base_price = self._compute_base_price(prices)
@@ -1944,7 +1944,7 @@ class DecisionEngine:
         actually required before the next high-price window.
 
         The former broad 35-percent price band could start AC charging too early,
-        e.g. at 0.20 EUR/kWh although sufficient 0.15 EUR/kWh slots were still
+        e.g. at 0.20 per kWh although sufficient 0.15 per kWh slots were still
         available later.
 
         The peak slot itself is never considered a charging candidate.

--- a/custom_components/battery_smartflow_ai/learned_planning.py
+++ b/custom_components/battery_smartflow_ai/learned_planning.py
@@ -10,6 +10,7 @@ from homeassistant.util import dt as dt_util
 
 from .decision_engine import PricePoint
 from .forecast import ForecastSummary
+from .price_math import peak_threshold
 
 
 LEARNED_STATUS_NOT_STARTED = "not_started"
@@ -165,7 +166,7 @@ class LearnedChargePlan:
 
     # Maximum price contained in the selected learned charge window.
     # Dev5.6 uses this as the economic continuation boundary before latest start.
-    acceptable_charge_price_eur_kwh: float | None = None
+    acceptable_charge_price_per_kwh: float | None = None
 
     window_score: float | None = None
 
@@ -812,12 +813,11 @@ def choose_deadline(
 
     if future_prices:
         prices = [float(p.price) for p in future_prices]
-        avg_price = sum(prices) / len(prices)
-        peak_threshold = max(avg_price * 1.35, avg_price + 0.03)
+        learned_peak_threshold = peak_threshold(prices, 1.35)
 
         peak_candidates = [
             p for p in future_prices
-            if float(p.price) >= peak_threshold
+            if float(p.price) >= learned_peak_threshold
         ]
 
         if peak_candidates:
@@ -1157,7 +1157,7 @@ def build_learned_charge_plan(
         optimal_charge_start=start,
         optimal_charge_end=end,
         latest_charge_start=latest_start,
-        acceptable_charge_price_eur_kwh=(
+        acceptable_charge_price_per_kwh=(
             round(float(acceptable_charge_price), 6)
             if acceptable_charge_price is not None
             else None

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": [],
-  "version": "4.4.2"
+  "version": "4.5.0-Beta1"
 }

--- a/custom_components/battery_smartflow_ai/number.py
+++ b/custom_components/battery_smartflow_ai/number.py
@@ -32,7 +32,6 @@ from .const import (
     DEFAULT_EMERGENCY_CHARGE,
     DEFAULT_EMERGENCY_SOC,
     DEFAULT_PROFIT_MARGIN_PCT,
-    DEFAULT_VERY_EXPENSIVE_THRESHOLD,
     SETTING_VALLEY_FACTOR,
     DEFAULT_VALLEY_FACTOR,
     SETTING_VERY_CHEAP_PRICE,
@@ -41,6 +40,15 @@ from .const import (
     DEFAULT_PV_CHARGE_START_EXPORT_W,
     SETTING_FORECAST_BASE_LOAD,
     DEFAULT_FORECAST_BASE_LOAD,
+)
+from .price_currency import price_input_profile
+
+
+PRICE_NUMBER_KEYS = frozenset(
+    {
+        SETTING_VERY_CHEAP_PRICE,
+        SETTING_VERY_EXPENSIVE_THRESHOLD,
+    }
 )
 
 
@@ -86,7 +94,6 @@ NUMBERS: tuple[ZendureNumberEntityDescription, ...] = (
         native_min_value=-1.0,
         native_max_value=1.0,
         native_step=0.01,
-        native_unit_of_measurement="€/kWh",
         icon="mdi:cash",
     ),
     ZendureNumberEntityDescription(
@@ -186,13 +193,17 @@ NUMBERS: tuple[ZendureNumberEntityDescription, ...] = (
         native_min_value=0,
         native_max_value=2,
         native_step=0.01,
-        native_unit_of_measurement="€/kWh",
-        icon="mdi:currency-eur",
+        icon="mdi:cash",
     ),
 )
 
 
-def _default_for_key(key: str) -> float:
+def _default_for_key(key: str, price_currency=None) -> float:
+    if key == SETTING_VERY_EXPENSIVE_THRESHOLD and price_currency is not None:
+        return price_input_profile(
+            price_currency
+        ).default_very_expensive_threshold
+
     defaults: dict[str, float] = {
         SETTING_BATTERY_PACKS: DEFAULT_BATTERY_PACKS,
         SETTING_PEAK_FACTOR: DEFAULT_PEAK_FACTOR,
@@ -207,7 +218,9 @@ def _default_for_key(key: str) -> float:
         SETTING_EMERGENCY_CHARGE: DEFAULT_EMERGENCY_CHARGE,
         SETTING_EMERGENCY_SOC: DEFAULT_EMERGENCY_SOC,
         SETTING_PROFIT_MARGIN_PCT: DEFAULT_PROFIT_MARGIN_PCT,
-        SETTING_VERY_EXPENSIVE_THRESHOLD: DEFAULT_VERY_EXPENSIVE_THRESHOLD,
+        SETTING_VERY_EXPENSIVE_THRESHOLD: price_input_profile(
+            "EUR"
+        ).default_very_expensive_threshold,
     }
     return float(defaults.get(key, 0.0))
 
@@ -232,7 +245,7 @@ async def async_setup_entry(
         if key not in coordinator.runtime_settings:
             coordinator.runtime_settings[key] = entry.options.get(
                 key,
-                _default_for_key(key),
+                _default_for_key(key, coordinator.price_currency),
             )
 
 
@@ -249,6 +262,16 @@ class ZendureSmartFlowNumber(NumberEntity):
         self.coordinator = coordinator
         self._entry = entry
 
+        if description.runtime_key in PRICE_NUMBER_KEYS:
+            profile = price_input_profile(coordinator.price_currency)
+            self._attr_native_min_value = profile.minimum
+            self._attr_native_max_value = profile.maximum
+            self._attr_native_step = profile.step
+            self._attr_suggested_display_precision = profile.display_precision
+            self._attr_native_unit_of_measurement = (
+                coordinator.price_currency.price_unit
+            )
+
         self._attr_unique_id = f"{entry.entry_id}_{description.key}"
         self._attr_device_info = {
             "identifiers": {(DOMAIN, entry.entry_id)},
@@ -261,7 +284,10 @@ class ZendureSmartFlowNumber(NumberEntity):
         if description.runtime_key not in coordinator.runtime_settings:
             coordinator.runtime_settings[description.runtime_key] = entry.options.get(
                 description.runtime_key,
-                _default_for_key(description.runtime_key),
+                _default_for_key(
+                    description.runtime_key,
+                    coordinator.price_currency,
+                ),
             )
 
     @property
@@ -269,7 +295,10 @@ class ZendureSmartFlowNumber(NumberEntity):
         return float(
             self.coordinator.runtime_settings.get(
                 self.entity_description.runtime_key,
-                _default_for_key(self.entity_description.runtime_key),
+                _default_for_key(
+                    self.entity_description.runtime_key,
+                    self.coordinator.price_currency,
+                ),
             )
         )
 

--- a/custom_components/battery_smartflow_ai/price_currency.py
+++ b/custom_components/battery_smartflow_ai/price_currency.py
@@ -1,0 +1,123 @@
+"""Currency context for price values used by Battery SmartFlow AI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, MutableMapping
+
+
+DEFAULT_CURRENCY = "EUR"
+
+LEGACY_PRICE_FIELD_NAMES: dict[str, str] = {
+    "charge_commit_acceptable_price_per_kwh": (
+        "charge_commit_acceptable_price_eur_kwh"
+    ),
+    "charge_commit_price_per_kwh": "charge_commit_price_eur_kwh",
+    "profit": "profit_eur",
+}
+
+
+def normalize_currency_code(value: object) -> str | None:
+    """Return a normalized ISO-style currency code or ``None``.
+
+    Home Assistant exposes its configured system currency as a three-letter
+    code. Keeping validation structural lets BSFAI follow every currency Home
+    Assistant supports without maintaining its own potentially stale list.
+    """
+
+    if not isinstance(value, str):
+        return None
+
+    code = value.strip().upper()
+    if len(code) != 3 or not code.isascii() or not code.isalpha():
+        return None
+    return code
+
+
+@dataclass(frozen=True, slots=True)
+class PriceCurrency:
+    """Active currency metadata; numeric price values are never converted."""
+
+    code: str
+    used_fallback: bool = False
+
+    @property
+    def price_unit(self) -> str:
+        """Return the Home Assistant unit used for prices per kWh."""
+
+        return f"{self.code}/kWh"
+
+    @property
+    def monetary_unit(self) -> str:
+        """Return the unit used for monetary totals."""
+
+        return self.code
+
+
+@dataclass(frozen=True, slots=True)
+class PriceInputProfile:
+    """Safe input range and precision for one nominal currency group."""
+
+    minimum: float
+    maximum: float
+    step: float
+    display_precision: int
+    default_expensive_threshold: float
+    default_very_expensive_threshold: float
+
+
+SMALL_NOMINAL_CURRENCIES = frozenset(
+    {"EUR", "CHF", "GBP", "USD", "CAD", "AUD", "NZD"}
+)
+MEDIUM_NOMINAL_CURRENCIES = frozenset({"DKK", "SEK", "NOK"})
+LARGE_NOMINAL_CURRENCIES = frozenset({"CZK", "PLN"})
+
+SMALL_NOMINAL_PRICE_PROFILE = PriceInputProfile(
+    -2.0, 5.0, 0.01, 2, 0.35, 0.49
+)
+MEDIUM_NOMINAL_PRICE_PROFILE = PriceInputProfile(
+    -20.0, 50.0, 0.05, 2, 3.5, 4.9
+)
+LARGE_NOMINAL_PRICE_PROFILE = PriceInputProfile(
+    -100.0, 250.0, 0.1, 1, 17.5, 24.5
+)
+GENERIC_PRICE_PROFILE = PriceInputProfile(
+    -1000.0, 10000.0, 0.01, 2, 700.0, 980.0
+)
+
+
+def resolve_price_currency(value: object) -> PriceCurrency:
+    """Resolve Home Assistant's currency with a safe EUR fallback."""
+
+    code = normalize_currency_code(value)
+    if code is None:
+        return PriceCurrency(DEFAULT_CURRENCY, used_fallback=True)
+    return PriceCurrency(code)
+
+
+def price_input_profile(currency: PriceCurrency | str) -> PriceInputProfile:
+    """Return ranges suitable for the currency's nominal price magnitude."""
+
+    code = currency.code if isinstance(currency, PriceCurrency) else str(currency)
+    code = normalize_currency_code(code) or DEFAULT_CURRENCY
+
+    if code in SMALL_NOMINAL_CURRENCIES:
+        return SMALL_NOMINAL_PRICE_PROFILE
+    if code in MEDIUM_NOMINAL_CURRENCIES:
+        return MEDIUM_NOMINAL_PRICE_PROFILE
+    if code in LARGE_NOMINAL_CURRENCIES:
+        return LARGE_NOMINAL_PRICE_PROFILE
+    return GENERIC_PRICE_PROFILE
+
+
+def migrate_legacy_price_fields(values: MutableMapping[str, Any]) -> None:
+    """Copy legacy EUR-named persisted values to currency-neutral fields.
+
+    Legacy fields are retained for downgrade safety. Existing numeric values
+    are copied exactly and are never interpreted as a different currency or
+    passed through an exchange-rate conversion.
+    """
+
+    for neutral_name, legacy_name in LEGACY_PRICE_FIELD_NAMES.items():
+        if values.get(neutral_name) is None and values.get(legacy_name) is not None:
+            values[neutral_name] = values[legacy_name]

--- a/custom_components/battery_smartflow_ai/price_math.py
+++ b/custom_components/battery_smartflow_ai/price_math.py
@@ -1,0 +1,27 @@
+"""Currency-neutral calculations for values expressed as price per kWh."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+
+def peak_threshold(prices: Sequence[float], peak_factor: float) -> float:
+    """Return a scale-invariant peak threshold for one price series."""
+
+    values = [float(value) for value in prices]
+    if not values:
+        raise ValueError("prices must not be empty")
+
+    average = sum(values) / len(values)
+    factor_delta = max(0.0, float(peak_factor) - 1.0)
+    price_span = max(values) - min(values)
+    relative_separation = abs(average) * factor_delta
+    observed_separation = max(0.0, price_span) * 0.10
+
+    return average + max(relative_separation, observed_separation)
+
+
+def comparison_tolerance(price_step: float) -> float:
+    """Return a small price hysteresis derived from UI precision."""
+
+    return max(0.0, float(price_step)) * 0.5

--- a/custom_components/battery_smartflow_ai/regulation_power_controller.py
+++ b/custom_components/battery_smartflow_ai/regulation_power_controller.py
@@ -9,6 +9,7 @@ from .regulation_models import (
     PowerControllerResult,
     StrategyIntent,
 )
+from .price_math import comparison_tolerance
 
 
 DEFAULT_TARGET_IMPORT_W = 10.0
@@ -38,7 +39,6 @@ DEFAULT_DISCHARGE_NEAR_ZERO_MAX_TRIM_W = 80.0
 # A small export is preferable to small import when export has a monetary
 # value or when stored battery energy is cheaper than the feed-in tariff.
 DEFAULT_ECONOMIC_EXPORT_TARGET_W = -15.0
-DEFAULT_ECONOMIC_EXPORT_MARGIN_EUR_KWH = 0.01
 DEFAULT_ECONOMIC_TARGET_DEADBAND_W = 15.0
 
 DEFAULT_CHARGE_DEADBAND_W = 30.0
@@ -71,9 +71,7 @@ class RegulationPowerConfig:
     discharge_near_zero_max_trim_w: float = DEFAULT_DISCHARGE_NEAR_ZERO_MAX_TRIM_W
     
     economic_export_target_w: float = DEFAULT_ECONOMIC_EXPORT_TARGET_W
-    economic_export_margin_eur_kwh: float = (
-        DEFAULT_ECONOMIC_EXPORT_MARGIN_EUR_KWH
-    )
+    economic_export_margin_per_kwh: float = 0.0
     economic_target_deadband_w: float = DEFAULT_ECONOMIC_TARGET_DEADBAND_W
 
     charge_deadband_w: float = DEFAULT_CHARGE_DEADBAND_W
@@ -100,7 +98,11 @@ def _profile_int(profile: dict[str, Any], key: str, default: int) -> int:
         return int(default)
 
 
-def build_regulation_power_config(profile: dict[str, Any]) -> RegulationPowerConfig:
+def build_regulation_power_config(
+    profile: dict[str, Any],
+    *,
+    price_step: float = 0.0,
+) -> RegulationPowerConfig:
     """Build technical power-controller config from device profile."""
 
     return RegulationPowerConfig(
@@ -179,10 +181,14 @@ def build_regulation_power_config(profile: dict[str, Any]) -> RegulationPowerCon
             "ECONOMIC_EXPORT_TARGET_W",
             DEFAULT_ECONOMIC_EXPORT_TARGET_W,
         ),
-        economic_export_margin_eur_kwh=_profile_float(
+        economic_export_margin_per_kwh=_profile_float(
             profile,
-            "ECONOMIC_EXPORT_MARGIN_EUR_KWH",
-            DEFAULT_ECONOMIC_EXPORT_MARGIN_EUR_KWH,
+            "ECONOMIC_EXPORT_MARGIN_PER_KWH",
+            _profile_float(
+                profile,
+                "ECONOMIC_EXPORT_MARGIN_EUR_KWH",
+                comparison_tolerance(price_step),
+            ),
         ),
         economic_target_deadband_w=_profile_float(
             profile,
@@ -510,19 +516,29 @@ class RegulationPowerController:
             base_target_w,
             float(self.config.economic_export_target_w),
         )
-        margin_eur_kwh = max(
+        margin_per_kwh = max(
             0.0,
-            float(self.config.economic_export_margin_eur_kwh),
+            float(self.config.economic_export_margin_per_kwh),
         )
 
         feed_in_tariff = self._intent_metadata_float(
             intent,
-            "feed_in_tariff_eur_kwh",
+            "feed_in_tariff_per_kwh",
         )
+        if feed_in_tariff is None:
+            feed_in_tariff = self._intent_metadata_float(
+                intent,
+                "feed_in_tariff_eur_kwh",
+            )
         battery_value = self._intent_metadata_float(
             intent,
-            "battery_value_eur_kwh",
+            "battery_value_per_kwh",
         )
+        if battery_value is None:
+            battery_value = self._intent_metadata_float(
+                intent,
+                "battery_value_eur_kwh",
+            )
 
         tariff_configured = bool(
             intent.metadata.get("feed_in_tariff_configured", False)
@@ -534,9 +550,9 @@ class RegulationPowerController:
             "economic_base_target_import_w": round(base_target_w, 2),
             "economic_effective_target_import_w": round(base_target_w, 2),
             "economic_export_target_w": round(export_target_w, 2),
-            "economic_feed_in_tariff_eur_kwh": feed_in_tariff,
-            "economic_battery_value_eur_kwh": battery_value,
-            "economic_margin_eur_kwh": round(margin_eur_kwh, 4),
+            "economic_feed_in_tariff_per_kwh": feed_in_tariff,
+            "economic_battery_value_per_kwh": battery_value,
+            "economic_margin_per_kwh": round(margin_per_kwh, 4),
         }
 
         if (
@@ -581,7 +597,7 @@ class RegulationPowerController:
                 return base_target_w, metadata
 
             economic_export_allowed = (
-                float(battery_value) + margin_eur_kwh
+                float(battery_value) + margin_per_kwh
                 < float(feed_in_tariff)
             )
 

--- a/custom_components/battery_smartflow_ai/sensor.py
+++ b/custom_components/battery_smartflow_ai/sensor.py
@@ -44,6 +44,7 @@ from .const import (
     AUTOMATIC_WEIGHTING_ENUMS,
 )
 from .device_profiles import DEVICE_PROFILES
+from .price_currency import price_input_profile
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -59,6 +60,22 @@ SOC_LIMIT_ENUMS = [
 FAULT_LEVEL_ENUMS = ["normal", "warning", "error"]
 
 DEVICE_PROFILE_ENUMS = list(DEVICE_PROFILES.keys())
+
+PRICE_SENSOR_KEYS = frozenset(
+    {
+        "learned_planning_window_score",
+        "price_daily_average",
+        "current_peak_threshold",
+        "current_valley_threshold",
+        "economic_discharge_threshold",
+        "effective_discharge_threshold",
+        "price_now",
+        "charge_price_applied",
+        "avg_charge_price",
+    }
+)
+
+MONETARY_SENSOR_KEYS = frozenset({"profit_eur"})
 
 LEARNED_PLANNING_STATUS_ENUMS = [
     "not_started",
@@ -593,7 +610,6 @@ _SENSOR_DESCRIPTIONS: tuple[ZendureSensorEntityDescription, ...] = (
         key="learned_planning_window_score",
         translation_key="learned_planning_window_score",
         runtime_key="learned_planning_window_score",
-        native_unit_of_measurement="€/kWh",
         icon="mdi:chart-bell-curve",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
@@ -637,35 +653,30 @@ _SENSOR_DESCRIPTIONS: tuple[ZendureSensorEntityDescription, ...] = (
         key="price_daily_average",
         translation_key="price_daily_average",
         runtime_key="price_daily_average",
-        native_unit_of_measurement="€/kWh",
         icon="mdi:chart-line",
     ),
     ZendureSensorEntityDescription(
         key="current_peak_threshold",
         translation_key="current_peak_threshold",
         runtime_key="current_peak_threshold",
-        native_unit_of_measurement="€/kWh",
         icon="mdi:chart-bell-curve",
     ),
     ZendureSensorEntityDescription(
         key="current_valley_threshold",
         translation_key="current_valley_threshold",
         runtime_key="current_valley_threshold",
-        native_unit_of_measurement="€/kWh",
         icon="mdi:chart-bell-curve-cumulative",
     ),
     ZendureSensorEntityDescription(
         key="economic_discharge_threshold",
         translation_key="economic_discharge_threshold",
         runtime_key="economic_discharge_threshold",
-        native_unit_of_measurement="€/kWh",
         icon="mdi:cash-clock",
     ),
     ZendureSensorEntityDescription(
         key="effective_discharge_threshold",
         translation_key="effective_discharge_threshold",
         runtime_key="effective_discharge_threshold",
-        native_unit_of_measurement="€/kWh",
         icon="mdi:chart-line-variant",
     ),
     ZendureSensorEntityDescription(
@@ -679,8 +690,7 @@ _SENSOR_DESCRIPTIONS: tuple[ZendureSensorEntityDescription, ...] = (
         key="price_now",
         translation_key="price_now",
         runtime_key="price_now",
-        native_unit_of_measurement="€/kWh",
-        icon="mdi:currency-eur",
+        icon="mdi:cash",
     ),
 
     # --------------------------------------------------
@@ -743,7 +753,6 @@ _SENSOR_DESCRIPTIONS: tuple[ZendureSensorEntityDescription, ...] = (
         key="charge_price_applied",
         translation_key="charge_price_applied",
         runtime_key="charge_price_applied",
-        native_unit_of_measurement="€/kWh",
         icon="mdi:cash-clock",
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
@@ -788,14 +797,12 @@ _SENSOR_DESCRIPTIONS: tuple[ZendureSensorEntityDescription, ...] = (
         key="avg_charge_price",
         translation_key="avg_charge_price",
         runtime_key="avg_charge_price",
-        native_unit_of_measurement="€/kWh",
         icon="mdi:scale-balance",
     ),
     ZendureSensorEntityDescription(
         key="profit_eur",
         translation_key="profit_eur",
         runtime_key="profit_eur",
-        native_unit_of_measurement="€",
         icon="mdi:cash",
     ),
 
@@ -966,6 +973,18 @@ class ZendureSmartFlowSensor(CoordinatorEntity, SensorEntity):
         self.entity_description = description
         self._entry = entry
 
+        if description.runtime_key in PRICE_SENSOR_KEYS:
+            self._attr_native_unit_of_measurement = (
+                coordinator.price_currency.price_unit
+            )
+            self._attr_suggested_display_precision = price_input_profile(
+                coordinator.price_currency
+            ).display_precision
+        elif description.runtime_key in MONETARY_SENSOR_KEYS:
+            self._attr_native_unit_of_measurement = (
+                coordinator.price_currency.monetary_unit
+            )
+
         self._attr_unique_id = f"{DOMAIN}_{entry.entry_id}_{description.key}"
 
         self._attr_device_info = {
@@ -1030,7 +1049,7 @@ class ZendureSmartFlowSensor(CoordinatorEntity, SensorEntity):
             except Exception:
                 return None
 
-        if self.entity_description.native_unit_of_measurement:
+        if self.native_unit_of_measurement:
             try:
                 return float(val)
             except Exception:

--- a/custom_components/battery_smartflow_ai/strategy_state.py
+++ b/custom_components/battery_smartflow_ai/strategy_state.py
@@ -118,7 +118,7 @@ class ChargeCommitState:
     deadline: datetime | None = None
 
     # Economic boundary for planned/learned charging.
-    acceptable_price_eur_kwh: float | None = None
+    acceptable_price_per_kwh: float | None = None
 
     requested_power_w: float | None = None
     allow_pv_blend: bool = True

--- a/tests/test_automatic_strategy_currency.py
+++ b/tests/test_automatic_strategy_currency.py
@@ -1,0 +1,65 @@
+"""Currency scaling tests for automatic strategy price weighting."""
+
+from __future__ import annotations
+
+import unittest
+
+from support import bootstrap
+
+
+bootstrap()
+
+from custom_components.battery_smartflow_ai.automatic_strategy import (  # noqa: E402
+    AutomaticStrategy,
+)
+
+
+class AutomaticStrategyCurrencyTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.strategy = AutomaticStrategy()
+
+    def test_price_range_weight_is_scale_invariant(self) -> None:
+        eur = self.strategy._price_weight(
+            price_now=0.45,
+            price_min=0.15,
+            price_max=0.50,
+            price_average=0.30,
+        )
+        scaled = self.strategy._price_weight(
+            price_now=4.5,
+            price_min=1.5,
+            price_max=5.0,
+            price_average=3.0,
+        )
+        self.assertAlmostEqual(eur[0], scaled[0])
+        self.assertEqual(eur[1], scaled[1])
+
+    def test_missing_range_weight_is_scale_invariant(self) -> None:
+        eur = self.strategy._price_weight(
+            price_now=0.40,
+            price_min=None,
+            price_max=None,
+            price_average=0.30,
+        )
+        scaled = self.strategy._price_weight(
+            price_now=4.0,
+            price_min=None,
+            price_max=None,
+            price_average=3.0,
+        )
+        self.assertAlmostEqual(eur[0], scaled[0])
+        self.assertEqual(eur[1], scaled[1])
+
+    def test_negative_prices_are_compared_relatively(self) -> None:
+        weight, reason = self.strategy._price_weight(
+            price_now=-0.05,
+            price_min=None,
+            price_max=None,
+            price_average=-0.10,
+        )
+        self.assertGreater(weight, 0.30)
+        self.assertEqual(reason, "price_deviation_from_average")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_charge_economics.py
+++ b/tests/test_charge_economics.py
@@ -15,6 +15,7 @@ from custom_components.battery_smartflow_ai.charge_economics import (  # noqa: E
     classify_charge_pricing,
     pricing_from_charge_evidence,
     resolve_feed_in_tariff,
+    trade_soc_min_reset_state,
 )
 
 
@@ -22,6 +23,52 @@ NOW = datetime(2026, 8, 2, 12, 0, tzinfo=timezone.utc)
 
 
 class ChargeEconomicsTests(unittest.TestCase):
+    def test_single_transient_zero_soc_does_not_confirm_trade_reset(self) -> None:
+        count, confirmed = trade_soc_min_reset_state(
+            soc=0.0,
+            soc_min=5.0,
+            previous_count=0,
+            previously_confirmed=False,
+        )
+
+        self.assertEqual(count, 1)
+        self.assertFalse(confirmed)
+
+        count, confirmed = trade_soc_min_reset_state(
+            soc=55.0,
+            soc_min=5.0,
+            previous_count=count,
+            previously_confirmed=confirmed,
+        )
+
+        self.assertEqual(count, 0)
+        self.assertFalse(confirmed)
+
+    def test_sustained_soc_min_confirms_trade_reset(self) -> None:
+        count = 0
+        confirmed = False
+
+        for expected_count in (1, 2, 3):
+            count, confirmed = trade_soc_min_reset_state(
+                soc=5.0,
+                soc_min=5.0,
+                previous_count=count,
+                previously_confirmed=confirmed,
+            )
+            self.assertEqual(count, expected_count)
+            self.assertEqual(confirmed, expected_count == 3)
+
+    def test_confirmed_trade_reset_clears_after_soc_recovers(self) -> None:
+        count, confirmed = trade_soc_min_reset_state(
+            soc=12.0,
+            soc_min=5.0,
+            previous_count=3,
+            previously_confirmed=True,
+        )
+
+        self.assertEqual(count, 0)
+        self.assertFalse(confirmed)
+
     def test_config_data_tariff_overrides_stale_zero_option(self) -> None:
         self.assertEqual(
             resolve_feed_in_tariff(
@@ -54,7 +101,7 @@ class ChargeEconomicsTests(unittest.TestCase):
 
         self.assertTrue(pricing.active)
         self.assertFalse(pricing.is_grid_charge)
-        self.assertAlmostEqual(pricing.price_eur_kwh, 0.122)
+        self.assertAlmostEqual(pricing.price_per_kwh, 0.122)
         self.assertEqual(pricing.source, "pv_surplus_export")
         self.assertEqual(pricing.grid_part_w, 0.0)
         self.assertEqual(pricing.pv_part_w, 1760.0)
@@ -73,7 +120,7 @@ class ChargeEconomicsTests(unittest.TestCase):
 
         self.assertTrue(pricing.active)
         self.assertFalse(pricing.is_grid_charge)
-        self.assertAlmostEqual(pricing.price_eur_kwh, 0.122)
+        self.assertAlmostEqual(pricing.price_per_kwh, 0.122)
         self.assertEqual(pricing.source, "pv_or_free_low_import")
         self.assertEqual(pricing.grid_part_w, 0.0)
         self.assertEqual(pricing.pv_part_w, 1760.0)
@@ -94,7 +141,7 @@ class ChargeEconomicsTests(unittest.TestCase):
         self.assertFalse(pricing.is_grid_charge)
         self.assertEqual(pricing.source, "mixed_grid_pv_charge")
         self.assertAlmostEqual(
-            pricing.price_eur_kwh,
+            pricing.price_per_kwh,
             ((80.0 * 0.31) + (1680.0 * 0.122)) / 1760.0,
         )
         self.assertEqual(pricing.grid_part_w, 80.0)
@@ -116,7 +163,7 @@ class ChargeEconomicsTests(unittest.TestCase):
         self.assertTrue(pricing.is_grid_charge)
         self.assertEqual(pricing.source, "mixed_grid_pv_charge")
         self.assertAlmostEqual(
-            pricing.price_eur_kwh,
+            pricing.price_per_kwh,
             ((400.0 * 0.31) + (1360.0 * 0.122)) / 1760.0,
         )
         self.assertEqual(pricing.grid_part_w, 400.0)
@@ -135,7 +182,7 @@ class ChargeEconomicsTests(unittest.TestCase):
         )
 
         self.assertTrue(pricing.active)
-        self.assertEqual(pricing.price_eur_kwh, 0.0)
+        self.assertEqual(pricing.price_per_kwh, 0.0)
 
     def test_mixed_charge_uses_weighted_grid_and_pv_price(self) -> None:
         pricing = classify_charge_pricing(
@@ -152,7 +199,7 @@ class ChargeEconomicsTests(unittest.TestCase):
         self.assertTrue(pricing.active)
         self.assertTrue(pricing.is_grid_charge)
         self.assertEqual(pricing.source, "mixed_grid_pv_charge")
-        self.assertAlmostEqual(pricing.price_eur_kwh, 0.192)
+        self.assertAlmostEqual(pricing.price_per_kwh, 0.192)
         self.assertEqual(pricing.grid_part_w, 400.0)
         self.assertEqual(pricing.pv_part_w, 600.0)
 
@@ -180,7 +227,38 @@ class ChargeEconomicsTests(unittest.TestCase):
 
         self.assertIsNotNone(delayed_pricing)
         assert delayed_pricing is not None
-        self.assertAlmostEqual(delayed_pricing.price_eur_kwh, -0.05)
+        self.assertAlmostEqual(delayed_pricing.price_per_kwh, -0.05)
+
+    def test_legacy_eur_named_evidence_is_read_without_conversion(self) -> None:
+        legacy_evidence = {
+            "energy_wh": 1000.0,
+            "cost_eur": 2.2,
+            "grid_energy_wh": 1000.0,
+            "pv_energy_wh": 0.0,
+            "duration_seconds": 3600.0,
+            "source": "grid_charge",
+            "updated_at": NOW.isoformat(),
+        }
+
+        delayed_pricing = pricing_from_charge_evidence(
+            legacy_evidence,
+            now=NOW + timedelta(seconds=10),
+        )
+
+        self.assertIsNotNone(delayed_pricing)
+        assert delayed_pricing is not None
+        self.assertAlmostEqual(delayed_pricing.price_per_kwh, 2.2)
+
+        updated_evidence = add_charge_evidence(
+            legacy_evidence,
+            pricing=delayed_pricing,
+            duration_seconds=10.0,
+            now=NOW + timedelta(seconds=10),
+        )
+        self.assertIsNotNone(updated_evidence)
+        assert updated_evidence is not None
+        self.assertIn("cost", updated_evidence)
+        self.assertNotIn("cost_eur", updated_evidence)
 
     def test_delayed_soc_delta_keeps_preceding_pv_price_evidence(self) -> None:
         pricing = classify_charge_pricing(
@@ -214,7 +292,7 @@ class ChargeEconomicsTests(unittest.TestCase):
 
         self.assertIsNotNone(delayed_pricing)
         assert delayed_pricing is not None
-        self.assertAlmostEqual(delayed_pricing.price_eur_kwh, 0.122)
+        self.assertAlmostEqual(delayed_pricing.price_per_kwh, 0.122)
         self.assertEqual(delayed_pricing.source, "pv_surplus_export")
         self.assertEqual(delayed_pricing.grid_part_w, 0.0)
         self.assertAlmostEqual(delayed_pricing.pv_part_w, 1160.0)
@@ -232,7 +310,7 @@ class ChargeEconomicsTests(unittest.TestCase):
         )
 
         self.assertTrue(pricing.active)
-        self.assertAlmostEqual(pricing.price_eur_kwh, 0.122)
+        self.assertAlmostEqual(pricing.price_per_kwh, 0.122)
         self.assertEqual(pricing.pv_part_w, 240.0)
 
 

--- a/tests/test_currency_scaled_scenarios.py
+++ b/tests/test_currency_scaled_scenarios.py
@@ -1,0 +1,251 @@
+"""End-to-end price scaling scenarios for V4.5.0."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+import unittest
+
+from support import bootstrap
+
+
+bootstrap()
+
+from custom_components.battery_smartflow_ai.charge_economics import (  # noqa: E402
+    classify_charge_pricing,
+)
+from custom_components.battery_smartflow_ai.decision_engine import (  # noqa: E402
+    DecisionContext,
+    DecisionEngine,
+    PricePoint,
+)
+from custom_components.battery_smartflow_ai.learned_planning import (  # noqa: E402
+    LearnedSlotModel,
+    LearningReadiness,
+    build_learned_charge_plan,
+)
+from test_dev9_scenarios import NOW, PROFILE, context, price_points  # noqa: E402
+
+
+def _scaled_optional(value: float | None, factor: float) -> float | None:
+    return None if value is None else float(value) * factor
+
+
+def scale_price_context(ctx: DecisionContext, factor: float) -> DecisionContext:
+    """Scale every monetary price input while preserving physical inputs."""
+
+    scaled_points = [
+        PricePoint(point.start, point.end, float(point.price) * factor)
+        for point in ctx.price_points
+    ]
+    return replace(
+        ctx,
+        price_now=_scaled_optional(ctx.price_now, factor),
+        avg_charge_price=_scaled_optional(ctx.avg_charge_price, factor),
+        expensive_threshold=float(ctx.expensive_threshold) * factor,
+        very_expensive_threshold=float(ctx.very_expensive_threshold) * factor,
+        very_cheap_price=_scaled_optional(ctx.very_cheap_price, factor),
+        feed_in_tariff=float(ctx.feed_in_tariff) * factor,
+        price_points=scaled_points,
+    )
+
+
+def assert_scaled_result(
+    case: unittest.TestCase,
+    eur_result,
+    scaled_result,
+    factor: float,
+) -> None:
+    """Assert identical decisions and proportionally scaled diagnostics."""
+
+    case.assertEqual(eur_result.action, scaled_result.action)
+    case.assertEqual(eur_result.ac_mode, scaled_result.ac_mode)
+    case.assertEqual(eur_result.reason, scaled_result.reason)
+    case.assertEqual(eur_result.charge_w, scaled_result.charge_w)
+    case.assertEqual(eur_result.discharge_w, scaled_result.discharge_w)
+    case.assertEqual(eur_result.target_soc, scaled_result.target_soc)
+
+    for field in (
+        "current_peak_threshold",
+        "current_valley_threshold",
+        "economic_discharge_threshold",
+        "effective_discharge_threshold",
+    ):
+        eur_value = getattr(eur_result, field)
+        scaled_value = getattr(scaled_result, field)
+        if eur_value is None:
+            case.assertIsNone(scaled_value)
+        else:
+            case.assertAlmostEqual(scaled_value, eur_value * factor)
+
+
+class CurrencyScaledDecisionScenarios(unittest.TestCase):
+    def assert_engine_scale_invariant(
+        self,
+        base_context: DecisionContext,
+        factor: float,
+    ) -> None:
+        eur_result = DecisionEngine().evaluate(base_context)
+        scaled_result = DecisionEngine().evaluate(
+            scale_price_context(base_context, factor)
+        )
+        assert_scaled_result(self, eur_result, scaled_result, factor)
+
+    def test_peak_and_economic_discharge_scale_to_dkk(self) -> None:
+        self.assert_engine_scale_invariant(
+            context(
+                price_now=0.45,
+                avg_charge_price=0.10,
+                automatic_planning_allowed=False,
+            ),
+            10.0,
+        )
+
+    def test_valley_charge_scale_to_dkk(self) -> None:
+        self.assert_engine_scale_invariant(
+            context(
+                price_now=0.10,
+                grid_import_w=0.0,
+                automatic_valley_charge_allowed=True,
+                automatic_planning_allowed=False,
+            ),
+            10.0,
+        )
+
+    def test_very_cheap_negative_price_scale_to_czk(self) -> None:
+        negative_points = [
+            replace(point, price=point.price - 0.20)
+            for point in price_points()
+        ]
+        self.assert_engine_scale_invariant(
+            context(
+                price_now=-0.10,
+                price_points=negative_points,
+                very_cheap_price=-0.05,
+                avg_charge_price=0.10,
+                automatic_planning_allowed=False,
+            ),
+            25.0,
+        )
+
+    def test_neutral_price_state_scale_to_pln(self) -> None:
+        self.assert_engine_scale_invariant(
+            context(
+                price_now=0.25,
+                automatic_planning_allowed=False,
+                automatic_valley_charge_allowed=False,
+            ),
+            4.5,
+        )
+
+    def test_all_required_currencies_keep_the_same_strategy_decision(self) -> None:
+        base_context = context(
+            price_now=0.45,
+            avg_charge_price=0.10,
+            automatic_planning_allowed=False,
+        )
+        nominal_factors = {
+            "EUR": 1.0,
+            "DKK": 10.0,
+            "CHF": 1.1,
+            "SEK": 11.0,
+            "NOK": 12.0,
+            "GBP": 0.85,
+            "CZK": 25.0,
+            "PLN": 4.5,
+        }
+
+        for currency, factor in nominal_factors.items():
+            with self.subTest(currency=currency):
+                self.assert_engine_scale_invariant(base_context, factor)
+
+
+class CurrencyScaledEconomicsScenarios(unittest.TestCase):
+    def test_mixed_grid_pv_price_scales_without_changing_source(self) -> None:
+        eur = classify_charge_pricing(
+            grid_import_w=400.0,
+            grid_export_w=0.0,
+            decision_charge_w=1000.0,
+            decision_ac_mode="input",
+            price_now=0.30,
+            feed_in_tariff=0.12,
+            battery_charge_w=1000.0,
+            decision_reason="valley_opportunity_charge",
+        )
+        dkk = classify_charge_pricing(
+            grid_import_w=400.0,
+            grid_export_w=0.0,
+            decision_charge_w=1000.0,
+            decision_ac_mode="input",
+            price_now=3.0,
+            feed_in_tariff=1.2,
+            battery_charge_w=1000.0,
+            decision_reason="valley_opportunity_charge",
+        )
+
+        self.assertEqual(eur.source, dkk.source)
+        self.assertEqual(eur.is_grid_charge, dkk.is_grid_charge)
+        self.assertEqual(eur.grid_part_w, dkk.grid_part_w)
+        self.assertEqual(eur.pv_part_w, dkk.pv_part_w)
+        self.assertAlmostEqual(dkk.price_per_kwh, eur.price_per_kwh * 10.0)
+
+
+class CurrencyScaledLearnedPlanningScenarios(unittest.TestCase):
+    def test_learned_plan_selection_is_scale_invariant(self) -> None:
+        model = LearnedSlotModel(
+            slot_kwh=[0.05] * 96,
+            slot_sample_count=[7] * 96,
+            data_coverage=1.0,
+            history_days=7,
+            usable_days=7,
+            night_window_days=7,
+            morning_window_days=7,
+            evening_window_days=7,
+        )
+        readiness = LearningReadiness(
+            status="ready",
+            history_days=7,
+            usable_days=7,
+            night_window_days=7,
+            morning_window_days=7,
+            evening_window_days=7,
+            data_coverage=1.0,
+        )
+
+        def build(points: list[PricePoint]):
+            return build_learned_charge_plan(
+                model=model,
+                readiness=readiness,
+                now=NOW,
+                price_points=points,
+                forecast=None,
+                total_battery_capacity_kwh=5.76,
+                current_soc=5.0,
+                soc_min=5.0,
+                soc_max=100.0,
+                profile_charge_limit_w=2400.0,
+                current_effective_charge_cap_w=2400.0,
+                learned_typical_charge_power_w=1161.0,
+            )
+
+        eur = build(price_points())
+        scaled = build(
+            [replace(point, price=point.price * 10.0) for point in price_points()]
+        )
+
+        self.assertEqual(eur.mode, scaled.mode)
+        self.assertEqual(eur.decision_reason, scaled.decision_reason)
+        self.assertEqual(eur.optimal_charge_start, scaled.optimal_charge_start)
+        self.assertEqual(eur.optimal_charge_end, scaled.optimal_charge_end)
+        self.assertEqual(eur.requested_charge_power_w, scaled.requested_charge_power_w)
+        self.assertEqual(
+            scaled.selected_prices,
+            [round(value * 10.0, 6) for value in eur.selected_prices],
+        )
+        self.assertAlmostEqual(
+            scaled.acceptable_charge_price_per_kwh,
+            eur.acceptable_charge_price_per_kwh * 10.0,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_currency_ui_contract.py
+++ b/tests/test_currency_ui_contract.py
@@ -1,0 +1,38 @@
+"""Static contract tests for currency-neutral Home Assistant entities."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
+
+
+class CurrencyUiContractTests(unittest.TestCase):
+    def test_entity_platforms_have_no_hard_coded_eur_units_or_icons(self) -> None:
+        for filename in ("number.py", "sensor.py"):
+            with self.subTest(filename=filename):
+                source = (COMPONENT / filename).read_text(encoding="utf-8")
+                self.assertNotIn("€/kWh", source)
+                self.assertNotIn('native_unit_of_measurement="€"', source)
+                self.assertNotIn("mdi:currency-eur", source)
+
+    def test_price_numbers_use_central_currency_profile_and_unit(self) -> None:
+        source = (COMPONENT / "number.py").read_text(encoding="utf-8")
+
+        self.assertIn("price_input_profile(coordinator.price_currency)", source)
+        self.assertIn("coordinator.price_currency.price_unit", source)
+
+    def test_price_sensors_use_central_dynamic_units(self) -> None:
+        source = (COMPONENT / "sensor.py").read_text(encoding="utf-8")
+
+        self.assertIn("coordinator.price_currency.price_unit", source)
+        self.assertIn("coordinator.price_currency.monetary_unit", source)
+        self.assertIn("price_input_profile(", source)
+        self.assertIn("if self.native_unit_of_measurement:", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -1,4 +1,4 @@
-"""Static integration contracts for the V4.4 Home Assistant wiring."""
+"""Static integration contracts for the Home Assistant wiring."""
 
 from __future__ import annotations
 
@@ -13,7 +13,7 @@ COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
 
 
 class DebugIntegrationContractTests(unittest.TestCase):
-    def test_manifest_and_runtime_version_match_v442_release(self) -> None:
+    def test_manifest_and_runtime_version_match_v450_beta1_release(self) -> None:
         manifest_version = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )["version"]
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "4.4.2")
+        self.assertEqual(manifest_version, "4.5.0-Beta1")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_maintenance_431.py
+++ b/tests/test_maintenance_431.py
@@ -56,6 +56,54 @@ from custom_components.battery_smartflow_ai.strategy_state import (  # noqa: E40
 
 
 class Maintenance431Tests(unittest.TestCase):
+    def test_economic_target_uses_currency_neutral_price_metadata(self) -> None:
+        controller = RegulationPowerController(RegulationPowerConfig())
+        intent = StrategyIntent(
+            intent="arbitrage_discharge",
+            requested_mode="output",
+            requested_power_w=500.0,
+            reason="price_based_discharge",
+            metadata={
+                "feed_in_tariff_configured": True,
+                "feed_in_tariff_per_kwh": 2.2,
+                "battery_value_per_kwh": 1.0,
+            },
+        )
+
+        target, metadata = controller._effective_target_import_w(
+            intent=intent,
+            base_target_import_w=10.0,
+            direction="output",
+        )
+
+        self.assertEqual(target, -15.0)
+        self.assertEqual(metadata["economic_feed_in_tariff_per_kwh"], 2.2)
+        self.assertEqual(metadata["economic_battery_value_per_kwh"], 1.0)
+
+    def test_economic_target_still_reads_legacy_eur_named_metadata(self) -> None:
+        controller = RegulationPowerController(RegulationPowerConfig())
+        intent = StrategyIntent(
+            intent="arbitrage_discharge",
+            requested_mode="output",
+            requested_power_w=500.0,
+            reason="price_based_discharge",
+            metadata={
+                "feed_in_tariff_configured": True,
+                "feed_in_tariff_eur_kwh": 2.2,
+                "battery_value_eur_kwh": 1.0,
+            },
+        )
+
+        target, metadata = controller._effective_target_import_w(
+            intent=intent,
+            base_target_import_w=10.0,
+            direction="output",
+        )
+
+        self.assertEqual(target, -15.0)
+        self.assertEqual(metadata["economic_feed_in_tariff_per_kwh"], 2.2)
+        self.assertEqual(metadata["economic_battery_value_per_kwh"], 1.0)
+
     def test_live_zero_need_does_not_cancel_targeted_active_binding(self) -> None:
         plan = SimpleNamespace(
             status="ready",

--- a/tests/test_price_currency.py
+++ b/tests/test_price_currency.py
@@ -1,0 +1,192 @@
+"""Tests for the central Home Assistant price currency context."""
+
+from __future__ import annotations
+
+import unittest
+
+from support import bootstrap
+
+
+bootstrap()
+
+from custom_components.battery_smartflow_ai.price_currency import (  # noqa: E402
+    DEFAULT_CURRENCY,
+    GENERIC_PRICE_PROFILE,
+    LARGE_NOMINAL_PRICE_PROFILE,
+    MEDIUM_NOMINAL_PRICE_PROFILE,
+    PriceCurrency,
+    SMALL_NOMINAL_PRICE_PROFILE,
+    migrate_legacy_price_fields,
+    normalize_currency_code,
+    price_input_profile,
+    resolve_price_currency,
+)
+
+
+class PriceCurrencyTests(unittest.TestCase):
+    def test_eur_remains_unchanged(self) -> None:
+        currency = resolve_price_currency("EUR")
+
+        self.assertEqual(currency, PriceCurrency("EUR"))
+        self.assertEqual(currency.price_unit, "EUR/kWh")
+        self.assertEqual(currency.monetary_unit, "EUR")
+        self.assertFalse(currency.used_fallback)
+
+    def test_dkk_is_used_without_conversion(self) -> None:
+        currency = resolve_price_currency("DKK")
+
+        self.assertEqual(currency.code, "DKK")
+        self.assertEqual(currency.price_unit, "DKK/kWh")
+        self.assertFalse(currency.used_fallback)
+
+    def test_currency_code_is_normalized(self) -> None:
+        self.assertEqual(normalize_currency_code(" chf "), "CHF")
+        self.assertEqual(resolve_price_currency("gbp").code, "GBP")
+
+    def test_missing_currency_uses_safe_eur_fallback(self) -> None:
+        currency = resolve_price_currency(None)
+
+        self.assertEqual(currency.code, DEFAULT_CURRENCY)
+        self.assertEqual(currency.price_unit, "EUR/kWh")
+        self.assertTrue(currency.used_fallback)
+
+    def test_invalid_currency_uses_safe_eur_fallback(self) -> None:
+        for value in ("", "EU", "EURO", "€€€", "12A", object()):
+            with self.subTest(value=value):
+                currency = resolve_price_currency(value)
+                self.assertEqual(currency.code, DEFAULT_CURRENCY)
+                self.assertTrue(currency.used_fallback)
+
+    def test_iso_style_codes_are_not_limited_to_a_hard_coded_list(self) -> None:
+        currency = resolve_price_currency("xyz")
+
+        self.assertEqual(currency.code, "XYZ")
+        self.assertFalse(currency.used_fallback)
+
+    def test_legacy_persisted_prices_are_copied_without_conversion(self) -> None:
+        values = {
+            "charge_commit_acceptable_price_eur_kwh": 2.2,
+            "charge_commit_price_eur_kwh": 1.75,
+            "profit_eur": 8.4,
+        }
+
+        migrate_legacy_price_fields(values)
+
+        self.assertEqual(values["charge_commit_acceptable_price_per_kwh"], 2.2)
+        self.assertEqual(values["charge_commit_price_per_kwh"], 1.75)
+        self.assertEqual(values["profit"], 8.4)
+        self.assertEqual(values["charge_commit_acceptable_price_eur_kwh"], 2.2)
+        self.assertEqual(values["charge_commit_price_eur_kwh"], 1.75)
+        self.assertEqual(values["profit_eur"], 8.4)
+
+    def test_neutral_persisted_prices_win_over_legacy_values(self) -> None:
+        values = {
+            "charge_commit_price_per_kwh": 3.0,
+            "charge_commit_price_eur_kwh": 0.3,
+        }
+
+        migrate_legacy_price_fields(values)
+
+        self.assertEqual(values["charge_commit_price_per_kwh"], 3.0)
+
+    def test_zero_legacy_prices_are_preserved_exactly(self) -> None:
+        values = {
+            "charge_commit_acceptable_price_eur_kwh": 0.0,
+            "charge_commit_price_eur_kwh": 0.0,
+            "profit_eur": 0.0,
+        }
+
+        migrate_legacy_price_fields(values)
+
+        self.assertEqual(values["charge_commit_acceptable_price_per_kwh"], 0.0)
+        self.assertEqual(values["charge_commit_price_per_kwh"], 0.0)
+        self.assertEqual(values["profit"], 0.0)
+
+    def test_legacy_price_migration_is_idempotent_and_keeps_source_fields(self) -> None:
+        values = {
+            "charge_commit_acceptable_price_eur_kwh": 0.35,
+            "charge_commit_price_eur_kwh": 0.49,
+            "profit_eur": -1.25,
+        }
+
+        migrate_legacy_price_fields(values)
+        first_result = dict(values)
+        migrate_legacy_price_fields(values)
+
+        self.assertEqual(values, first_result)
+        self.assertEqual(values["charge_commit_acceptable_price_eur_kwh"], 0.35)
+        self.assertEqual(values["charge_commit_price_eur_kwh"], 0.49)
+        self.assertEqual(values["profit_eur"], -1.25)
+
+    def test_currency_resolution_never_converts_existing_values(self) -> None:
+        configured = {
+            "price_threshold": 0.35,
+            "very_expensive_threshold": 0.49,
+            "feed_in_tariff": 0.081,
+        }
+        original = dict(configured)
+
+        for code in ("EUR", "DKK", "CHF", "SEK", "NOK", "GBP", "CZK", "PLN"):
+            resolve_price_currency(code)
+            price_input_profile(code)
+
+        self.assertEqual(configured, original)
+
+    def test_small_nominal_currency_profiles(self) -> None:
+        for code in ("EUR", "CHF", "GBP"):
+            with self.subTest(code=code):
+                self.assertEqual(
+                    price_input_profile(code),
+                    SMALL_NOMINAL_PRICE_PROFILE,
+                )
+
+    def test_medium_nominal_currency_profiles(self) -> None:
+        for code in ("DKK", "SEK", "NOK"):
+            with self.subTest(code=code):
+                self.assertEqual(
+                    price_input_profile(code),
+                    MEDIUM_NOMINAL_PRICE_PROFILE,
+                )
+
+    def test_large_nominal_currency_profiles(self) -> None:
+        for code in ("CZK", "PLN"):
+            with self.subTest(code=code):
+                self.assertEqual(
+                    price_input_profile(code),
+                    LARGE_NOMINAL_PRICE_PROFILE,
+                )
+
+    def test_unknown_valid_currency_gets_safe_generic_profile(self) -> None:
+        self.assertEqual(price_input_profile("XYZ"), GENERIC_PRICE_PROFILE)
+
+    def test_profiles_allow_negative_and_high_price_scenarios(self) -> None:
+        self.assertLess(SMALL_NOMINAL_PRICE_PROFILE.minimum, 0.0)
+        self.assertGreaterEqual(MEDIUM_NOMINAL_PRICE_PROFILE.maximum, 50.0)
+        self.assertGreaterEqual(LARGE_NOMINAL_PRICE_PROFILE.maximum, 250.0)
+
+    def test_eur_defaults_remain_backward_compatible(self) -> None:
+        profile = price_input_profile("EUR")
+        self.assertEqual(profile.default_expensive_threshold, 0.35)
+        self.assertEqual(profile.default_very_expensive_threshold, 0.49)
+
+    def test_nominal_groups_receive_suitable_unconfigured_defaults(self) -> None:
+        self.assertEqual(
+            price_input_profile("DKK").default_expensive_threshold,
+            3.5,
+        )
+        self.assertEqual(
+            price_input_profile("DKK").default_very_expensive_threshold,
+            4.9,
+        )
+        self.assertEqual(
+            price_input_profile("CZK").default_expensive_threshold,
+            17.5,
+        )
+        self.assertEqual(
+            price_input_profile("CZK").default_very_expensive_threshold,
+            24.5,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_price_math.py
+++ b/tests/test_price_math.py
@@ -1,0 +1,46 @@
+"""Tests for currency-neutral price calculations."""
+
+from __future__ import annotations
+
+import unittest
+
+from support import bootstrap
+
+
+bootstrap()
+
+from custom_components.battery_smartflow_ai.price_math import (  # noqa: E402
+    comparison_tolerance,
+    peak_threshold,
+)
+
+
+class PriceMathTests(unittest.TestCase):
+    def test_peak_threshold_scales_with_all_input_prices(self) -> None:
+        eur_prices = [0.15, 0.30, 0.45]
+        scaled_prices = [value * 10.0 for value in eur_prices]
+        self.assertAlmostEqual(
+            peak_threshold(scaled_prices, 1.35),
+            peak_threshold(eur_prices, 1.35) * 10.0,
+        )
+
+    def test_peak_threshold_supports_negative_prices(self) -> None:
+        threshold = peak_threshold([-0.20, -0.05, 0.10], 1.35)
+        self.assertGreater(threshold, -0.05)
+        self.assertLessEqual(threshold, 0.10)
+
+    def test_market_spread_provides_separation_around_zero(self) -> None:
+        self.assertGreater(peak_threshold([-1.0, 0.0, 1.0], 1.35), 0.0)
+
+    def test_empty_price_series_is_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            peak_threshold([], 1.35)
+
+    def test_comparison_tolerance_follows_price_step(self) -> None:
+        self.assertEqual(comparison_tolerance(0.01), 0.005)
+        self.assertEqual(comparison_tolerance(0.05), 0.025)
+        self.assertEqual(comparison_tolerance(0.1), 0.05)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Zusammenfassung

V4.5.0-Beta1 führt eine zentrale, von Home Assistant übernommene Preiswährung ein. Preiswerte werden nicht umgerechnet; bestehende EUR-Werte bleiben numerisch unverändert. Preisbereiche, Schrittweiten, Einheiten und wirtschaftliche Berechnungen funktionieren auch mit Währungen wie DKK, SEK, NOK, CHF, GBP, CZK und PLN.

Zusätzlich verhindert der Fix für #158, dass ein einzelner transienter SoC-Nullwert den gespeicherten durchschnittlichen Ladepreis und die wirtschaftliche Preisbasis dauerhaft löscht. Ein echter SoC-Min-Reset wird nun über drei aufeinanderfolgende Messzyklen bestätigt.

## Änderungen

- zentrale Währungsauflösung aus `hass.config.currency` mit sicherem EUR-Fallback
- dynamische Preis-Einheiten für Sensoren, Number-Entities und Einspeisevergütung
- währungstypische Eingabebereiche, Schrittweiten und Standardwerte
- neutrale interne Preis-, Kosten- und Gewinnbezeichner mit Kompatibilitätslesen alter EUR-Felder
- währungsneutrale Valley-, Peak-, Lade-, Entlade-, Mischpreis- und Lernplanungslogik
- Schutz der wirtschaftlichen Preisbasis gegen kurze SoC-Sensorausreißer
- Versionsstand `4.5.0-Beta1`

## Kompatibilität

- keine Wechselkursumrechnung
- bestehende EUR-Konfigurationen behalten ihre Zahlenwerte
- alte persistierte EUR-benannte Felder und Profil-Overrides bleiben lesbar
- bestehender Entity-Schlüssel `profit_eur` bleibt für die Home-Assistant-Entity-Registry stabil; seine sichtbare Einheit ist dynamisch

## Prüfung

- 172 Tests bestanden
- 267 Untertests bestanden
- Python-Kompilierungsprüfung bestanden
- JSON-Prüfung bestanden
- `git diff --check` bestanden

Closes #222
Closes #223
Closes #224
Closes #225
Closes #226
Closes #227
Closes #228
Closes #229
Closes #230

Addresses #158
