### PR TITLE
Restore persisted profit in 4.5.0-Beta2

### DIFF
--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -10,7 +10,7 @@ DOMAIN = "battery_smartflow_ai"
 INTEGRATION_NAME = "Battery SmartFlow AI"
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "4.5.0-Beta1"
+INTEGRATION_VERSION = "4.5.0-Beta2"
 
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,

--- a/custom_components/battery_smartflow_ai/coordinator.py
+++ b/custom_components/battery_smartflow_ai/coordinator.py
@@ -530,8 +530,9 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     async def _load(self) -> None:
         data = await self._store.async_load()
         if isinstance(data, dict):
-            self._persist.update(data)
-            migrate_legacy_price_fields(self._persist)
+            loaded_data = dict(data)
+            migrate_legacy_price_fields(loaded_data)
+            self._persist.update(loaded_data)
 
             # V4.2.2:
             # Normalize old persisted extreme values. Previous versions could let
@@ -541,8 +542,10 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 self._persist.get("season_counter", 0)
             )
 
-            if "runtime_mode" in data and isinstance(data["runtime_mode"], dict):
-                self.runtime_mode.update(data["runtime_mode"])
+            if "runtime_mode" in loaded_data and isinstance(
+                loaded_data["runtime_mode"], dict
+            ):
+                self.runtime_mode.update(loaded_data["runtime_mode"])
                 
             self.runtime_mode["ai_mode"] = normalize_ai_mode(
                 self.runtime_mode.get("ai_mode")

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": [],
-  "version": "4.5.0-Beta1"
+  "version": "4.5.0-Beta2"
 }

--- a/custom_components/battery_smartflow_ai/price_currency.py
+++ b/custom_components/battery_smartflow_ai/price_currency.py
@@ -7,6 +7,7 @@ from typing import Any, MutableMapping
 
 
 DEFAULT_CURRENCY = "EUR"
+PRICE_STORAGE_MIGRATION_MARKER = "price_currency_storage_migrated"
 
 LEGACY_PRICE_FIELD_NAMES: dict[str, str] = {
     "charge_commit_acceptable_price_per_kwh": (
@@ -118,6 +119,24 @@ def migrate_legacy_price_fields(values: MutableMapping[str, Any]) -> None:
     passed through an exchange-rate conversion.
     """
 
+    if values.get(PRICE_STORAGE_MIGRATION_MARKER) is True:
+        return
+
     for neutral_name, legacy_name in LEGACY_PRICE_FIELD_NAMES.items():
-        if values.get(neutral_name) is None and values.get(legacy_name) is not None:
-            values[neutral_name] = values[legacy_name]
+        legacy_value = values.get(legacy_name)
+        if legacy_value is None:
+            continue
+
+        neutral_value = values.get(neutral_name)
+        if neutral_name == "profit" and neutral_value is not None:
+            # Beta1 initialized the new key with 0.0 before loading the old
+            # persisted ``profit_eur`` total. Preserve that historic total and
+            # add any profit accrued while Beta1 was already running.
+            try:
+                values[neutral_name] = float(legacy_value) + float(neutral_value)
+            except (TypeError, ValueError):
+                values[neutral_name] = legacy_value
+        elif neutral_value is None:
+            values[neutral_name] = legacy_value
+
+    values[PRICE_STORAGE_MIGRATION_MARKER] = True

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -13,7 +13,7 @@ COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
 
 
 class DebugIntegrationContractTests(unittest.TestCase):
-    def test_manifest_and_runtime_version_match_v450_beta1_release(self) -> None:
+    def test_manifest_and_runtime_version_match_v450_beta2_release(self) -> None:
         manifest_version = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )["version"]
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "4.5.0-Beta1")
+        self.assertEqual(manifest_version, "4.5.0-Beta2")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_price_currency.py
+++ b/tests/test_price_currency.py
@@ -15,6 +15,7 @@ from custom_components.battery_smartflow_ai.price_currency import (  # noqa: E40
     LARGE_NOMINAL_PRICE_PROFILE,
     MEDIUM_NOMINAL_PRICE_PROFILE,
     PriceCurrency,
+    PRICE_STORAGE_MIGRATION_MARKER,
     SMALL_NOMINAL_PRICE_PROFILE,
     migrate_legacy_price_fields,
     normalize_currency_code,
@@ -88,6 +89,30 @@ class PriceCurrencyTests(unittest.TestCase):
         migrate_legacy_price_fields(values)
 
         self.assertEqual(values["charge_commit_price_per_kwh"], 3.0)
+
+    def test_beta1_zero_profit_recovers_the_legacy_total(self) -> None:
+        values = {
+            "profit": 0.0,
+            "profit_eur": 151.696931286252,
+        }
+
+        migrate_legacy_price_fields(values)
+
+        self.assertEqual(values["profit"], 151.696931286252)
+        self.assertTrue(values[PRICE_STORAGE_MIGRATION_MARKER])
+
+    def test_beta1_accrued_profit_is_added_to_the_legacy_total_once(self) -> None:
+        values = {
+            "profit": 0.25,
+            "profit_eur": 151.696931286252,
+        }
+
+        migrate_legacy_price_fields(values)
+        first_result = values["profit"]
+        migrate_legacy_price_fields(values)
+
+        self.assertAlmostEqual(first_result, 151.946931286252)
+        self.assertEqual(values["profit"], first_result)
 
     def test_zero_legacy_prices_are_preserved_exactly(self) -> None:
         values = {


### PR DESCRIPTION
## Was wurde geändert?

- stellt den vor Beta1 gespeicherten Gesamtertrag aus `profit_eur` beim ersten Start wieder her
- addiert einen gegebenenfalls unter Beta1 neu angesammelten Betrag
- verhindert über eine persistente Migrationsmarkierung jede doppelte Übernahme
- migriert geladene Werte vor dem Zusammenführen mit den neuen Standardwerten
- erhöht die Versionsangabe auf `4.5.0-Beta2`

## Ursache

Beta1 initialisierte das neue währungsneutrale Feld `profit` mit `0.0`, bevor die alte persistente Speicherung geladen wurde. Dadurch blockierte der Standardwert die Übernahme von `profit_eur`, obwohl der historische Wert weiterhin gespeichert war.

## Auswirkung

Nach Installation und erstem Laden von Beta2 wird der historische Gesamtwert automatisch und dauerhaft wiederhergestellt. Manuelle Änderungen an Home Assistants Speicherdateien sind nicht erforderlich.

## Prüfung

- `174 passed, 267 subtests passed`
- Wiederherstellung aus einem Beta1-Nullwert getestet
- Addition eines unter Beta1 neu entstandenen Gewinns getestet
- wiederholte Migration auf Idempotenz getestet