### PR TITLE
V4.6.0-Beta3: Aktive Leistung bei manuellem Standby stoppen

### DIFF
--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -25,7 +25,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "4.6.0-Beta2"
+INTEGRATION_VERSION = "4.6.0-Beta3"
 
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,

--- a/custom_components/battery_smartflow_ai/coordinator.py
+++ b/custom_components/battery_smartflow_ai/coordinator.py
@@ -196,6 +196,7 @@ from .market_price import (
     MarketPriceSourceAdapter,
     NumericPriceNormalizer,
 )
+from .manual_standby import active_power_direction
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -5660,45 +5661,46 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 and str(manual_action) == MANUAL_STANDBY
             )
 
-            manual_standby_active_charge = bool(
-                manual_standby_no_command
-                and (
-                    str(self._state(self.entities.ac_mode) or "")
-                    == ZENDURE_MODE_INPUT
-                    or str(self._persist.get("last_set_mode") or "")
-                    == ZENDURE_MODE_INPUT
-                    or float(
-                        self._persist.get(
-                            "last_set_input_w",
-                            0.0,
-                        )
-                        or 0.0
-                    )
-                    > 0.0
-                )
-            )
-
             if manual_standby_no_command:
-                # Dev5.6 emergency correction:
-                # Manual standby must actively stop an AC charge that BSFAI previously
-                # started. Merely stopping future writes leaves the device in its last
-                # INPUT state and therefore allows grid charging to continue indefinitely.
-                #
-                # After the neutral stop command has been sent, subsequent standby cycles
-                # remain passive and do not fight external control.
-                if manual_standby_active_charge:
-                    # Stop the active INPUT side once, then leave the neutral
-                    # display mode in OUTPUT. Do not follow it with a redundant
-                    # outputLimit=0 command.
-                    await self._set_input_limit(0.0, force=True)
-                    await self._set_ac_mode(ZENDURE_MODE_OUTPUT)
+                # Stop BSFAI's active side exactly once when manual standby is
+                # entered. Later standby cycles stay passive, so external
+                # controls are not overwritten. The persisted latch also makes
+                # an update/restart in an already active standby safe.
+                if not bool(self._persist.get("manual_standby_stop_applied")):
+                    standby_direction = active_power_direction(
+                        current_ac_mode=self._state(self.entities.ac_mode),
+                        last_ac_mode=self._persist.get("last_set_mode"),
+                        current_input_limit_w=_to_float(
+                            self._state(self.entities.input_limit), 0.0
+                        ),
+                        current_output_limit_w=_to_float(
+                            self._state(self.entities.output_limit), 0.0
+                        ),
+                        last_input_limit_w=_to_float(
+                            self._persist.get("last_set_input_w"), 0.0
+                        ),
+                        last_output_limit_w=_to_float(
+                            self._persist.get("last_set_output_w"), 0.0
+                        ),
+                        measured_charge_w=battery_charge_w,
+                        measured_discharge_w=battery_discharge_w,
+                    )
+
+                    if standby_direction == "input":
+                        await self._set_input_limit(0.0, force=True)
+                        await self._set_ac_mode(ZENDURE_MODE_OUTPUT)
+                    elif standby_direction == "output":
+                        await self._set_output_limit(0.0, force=True)
 
                     self._persist["last_set_input_w"] = 0
                     self._persist["last_set_output_w"] = 0
                     self._persist["last_set_mode"] = ZENDURE_MODE_OUTPUT
+                    self._persist["manual_standby_stop_applied"] = True
 
                     self._persist["regulation_skipped_write_reason"] = (
-                        "manual_standby_stopped_active_charge"
+                        f"manual_standby_stopped_active_{standby_direction}"
+                        if standby_direction
+                        else "manual_standby_no_active_power"
                     )
                 else:
                     self._persist["regulation_skipped_write_reason"] = (
@@ -5706,6 +5708,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     )
 
             else:
+                self._persist["manual_standby_stop_applied"] = False
                 if regulation_device_command.should_write_mode:
                     await self._set_ac_mode(ac_mode)
 

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": [],
-  "version": "4.6.0-Beta2"
+  "version": "4.6.0-Beta3"
 }

--- a/custom_components/battery_smartflow_ai/manual_standby.py
+++ b/custom_components/battery_smartflow_ai/manual_standby.py
@@ -1,0 +1,48 @@
+"""One-shot handover helpers for manual standby."""
+
+from __future__ import annotations
+
+
+def active_power_direction(
+    *,
+    current_ac_mode: str | None,
+    last_ac_mode: str | None,
+    current_input_limit_w: float | None,
+    current_output_limit_w: float | None,
+    last_input_limit_w: float | None,
+    last_output_limit_w: float | None,
+    measured_charge_w: float = 0.0,
+    measured_discharge_w: float = 0.0,
+) -> str | None:
+    """Return the active side that must be stopped on standby entry.
+
+    Live entity values take precedence over the coordinator cache. Measured
+    battery power is a final fallback when a Zendure Number entity has not yet
+    refreshed. Merely being in OUTPUT mode is not enough to issue a stop: that
+    is the neutral display mode and may legitimately carry 0 W.
+    """
+
+    current_mode = str(current_ac_mode or "").lower()
+    last_mode = str(last_ac_mode or "").lower()
+    current_input = max(0.0, float(current_input_limit_w or 0.0))
+    current_output = max(0.0, float(current_output_limit_w or 0.0))
+    last_input = max(0.0, float(last_input_limit_w or 0.0))
+    last_output = max(0.0, float(last_output_limit_w or 0.0))
+    measured_charge = max(0.0, float(measured_charge_w or 0.0))
+    measured_discharge = max(0.0, float(measured_discharge_w or 0.0))
+
+    if current_mode == "input":
+        return "input"
+    if current_mode == "output" and (
+        current_output > 0.0 or last_output > 0.0 or measured_discharge > 30.0
+    ):
+        return "output"
+    if current_input > 0.0 or last_input > 0.0 or measured_charge > 30.0:
+        return "input"
+    if current_output > 0.0 or last_output > 0.0:
+        return "output"
+    if last_mode == "input":
+        return "input"
+    if last_mode == "output" and measured_discharge > 30.0:
+        return "output"
+    return None

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -13,7 +13,7 @@ COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
 
 
 class DebugIntegrationContractTests(unittest.TestCase):
-    def test_manifest_and_runtime_version_match_v460_beta2_release(self) -> None:
+    def test_manifest_and_runtime_version_match_v460_beta3_release(self) -> None:
         manifest_version = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )["version"]
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "4.6.0-Beta2")
+        self.assertEqual(manifest_version, "4.6.0-Beta3")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_manual_standby.py
+++ b/tests/test_manual_standby.py
@@ -1,0 +1,59 @@
+"""Regression tests for the one-shot manual-standby handover."""
+
+from __future__ import annotations
+
+from support import bootstrap
+
+
+bootstrap()
+
+from custom_components.battery_smartflow_ai.manual_standby import (  # noqa: E402
+    active_power_direction,
+)
+
+
+def _direction(**overrides: object) -> str | None:
+    values = {
+        "current_ac_mode": "output",
+        "last_ac_mode": "output",
+        "current_input_limit_w": 0.0,
+        "current_output_limit_w": 0.0,
+        "last_input_limit_w": 0.0,
+        "last_output_limit_w": 0.0,
+        "measured_charge_w": 0.0,
+        "measured_discharge_w": 0.0,
+    }
+    values.update(overrides)
+    return active_power_direction(**values)
+
+
+def test_standby_stops_live_output_limit_from_issue_254() -> None:
+    assert _direction(current_output_limit_w=170.0) == "output"
+    assert _direction(current_output_limit_w=600.0) == "output"
+
+
+def test_standby_stops_cached_or_measured_discharge() -> None:
+    assert _direction(last_output_limit_w=167.0) == "output"
+    assert _direction(measured_discharge_w=167.0) == "output"
+
+
+def test_standby_still_stops_active_input_charge() -> None:
+    assert _direction(current_ac_mode="input") == "input"
+    assert _direction(
+        current_ac_mode="unknown",
+        last_ac_mode="input",
+        last_input_limit_w=700.0,
+    ) == "input"
+
+
+def test_neutral_output_mode_needs_no_stop_command() -> None:
+    assert _direction() is None
+
+
+def test_live_mode_wins_over_stale_opposite_cache() -> None:
+    assert _direction(
+        current_ac_mode="output",
+        current_output_limit_w=600.0,
+        last_ac_mode="input",
+        last_input_limit_w=700.0,
+    ) == "output"


### PR DESCRIPTION
## Zusammenfassung
- beendet beim Eintritt in Manuell → Standby eine aktive Lade- oder Ausgangsleistung genau einmal
- erkennt reale Zendure-Limits, den BSFAI-Cache und gemessene Akkuleistung
- bleibt nach der Nullübergabe passiv und überschreibt keine spätere externe Steuerung
- enthält die bereits gemergten lokalisierten Gerätenamen aus PR #258
- setzt die Version auf 4.6.0-Beta3

Addresses #254

## Regression
- 170 W und 600 W Ausgangslimit werden als aktive Ausgabe erkannt
- aktive INPUT-Ladung wird weiterhin gestoppt
- neutrales OUTPUT 0 W erzeugt keinen unnötigen Stopbefehl
- reale aktive Richtung gewinnt gegen einen veralteten Gegenrichtungs-Cache

## Prüfung
- 291 Tests bestanden
- 324 Subtests bestanden
- compileall und git diff --check erfolgreich