### PR TITLE
V4.6.0-Beta5: Sehr-billig-Ladung vor Lernfenster priorisieren

### DIFF
--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -25,7 +25,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "4.6.0-Beta4"
+INTEGRATION_VERSION = "4.6.0-Beta5"
 
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,

--- a/custom_components/battery_smartflow_ai/decision_engine.py
+++ b/custom_components/battery_smartflow_ai/decision_engine.py
@@ -1322,6 +1322,7 @@ class DecisionEngine:
 
         if (
             self._learned_planning_waits_for_window(ctx)
+            and str(result.reason or "") != "very_cheap_force_charge"
             and state
             in {
                 "ac_charge_planned",
@@ -1693,8 +1694,10 @@ class DecisionEngine:
         except Exception:
             pv_opportunity_price = 0.0
 
-        # Small epsilon avoids oscillation on equal/rounded values.
-        return price_now <= (pv_opportunity_price - 0.001)
+        # Equal prices are economically equivalent. This also lets a zero or
+        # negative grid price override PV when no feed-in tariff is configured,
+        # without introducing a fixed tolerance that depends on the currency.
+        return price_now <= pv_opportunity_price
 
     def _optional_grid_charge_should_wait_for_pv(self, ctx: DecisionContext) -> bool:
         """Return True when optional grid charging should not override current PV.

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": [],
-  "version": "4.6.0-Beta4"
+  "version": "4.6.0-Beta5"
 }

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -13,7 +13,7 @@ COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
 
 
 class DebugIntegrationContractTests(unittest.TestCase):
-    def test_manifest_and_runtime_version_match_v460_beta4_release(self) -> None:
+    def test_manifest_and_runtime_version_match_v460_beta5_release(self) -> None:
         manifest_version = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )["version"]
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "4.6.0-Beta4")
+        self.assertEqual(manifest_version, "4.6.0-Beta5")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_dev9_scenarios.py
+++ b/tests/test_dev9_scenarios.py
@@ -278,6 +278,61 @@ class Dev9FallbackScenarios(unittest.TestCase):
 
 
 class Dev9OptionalDataScenarios(unittest.TestCase):
+    @staticmethod
+    def _waiting_learned_plan() -> SimpleNamespace:
+        return SimpleNamespace(
+            status="ready",
+            mode="wait",
+            decision_reason="learned_charge_window_wait",
+            required_charge_energy_kwh=1.0,
+            requested_charge_power_w=1000.0,
+        )
+
+    def test_issue_255_very_cheap_near_zero_price_overrides_learned_wait(self) -> None:
+        result = DecisionEngine().evaluate(
+            context(
+                price_now=-0.00001,
+                very_cheap_price=0.02,
+                pv_w=1000.0,
+                house_load_w=200.0,
+                grid_import_w=0.0,
+                feed_in_tariff=0.0,
+                learned_planning_enabled=True,
+                learned_charge_plan=self._waiting_learned_plan(),
+            )
+        )
+
+        self.assertEqual(result.reason, "very_cheap_force_charge")
+        self.assertEqual(result.action, "charge")
+        self.assertEqual(result.charge_w, 1000.0)
+
+    def test_zero_price_is_equivalent_to_pv_without_feed_in_tariff(self) -> None:
+        result = DecisionEngine().evaluate(
+            context(
+                price_now=0.0,
+                very_cheap_price=0.02,
+                pv_w=1000.0,
+                house_load_w=200.0,
+                grid_import_w=0.0,
+                feed_in_tariff=0.0,
+            )
+        )
+
+        self.assertEqual(result.reason, "very_cheap_force_charge")
+
+    def test_normal_price_still_respects_waiting_learned_window(self) -> None:
+        result = DecisionEngine().evaluate(
+            context(
+                price_now=0.10,
+                very_cheap_price=0.02,
+                learned_planning_enabled=True,
+                learned_charge_plan=self._waiting_learned_plan(),
+            )
+        )
+
+        self.assertEqual(result.reason, "learned_charge_window_wait")
+        self.assertEqual(result.action, "idle")
+
     def test_active_learned_window_bypasses_coarse_pv_planning_gate(self) -> None:
         plan = SimpleNamespace(
             status="ready",


### PR DESCRIPTION
## Inhalt

- behebt den in #255 gemeldeten Fall, in dem ein sehr billiger Preis durch ein wartendes Lernfenster blockiert wurde
- behandelt einen Nullpreis bzw. negativen Preis ohne Einspeisevergütung korrekt als mindestens gleichwertig zur PV-Nutzung
- lässt das normale Warten auf ein gelerntes Ladefenster bei Preisen oberhalb der Sehr-billig-Schwelle unverändert
- erhöht die Integrationsversion auf `4.6.0-Beta5`

## Validierung

- 297 Tests bestanden
- 326 Untertests bestanden
- zusätzliche Regressionstests für den exakten Preis `-0.00001`, Nullpreis und das unveränderte normale Lernfenster
- Syntaxprüfung und Diff-Prüfung erfolgreich

Addresses #255. Das Issue bleibt bis zur Bestätigung auf echter Hardware offen.