### PR TITLE
Gerätenamen für Steuerung und Wirtschaft lokalisieren

### DIFF
--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -8,6 +8,21 @@ from homeassistant.const import Platform
 DOMAIN = "battery_smartflow_ai"
 
 INTEGRATION_NAME = "Battery SmartFlow AI"
+
+VIRTUAL_DEVICE_MODELS = {
+    "de": "Virtuelles Gerät",
+    "en": "Virtual device",
+    "fr": "Appareil virtuel",
+    "nl": "Virtueel apparaat",
+}
+
+
+def virtual_device_model(language: str | None) -> str:
+    """Return the short virtual-device label for the HA backend language."""
+    language_code = (language or "en").replace("_", "-").split("-", 1)[0]
+    return VIRTUAL_DEVICE_MODELS.get(language_code, VIRTUAL_DEVICE_MODELS["en"])
+
+
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
 INTEGRATION_VERSION = "4.6.0-Beta2"

--- a/custom_components/battery_smartflow_ai/number.py
+++ b/custom_components/battery_smartflow_ai/number.py
@@ -9,7 +9,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
     DOMAIN,
-    INTEGRATION_NAME,
     INTEGRATION_MANUFACTURER,
     INTEGRATION_MODEL,
     INTEGRATION_VERSION,
@@ -275,7 +274,7 @@ class ZendureSmartFlowNumber(NumberEntity):
         self._attr_unique_id = f"{entry.entry_id}_{description.key}"
         self._attr_device_info = {
             "identifiers": {(DOMAIN, entry.entry_id)},
-            "name": INTEGRATION_NAME,
+            "translation_key": "control_and_planning",
             "manufacturer": INTEGRATION_MANUFACTURER,
             "model": INTEGRATION_MODEL,
             "sw_version": INTEGRATION_VERSION,

--- a/custom_components/battery_smartflow_ai/select.py
+++ b/custom_components/battery_smartflow_ai/select.py
@@ -11,7 +11,6 @@ from .const import (
     DOMAIN,
     INTEGRATION_MANUFACTURER,
     INTEGRATION_MODEL,
-    INTEGRATION_NAME,
     INTEGRATION_VERSION,
     AI_MODES,
     MANUAL_ACTIONS,
@@ -87,7 +86,7 @@ class ZendureSmartFlowSelect(SelectEntity):
 
         self._attr_device_info = {
             "identifiers": {(DOMAIN, entry.entry_id)},
-            "name": INTEGRATION_NAME,
+            "translation_key": "control_and_planning",
             "manufacturer": INTEGRATION_MANUFACTURER,
             "model": INTEGRATION_MODEL,
             "sw_version": INTEGRATION_VERSION,

--- a/custom_components/battery_smartflow_ai/sensor.py
+++ b/custom_components/battery_smartflow_ai/sensor.py
@@ -21,10 +21,10 @@ from homeassistant.util import dt as dt_util
 
 from .const import (
     DOMAIN,
-    INTEGRATION_NAME,
     INTEGRATION_MANUFACTURER,
     INTEGRATION_MODEL,
     INTEGRATION_VERSION,
+    virtual_device_model,
     STATUS_ENUMS,
     AI_STATUS_ENUMS,
     RECO_ENUMS,
@@ -1263,16 +1263,16 @@ class ZendureSmartFlowSensor(CoordinatorEntity, SensorEntity):
         if description.economics_device:
             self._attr_device_info = DeviceInfo(
                 identifiers={(DOMAIN, f"{entry.entry_id}_economics")},
-                name="Battery SmartFlow AI – Wirtschaft & Preise",
+                translation_key="economics_and_prices",
                 manufacturer=INTEGRATION_MANUFACTURER,
-                model="Virtual economics and market price device",
+                model=virtual_device_model(coordinator.hass.config.language),
                 sw_version=INTEGRATION_VERSION,
                 via_device=(DOMAIN, entry.entry_id),
             )
         else:
             self._attr_device_info = DeviceInfo(
                 identifiers={(DOMAIN, entry.entry_id)},
-                name=INTEGRATION_NAME,
+                translation_key="control_and_planning",
                 manufacturer=INTEGRATION_MANUFACTURER,
                 model=INTEGRATION_MODEL,
                 sw_version=INTEGRATION_VERSION,

--- a/custom_components/battery_smartflow_ai/strings.json
+++ b/custom_components/battery_smartflow_ai/strings.json
@@ -1,5 +1,9 @@
 {
   "title": "Battery SmartFlow AI",
+  "device": {
+    "control_and_planning": {"name": "Battery SmartFlow AI – Control & Planning"},
+    "economics_and_prices": {"name": "Battery SmartFlow AI – Economics & Prices"}
+  },
   "config": {
     "abort": {
       "debug_integration_not_loaded": "Battery SmartFlow AI is not currently loaded.",

--- a/custom_components/battery_smartflow_ai/translations/de.json
+++ b/custom_components/battery_smartflow_ai/translations/de.json
@@ -1,4 +1,8 @@
 {
+  "device": {
+    "control_and_planning": {"name": "Battery SmartFlow AI – Steuerung & Planung"},
+    "economics_and_prices": {"name": "Battery SmartFlow AI – Wirtschaft & Preise"}
+  },
   "config": {
     "abort": {
       "debug_integration_not_loaded": "Battery SmartFlow AI ist derzeit nicht geladen.",

--- a/custom_components/battery_smartflow_ai/translations/en.json
+++ b/custom_components/battery_smartflow_ai/translations/en.json
@@ -1,4 +1,8 @@
 {
+  "device": {
+    "control_and_planning": {"name": "Battery SmartFlow AI – Control & Planning"},
+    "economics_and_prices": {"name": "Battery SmartFlow AI – Economics & Prices"}
+  },
   "config": {
     "abort": {
       "debug_integration_not_loaded": "Battery SmartFlow AI is not currently loaded.",

--- a/custom_components/battery_smartflow_ai/translations/fr.json
+++ b/custom_components/battery_smartflow_ai/translations/fr.json
@@ -1,4 +1,8 @@
 {
+  "device": {
+    "control_and_planning": {"name": "Battery SmartFlow AI – Commande et planification"},
+    "economics_and_prices": {"name": "Battery SmartFlow AI – Économie et prix"}
+  },
   "config": {
     "abort": {
       "debug_recording_started": "Enregistrement de débogage démarré. La progression est affichée par les capteurs d’état.",

--- a/custom_components/battery_smartflow_ai/translations/nl.json
+++ b/custom_components/battery_smartflow_ai/translations/nl.json
@@ -1,4 +1,8 @@
 {
+  "device": {
+    "control_and_planning": {"name": "Battery SmartFlow AI – Besturing en planning"},
+    "economics_and_prices": {"name": "Battery SmartFlow AI – Economie en prijzen"}
+  },
   "config": {
     "abort": {
       "debug_integration_not_loaded": "Battery SmartFlow AI is momenteel niet geladen.",

--- a/tests/test_economics_sensor_structure.py
+++ b/tests/test_economics_sensor_structure.py
@@ -80,7 +80,8 @@ def test_all_new_economics_sensors_use_the_virtual_device() -> None:
         assert _source(descriptions[key]["economics_device"]) == "True"
 
     source = SENSOR_PATH.read_text(encoding="utf-8")
-    assert 'name="Battery SmartFlow AI – Wirtschaft & Preise"' in source
+    assert 'translation_key="economics_and_prices"' in source
+    assert "model=virtual_device_model(coordinator.hass.config.language)" in source
     assert 'via_device=(DOMAIN, entry.entry_id)' in source
     assert 'identifiers={(DOMAIN, f"{entry.entry_id}_economics")}' in source
 

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -41,6 +41,8 @@ def translation_keys(module_name: str) -> set[str]:
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
+        if isinstance(node.func, ast.Name) and node.func.id == "DeviceInfo":
+            continue
         for keyword in node.keywords:
             if keyword.arg != "translation_key":
                 continue
@@ -108,6 +110,39 @@ def enum_translation_options() -> dict[tuple[str, str], set[str]]:
 
 
 class TranslationCoverageTests(unittest.TestCase):
+    def test_device_names_and_virtual_model_are_localized(self) -> None:
+        expected = {
+            "de": (
+                "Battery SmartFlow AI – Steuerung & Planung",
+                "Battery SmartFlow AI – Wirtschaft & Preise",
+                "Virtuelles Gerät",
+            ),
+            "en": (
+                "Battery SmartFlow AI – Control & Planning",
+                "Battery SmartFlow AI – Economics & Prices",
+                "Virtual device",
+            ),
+            "fr": (
+                "Battery SmartFlow AI – Commande et planification",
+                "Battery SmartFlow AI – Économie et prix",
+                "Appareil virtuel",
+            ),
+            "nl": (
+                "Battery SmartFlow AI – Besturing en planning",
+                "Battery SmartFlow AI – Economie en prijzen",
+                "Virtueel apparaat",
+            ),
+        }
+        for language, values in expected.items():
+            with self.subTest(language=language):
+                devices = load_json(TRANSLATIONS / f"{language}.json")["device"]
+                self.assertEqual(devices["control_and_planning"]["name"], values[0])
+                self.assertEqual(devices["economics_and_prices"]["name"], values[1])
+                self.assertEqual(const.virtual_device_model(language), values[2])
+
+        self.assertEqual(const.virtual_device_model("de-DE"), "Virtuelles Gerät")
+        self.assertEqual(const.virtual_device_model("es"), "Virtual device")
+
     def test_debug_abort_reasons_exist_on_config_flow_surface(self) -> None:
         expected = {
             "debug_recording_started",


### PR DESCRIPTION
## Zusammenfassung
- benennt das Hauptgerät sprachabhängig als Steuerung & Planung
- behält Wirtschaft & Preise als eindeutigen Namen des virtuellen Geräts
- kürzt dessen Modellzeile sprachabhängig auf Virtuelles Gerät
- bewahrt Gerätekennungen, Entitätszuordnung und gespeicherte Werte

## Sprachen
- Deutsch
- Englisch
- Französisch
- Niederländisch

## Prüfung
- 286 Tests bestanden
- 324 Subtests bestanden
- compileall und git diff --check erfolgreich