### PR TITLE
V4.6.0-Beta4: EPEX-Euro-Einheiten wieder unterstützen

### DIFF
--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -25,7 +25,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "4.6.0-Beta3"
+INTEGRATION_VERSION = "4.6.0-Beta4"
 
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": [],
-  "version": "4.6.0-Beta3"
+  "version": "4.6.0-Beta4"
 }

--- a/custom_components/battery_smartflow_ai/market_price/adapters.py
+++ b/custom_components/battery_smartflow_ai/market_price/adapters.py
@@ -69,6 +69,7 @@ _SOURCE_VALIDITY = {
 
 
 _CURRENCY_ENERGY_UNIT = re.compile(r"^([A-Za-z]{3})/(kWh|MWh)$", re.IGNORECASE)
+_EURO_SYMBOL_ENERGY_UNIT = re.compile(r"^€/(kWh|MWh)$", re.IGNORECASE)
 _CENT_PER_KWH_UNITS = frozenset({"ct/kwh", "cent/kwh", "c/kwh"})
 DEFAULT_CURRENT_PRICE_MAX_AGE = timedelta(hours=6)
 MAX_FUTURE_TIMESTAMP_SKEW = timedelta(minutes=5)
@@ -130,15 +131,21 @@ def normalize_price_value(
     elif compact_unit.lower() in _CENT_PER_KWH_UNITS:
         divisor = 100.0
     else:
-        match = _CURRENCY_ENERGY_UNIT.fullmatch(compact_unit)
-        if match is None:
+        euro_match = _EURO_SYMBOL_ENERGY_UNIT.fullmatch(compact_unit)
+        currency_match = _CURRENCY_ENERGY_UNIT.fullmatch(compact_unit)
+        if euro_match is not None:
+            unit_currency = "EUR"
+            energy_unit = euro_match.group(1)
+        elif currency_match is not None:
+            unit_currency = normalize_currency_code(currency_match.group(1))
+            energy_unit = currency_match.group(2)
+        else:
             return NormalizedNumericPrice(
                 value=None,
                 currency=source_code or active_code,
                 unit=canonical_unit,
                 validity=MarketPriceValidity.INVALID,
             )
-        unit_currency = normalize_currency_code(match.group(1))
         if unit_currency != active_code:
             return NormalizedNumericPrice(
                 value=None,
@@ -146,7 +153,7 @@ def normalize_price_value(
                 unit=canonical_unit,
                 validity=MarketPriceValidity.INVALID,
             )
-        divisor = 1000.0 if match.group(2).lower() == "mwh" else 1.0
+        divisor = 1000.0 if energy_unit.lower() == "mwh" else 1.0
 
     if source_code is not None and unit_currency is not None:
         if source_code != unit_currency:

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -13,7 +13,7 @@ COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
 
 
 class DebugIntegrationContractTests(unittest.TestCase):
-    def test_manifest_and_runtime_version_match_v460_beta3_release(self) -> None:
+    def test_manifest_and_runtime_version_match_v460_beta4_release(self) -> None:
         manifest_version = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )["version"]
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "4.6.0-Beta3")
+        self.assertEqual(manifest_version, "4.6.0-Beta4")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_legacy_import_price_adapter.py
+++ b/tests/test_legacy_import_price_adapter.py
@@ -254,6 +254,27 @@ class LegacyImportForecastAdapterTests(unittest.TestCase):
 
         self.assertEqual(forecast.points[0].price, 0.122)
 
+    def test_epex_euro_symbol_forecast_is_preserved(self) -> None:
+        forecast = normalize(
+            {
+                "unit_of_measurement": "€/kWh",
+                "data": [
+                    {
+                        "start_time": "2026-08-22T11:00:00+00:00",
+                        "end_time": "2026-08-22T12:00:00+00:00",
+                        "price_per_kwh": -0.04,
+                    },
+                    {
+                        "start_time": "2026-08-22T12:00:00+00:00",
+                        "end_time": "2026-08-22T13:00:00+00:00",
+                        "price_per_kwh": 0.22,
+                    },
+                ],
+            }
+        )
+
+        self.assertEqual([point.price for point in forecast.points], [-0.04, 0.22])
+
     def test_forecast_with_different_currency_is_rejected(self) -> None:
         forecast = normalize(
             {

--- a/tests/test_market_price_normalization.py
+++ b/tests/test_market_price_normalization.py
@@ -60,8 +60,25 @@ class MarketPriceValueNormalizationTests(unittest.TestCase):
         self.assertEqual(result.value, 0.122)
         self.assertEqual(result.unit, "EUR/kWh")
 
+    def test_epex_euro_symbol_units_are_supported_for_eur(self) -> None:
+        per_kwh = normalize(-0.125, unit="€/kWh")
+        per_mwh = normalize(122.0, unit="€/MWh")
+
+        self.assertEqual(per_kwh.validity, MarketPriceValidity.VALID)
+        self.assertEqual(per_kwh.value, -0.125)
+        self.assertEqual(per_kwh.currency, "EUR")
+        self.assertEqual(per_kwh.unit, "EUR/kWh")
+        self.assertEqual(per_mwh.validity, MarketPriceValidity.VALID)
+        self.assertEqual(per_mwh.value, 0.122)
+
+    def test_euro_symbol_unit_is_rejected_for_non_eur_system_currency(self) -> None:
+        result = normalize(0.25, unit="€/kWh", active_currency="CHF")
+
+        self.assertEqual(result.validity, MarketPriceValidity.INVALID)
+        self.assertIsNone(result.value)
+
     def test_zero_remains_valid_for_every_supported_scale(self) -> None:
-        for unit in ("EUR/kWh", "ct/kWh", "EUR/MWh"):
+        for unit in ("EUR/kWh", "ct/kWh", "EUR/MWh", "€/kWh", "€/MWh"):
             with self.subTest(unit=unit):
                 result = normalize(0.0, unit=unit)
                 self.assertEqual(result.validity, MarketPriceValidity.VALID)
@@ -87,7 +104,7 @@ class MarketPriceValueNormalizationTests(unittest.TestCase):
     def test_unknown_units_and_invalid_currency_metadata_are_rejected(self) -> None:
         for unit, currency in (
             ("EUR/Wh", "EUR"),
-            ("€/kWh", None),
+            ("$/kWh", None),
             ("W", "EUR"),
             ("EUR/kWh", "EURO"),
         ):


### PR DESCRIPTION
## Zusammenfassung
- akzeptiert die von EPEX Spot 4.1.0 verwendeten Einheiten €/kWh und €/MWh
- übernimmt dadurch aktuellen EPEX-Preis und Preisprognose wieder vollständig
- erhält Null- und Negativpreise
- lehnt Euro-Symbolwerte bei einer anderen aktiven Systemwährung weiterhin ab
- lässt Tibber- und ISO-Formate wie EUR/kWh unverändert
- setzt die Version auf 4.6.0-Beta4

Addresses #259

## Prüfung
- 294 Tests bestanden
- 326 Subtests bestanden
- compileall und git diff --check erfolgreich