### PR TITLE
Release 4.5.0

### DIFF
--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -10,7 +10,7 @@ DOMAIN = "battery_smartflow_ai"
 INTEGRATION_NAME = "Battery SmartFlow AI"
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "4.5.0-Beta2"
+INTEGRATION_VERSION = "4.5.0"
 
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": [],
-  "version": "4.5.0-Beta2"
+  "version": "4.5.0"
 }

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -13,7 +13,7 @@ COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
 
 
 class DebugIntegrationContractTests(unittest.TestCase):
-    def test_manifest_and_runtime_version_match_v450_beta2_release(self) -> None:
+    def test_manifest_and_runtime_version_match_v450_release(self) -> None:
         manifest_version = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )["version"]
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "4.5.0-Beta2")
+        self.assertEqual(manifest_version, "4.5.0")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:


### PR DESCRIPTION
## Veröffentlichung

Bereitet den stabilen Release `4.5.0` auf Basis der erfolgreich getesteten `4.5.0-Beta2` vor.

## Inhalt von V4.5.0

- verwendet die in Home Assistant konfigurierte Systemwährung für Preisangaben
- passt Preis-Einheiten, Eingabebereiche, Schrittweiten und Darstellungspräzision an die aktive Währung an
- entfernt feste EUR-Annahmen aus Strategie-, Schwellen- und Wirtschaftlichkeitslogik
- erhält bestehende EUR-Installationen und gespeicherte Zahlenwerte ohne Wechselkursumrechnung
- stellt historische Gesamtersparnisse bei der Migration aus älteren Versionen zuverlässig wieder her
- schützt den durchschnittlichen Batteriepreis vor transienten SoC-Nullwerten
- ergänzt internationale Regressionstests unter anderem für EUR und DKK

## Release-Entscheidung

Seit Beta2 wurden keine neuen V4.5.0-Fehler gemeldet. Alle Milestone-Issues #222 bis #230 sind geschlossen. Der stabile Release macht die Währungsunterstützung nun auch Nutzern zugänglich, die keine Vorabversionen installieren.

## Prüfung

- 174 Tests bestanden
- 267 Untertests bestanden
- Python-Kompilierungsprüfung bestanden
- Diff- und Formatprüfung bestanden
- Manifest- und Laufzeitversion stimmen auf `4.5.0` überein