### PR TITLE
V4.6.0-RC1: Automatischer Stopp, Prozentregler und Wirkungsgrad

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,8 +471,14 @@ The integration can show:
 * Discharged energy
 * Price difference
 * Total profit / savings in €
+* Economic efficiency since start (100% = cost recovery)
 
 Technical support modes such as off-grid support or PV house-load passthrough are not counted as economic price discharge.
+
+The economic efficiency is intentionally different from the technical battery
+efficiency reported by Zendure-HA. It compares the value of discharged battery
+energy with valued grid-charge costs and PV opportunity costs. The value becomes
+available after at least 0.1 kWh of both charging and discharging have been observed.
 
 Note: Details about the calculation are in the **manual**.
 

--- a/README.md
+++ b/README.md
@@ -413,21 +413,22 @@ Technical regulation holds are not allowed to override SoC or cell-voltage prote
 
 ---
 
-# 🧠 Peak factor (Adaptive Peak)
+# 🧠 Peak price markup (Adaptive Peak)
 
-The peak factor can be adjusted via the GUI and influences the detection of price peaks.
+The GUI setting is expressed as an understandable percentage above the average
+price and influences the detection of price peaks.
 
 Formula:
 
 Peak threshold = max(
-Average price × Peak factor,
+Average price × (1 + peak price markup / 100),
 Average price + €0.03
 )
 
-Default: **1.35**
+Default: **35%**
 
-* Lower → detects more peaks (more sensitive)
-* Higher → detects only strong price peaks (more conservative)
+* Lower markup → detects more peaks (more sensitive)
+* Higher markup → detects only strong price peaks (more conservative)
 
 ---
 
@@ -898,21 +899,22 @@ Technische Haltezustände dürfen SoC- oder Zellspannungs-Schutz nicht überstim
 
 ---
 
-# 🧠 Peak-Faktor (Adaptive Peak)
+# 🧠 Peakpreis-Aufschlag (Adaptive Peak)
 
-Der Peak-Faktor ist über die GUI einstellbar und beeinflusst die Erkennung von Preisspitzen.
+Die GUI-Einstellung gibt verständlich an, wie viel Prozent ein Preis über dem
+Durchschnitt liegen muss, und beeinflusst so die Erkennung von Preisspitzen.
 
 Formel:
 
 Peak-Schwelle = max(
-Durchschnittspreis × Peak-Faktor,
+Durchschnittspreis × (1 + Peakpreis-Aufschlag / 100),
 Durchschnittspreis + 0,03 €
 )
 
-Standard: **1.35**
+Standard: **35 %**
 
-* Niedriger → erkennt mehr Peaks (sensitiver)
-* Höher → erkennt nur starke Preisspitzen (konservativer)
+* Niedrigerer Aufschlag → erkennt mehr Peaks (sensitiver)
+* Höherer Aufschlag → erkennt nur starke Preisspitzen (konservativer)
 
 ---
 

--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -25,7 +25,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "4.6.0-Beta5"
+INTEGRATION_VERSION = "4.6.0-RC1"
 
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,

--- a/custom_components/battery_smartflow_ai/coordinator.py
+++ b/custom_components/battery_smartflow_ai/coordinator.py
@@ -4898,6 +4898,9 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 "economics_average_battery_discharge_value": (
                     economics_total_snapshot.average_battery_discharge_value
                 ),
+                "economics_total_economic_efficiency_pct": (
+                    self._economics_engine.total_economic_efficiency_pct()
+                ),
             }
 
             sample_duration_seconds = float(UPDATE_INTERVAL)

--- a/custom_components/battery_smartflow_ai/device_command.py
+++ b/custom_components/battery_smartflow_ai/device_command.py
@@ -141,6 +141,7 @@ class DeviceCommandBuilder:
             current_ac_mode=current_ac_mode,
             last_input_limit_w=last_input_limit_w,
             last_output_limit_w=last_output_limit_w,
+            current_output_limit_w=current_output_limit_w,
         )
 
     def _build_input_command(
@@ -386,6 +387,7 @@ class DeviceCommandBuilder:
         current_ac_mode: str | None,
         last_input_limit_w: float,
         last_output_limit_w: float,
+        current_output_limit_w: float | None,
     ) -> DeviceCommand:
         ac_mode: Literal["input", "output"] = "output"
 
@@ -394,6 +396,10 @@ class DeviceCommandBuilder:
         has_power_to_stop = (
             self._zero_write_needed(old_value=last_input_limit_w)
             or self._zero_write_needed(old_value=last_output_limit_w)
+            or self._live_value_differs(
+                expected_value=0.0,
+                current_value=current_output_limit_w,
+            )
         )
 
         # Neutral idle is always represented by one outputLimit=0 command.
@@ -427,6 +433,7 @@ class DeviceCommandBuilder:
                 "current_ac_mode": current_ac_mode,
                 "last_input_limit_w": round(float(last_input_limit_w or 0.0), 2),
                 "last_output_limit_w": round(float(last_output_limit_w or 0.0), 2),
+                "current_output_limit_w": current_output_limit_w,
                 "single_stop_command": True,
                 "min_power_write_delta_w": float(
                     self.config.min_power_write_delta_w

--- a/custom_components/battery_smartflow_ai/economic_efficiency.py
+++ b/custom_components/battery_smartflow_ai/economic_efficiency.py
@@ -1,0 +1,48 @@
+"""Economic efficiency derived from the persistent BSFAI value ledger."""
+
+from __future__ import annotations
+
+from math import isfinite
+
+
+MIN_EVALUATED_ENERGY_KWH = 0.1
+
+
+def economic_efficiency_pct(
+    *,
+    grid_charge_cost: float,
+    pv_opportunity_cost: float,
+    battery_benefit: float,
+    charged_energy_kwh: float,
+    discharged_energy_kwh: float,
+) -> float | None:
+    """Return economic value recovery in percent, or None if not meaningful.
+
+    One hundred percent means the economic value of discharged battery energy
+    exactly covers the valued grid-charge and PV-opportunity input. Values above
+    100 percent represent an economic surplus. A non-positive input value has no
+    finite cost-recovery ratio and is therefore deliberately unavailable.
+    """
+
+    values = (
+        float(grid_charge_cost),
+        float(pv_opportunity_cost),
+        float(battery_benefit),
+        float(charged_energy_kwh),
+        float(discharged_energy_kwh),
+    )
+    if not all(isfinite(value) for value in values):
+        return None
+
+    if (
+        charged_energy_kwh < MIN_EVALUATED_ENERGY_KWH
+        or discharged_energy_kwh < MIN_EVALUATED_ENERGY_KWH
+    ):
+        return None
+
+    valued_input = float(grid_charge_cost) + float(pv_opportunity_cost)
+    if valued_input <= 0.0:
+        return None
+
+    discharged_value = float(battery_benefit) + valued_input
+    return round((discharged_value / valued_input) * 100.0, 1)

--- a/custom_components/battery_smartflow_ai/economics.py
+++ b/custom_components/battery_smartflow_ai/economics.py
@@ -8,6 +8,7 @@ from math import isfinite
 from typing import Any, Mapping
 
 from .market_price.models import MarketPrice, MarketPriceDirection
+from .economic_efficiency import economic_efficiency_pct
 
 
 @dataclass(frozen=True, slots=True)
@@ -508,6 +509,18 @@ class EconomicsEngine:
 
     def total_snapshot(self) -> EconomicsSnapshot:
         return self._snapshot(self._total)
+
+    def total_economic_efficiency_pct(self) -> float | None:
+        """Return the since-start cost-recovery ratio from valued flows."""
+        return economic_efficiency_pct(
+            grid_charge_cost=self._total.grid_charge_cost,
+            pv_opportunity_cost=self._total.pv_opportunity_cost,
+            battery_benefit=self._total.battery_benefit,
+            charged_energy_kwh=(
+                self._total.grid_charge_kwh + self._total.pv_charge_kwh
+            ),
+            discharged_energy_kwh=self._total.battery_discharge_kwh,
+        )
 
     def reset_daily(self) -> None:
         """Start a fresh daily bucket without changing lifetime totals."""

--- a/custom_components/battery_smartflow_ai/factor_display.py
+++ b/custom_components/battery_smartflow_ai/factor_display.py
@@ -1,0 +1,23 @@
+"""User-facing percentage conversion for internal market price factors."""
+
+from __future__ import annotations
+
+
+def peak_factor_to_markup_pct(factor: float) -> float:
+    """Convert an internal peak multiplier to a user-facing markup percent."""
+    return round((float(factor) - 1.0) * 100.0, 6)
+
+
+def markup_pct_to_peak_factor(percent: float) -> float:
+    """Convert a user-facing peak markup percent to an internal multiplier."""
+    return round(1.0 + (float(percent) / 100.0), 6)
+
+
+def valley_factor_to_discount_pct(factor: float) -> float:
+    """Convert an internal valley multiplier to a user-facing discount percent."""
+    return round((1.0 - float(factor)) * 100.0, 6)
+
+
+def discount_pct_to_valley_factor(percent: float) -> float:
+    """Convert a user-facing valley discount percent to an internal multiplier."""
+    return round(1.0 - (float(percent) / 100.0), 6)

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": [],
-  "version": "4.6.0-Beta5"
+  "version": "4.6.0-RC1"
 }

--- a/custom_components/battery_smartflow_ai/number.py
+++ b/custom_components/battery_smartflow_ai/number.py
@@ -41,6 +41,12 @@ from .const import (
     DEFAULT_FORECAST_BASE_LOAD,
 )
 from .price_currency import price_input_profile
+from .factor_display import (
+    discount_pct_to_valley_factor,
+    markup_pct_to_peak_factor,
+    peak_factor_to_markup_pct,
+    valley_factor_to_discount_pct,
+)
 
 
 PRICE_NUMBER_KEYS = frozenset(
@@ -54,6 +60,7 @@ PRICE_NUMBER_KEYS = frozenset(
 @dataclass(frozen=True, kw_only=True)
 class ZendureNumberEntityDescription(NumberEntityDescription):
     runtime_key: str
+    factor_percentage_kind: str | None = None
 
 
 NUMBERS: tuple[ZendureNumberEntityDescription, ...] = (
@@ -70,9 +77,11 @@ NUMBERS: tuple[ZendureNumberEntityDescription, ...] = (
         key=SETTING_PEAK_FACTOR,
         translation_key="peak_factor",
         runtime_key=SETTING_PEAK_FACTOR,
-        native_min_value=1.0,
-        native_max_value=2.5,
-        native_step=0.01,
+        factor_percentage_kind="peak_markup",
+        native_min_value=0,
+        native_max_value=150,
+        native_step=1,
+        native_unit_of_measurement="%",
         mode="box",
         icon="mdi:chart-bell-curve",
     ),
@@ -80,9 +89,11 @@ NUMBERS: tuple[ZendureNumberEntityDescription, ...] = (
         key=SETTING_VALLEY_FACTOR,
         translation_key="valley_factor",
         runtime_key=SETTING_VALLEY_FACTOR,
-        native_min_value=0.5,
-        native_max_value=1.0,
-        native_step=0.01,
+        factor_percentage_kind="valley_discount",
+        native_min_value=0,
+        native_max_value=50,
+        native_step=1,
+        native_unit_of_measurement="%",
         mode="box",
         icon="mdi:chart-bell-curve",
     ),
@@ -291,7 +302,7 @@ class ZendureSmartFlowNumber(NumberEntity):
 
     @property
     def native_value(self) -> float:
-        return float(
+        value = float(
             self.coordinator.runtime_settings.get(
                 self.entity_description.runtime_key,
                 _default_for_key(
@@ -301,8 +312,19 @@ class ZendureSmartFlowNumber(NumberEntity):
             )
         )
 
+        if self.entity_description.factor_percentage_kind == "peak_markup":
+            return peak_factor_to_markup_pct(value)
+        if self.entity_description.factor_percentage_kind == "valley_discount":
+            return valley_factor_to_discount_pct(value)
+        return value
+
     async def async_set_native_value(self, value: float) -> None:
         value = float(value)
+
+        if self.entity_description.factor_percentage_kind == "peak_markup":
+            value = markup_pct_to_peak_factor(value)
+        elif self.entity_description.factor_percentage_kind == "valley_discount":
+            value = discount_pct_to_valley_factor(value)
 
         self.coordinator.runtime_settings[self.entity_description.runtime_key] = value
 

--- a/custom_components/battery_smartflow_ai/sensor.py
+++ b/custom_components/battery_smartflow_ai/sensor.py
@@ -926,6 +926,16 @@ _SENSOR_DESCRIPTIONS: tuple[ZendureSensorEntityDescription, ...] = (
         economics_device=True,
     ),
     ZendureSensorEntityDescription(
+        key="economics_total_economic_efficiency_pct",
+        translation_key="economics_total_economic_efficiency_pct",
+        runtime_key="economics_total_economic_efficiency_pct",
+        native_unit_of_measurement="%",
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+        icon="mdi:finance",
+        economics_device=True,
+    ),
+    ZendureSensorEntityDescription(
         key="economics_daily_grid_to_battery_kwh",
         translation_key="economics_daily_grid_to_battery_kwh",
         runtime_key="economics_daily_grid_to_battery_kwh",

--- a/custom_components/battery_smartflow_ai/strings.json
+++ b/custom_components/battery_smartflow_ai/strings.json
@@ -332,10 +332,10 @@
         "name": "Profit margin (%)"
       },
       "peak_factor": {
-        "name": "Peak factor"
+        "name": "Peak price markup"
       },
       "valley_factor": {
-        "name": "Valley factor"
+        "name": "Valley price discount"
       },
       "very_cheap_price": {
         "name": "Very-cheap threshold"

--- a/custom_components/battery_smartflow_ai/strings.json
+++ b/custom_components/battery_smartflow_ai/strings.json
@@ -820,6 +820,7 @@
       "economics_total_export_revenue": {"name": "Balance since start – Export revenue"},
       "economics_total_avoided_grid_import_cost": {"name": "Balance since start – Avoided grid import cost"},
       "economics_total_battery_benefit": {"name": "Balance since start – Battery benefit"},
+      "economics_total_economic_efficiency_pct": {"name": "Balance since start – Economic efficiency"},
       "economics_daily_grid_to_battery_kwh": {"name": "Energy today – Grid to battery"},
       "economics_daily_pv_to_battery_kwh": {"name": "Energy today – PV to battery"},
       "economics_daily_grid_export_kwh": {"name": "Energy today – Grid export"},

--- a/custom_components/battery_smartflow_ai/translations/de.json
+++ b/custom_components/battery_smartflow_ai/translations/de.json
@@ -815,6 +815,7 @@
       "economics_total_export_revenue": {"name": "Bilanz seit Start – Einspeiseertrag"},
       "economics_total_avoided_grid_import_cost": {"name": "Bilanz seit Start – Vermiedene Netzbezugskosten"},
       "economics_total_battery_benefit": {"name": "Bilanz seit Start – Batterienutzen"},
+      "economics_total_economic_efficiency_pct": {"name": "Bilanz seit Start – Wirtschaftlicher Wirkungsgrad"},
       "economics_daily_grid_to_battery_kwh": {"name": "Energie heute – Netz zu Akku"},
       "economics_daily_pv_to_battery_kwh": {"name": "Energie heute – PV zu Akku"},
       "economics_daily_grid_export_kwh": {"name": "Energie heute – Netzeinspeisung"},

--- a/custom_components/battery_smartflow_ai/translations/de.json
+++ b/custom_components/battery_smartflow_ai/translations/de.json
@@ -327,10 +327,10 @@
         "name": "Gewinnmarge (%)"
       },
       "peak_factor": {
-        "name": "Peak-Faktor"
+        "name": "Peakpreis-Aufschlag"
       },
       "valley_factor": {
-        "name": "Tal-Faktor"
+        "name": "Talpreis-Abschlag"
       },
       "very_cheap_price": {
         "name": "Sehr-billig Schwelle"

--- a/custom_components/battery_smartflow_ai/translations/en.json
+++ b/custom_components/battery_smartflow_ai/translations/en.json
@@ -815,6 +815,7 @@
       "economics_total_export_revenue": {"name": "Balance since start – Export revenue"},
       "economics_total_avoided_grid_import_cost": {"name": "Balance since start – Avoided grid import cost"},
       "economics_total_battery_benefit": {"name": "Balance since start – Battery benefit"},
+      "economics_total_economic_efficiency_pct": {"name": "Balance since start – Economic efficiency"},
       "economics_daily_grid_to_battery_kwh": {"name": "Energy today – Grid to battery"},
       "economics_daily_pv_to_battery_kwh": {"name": "Energy today – PV to battery"},
       "economics_daily_grid_export_kwh": {"name": "Energy today – Grid export"},

--- a/custom_components/battery_smartflow_ai/translations/en.json
+++ b/custom_components/battery_smartflow_ai/translations/en.json
@@ -327,10 +327,10 @@
         "name": "Profit margin (%)"
       },
       "peak_factor": {
-        "name": "Peak factor"
+        "name": "Peak price markup"
       },
       "valley_factor": {
-        "name": "Valley factor"
+        "name": "Valley price discount"
       },
       "very_cheap_price": {
         "name": "Very-cheap threshold"

--- a/custom_components/battery_smartflow_ai/translations/fr.json
+++ b/custom_components/battery_smartflow_ai/translations/fr.json
@@ -815,6 +815,7 @@
       "economics_total_export_revenue": {"name": "Bilan depuis le début – Revenu d’injection"},
       "economics_total_avoided_grid_import_cost": {"name": "Bilan depuis le début – Coût d’import évité"},
       "economics_total_battery_benefit": {"name": "Bilan depuis le début – Bénéfice de la batterie"},
+      "economics_total_economic_efficiency_pct": {"name": "Bilan depuis le début – Rendement économique"},
       "economics_daily_grid_to_battery_kwh": {"name": "Énergie aujourd’hui – Réseau vers batterie"},
       "economics_daily_pv_to_battery_kwh": {"name": "Énergie aujourd’hui – PV vers batterie"},
       "economics_daily_grid_export_kwh": {"name": "Énergie aujourd’hui – Injection réseau"},

--- a/custom_components/battery_smartflow_ai/translations/fr.json
+++ b/custom_components/battery_smartflow_ai/translations/fr.json
@@ -327,10 +327,10 @@
         "name": "Marge bénéficiaire (%)"
       },
       "peak_factor": {
-        "name": "Facteur de pic"
+        "name": "Majoration du prix de pointe"
       },
       "valley_factor": {
-        "name": "Facteur de creux"
+        "name": "Réduction du prix bas"
       },
       "very_cheap_price": {
         "name": "Seuil très bon marché"

--- a/custom_components/battery_smartflow_ai/translations/nl.json
+++ b/custom_components/battery_smartflow_ai/translations/nl.json
@@ -815,6 +815,7 @@
       "economics_total_export_revenue": {"name": "Balans sinds start – Terugleveropbrengst"},
       "economics_total_avoided_grid_import_cost": {"name": "Balans sinds start – Vermeden netafnamekosten"},
       "economics_total_battery_benefit": {"name": "Balans sinds start – Batterijvoordeel"},
+      "economics_total_economic_efficiency_pct": {"name": "Balans sinds start – Economisch rendement"},
       "economics_daily_grid_to_battery_kwh": {"name": "Energie vandaag – Net naar batterij"},
       "economics_daily_pv_to_battery_kwh": {"name": "Energie vandaag – PV naar batterij"},
       "economics_daily_grid_export_kwh": {"name": "Energie vandaag – Teruglevering"},

--- a/custom_components/battery_smartflow_ai/translations/nl.json
+++ b/custom_components/battery_smartflow_ai/translations/nl.json
@@ -327,10 +327,10 @@
         "name": "Winstmarge (%)"
       },
       "peak_factor": {
-        "name": "Piekfactor"
+        "name": "Piekprijsopslag"
       },
       "valley_factor": {
-        "name": "Dalfactor"
+        "name": "Dalprijskorting"
       },
       "very_cheap_price": {
         "name": "Zeer-goedkoop-drempel"

--- a/docs/anleitung.md
+++ b/docs/anleitung.md
@@ -1421,6 +1421,34 @@ Energiezuwachs dauerhaft gewichtet.
 
 ---
 
+## Wirtschaftlicher Wirkungsgrad seit Start
+
+Dieser Sensor bewertet nicht den technischen Wirkungsgrad von Akku und
+Wechselrichter. Dafür bleibt der gerätenahe Sensor aus Zendure-HA zuständig.
+
+BSFAI vergleicht stattdessen den wirtschaftlichen Wert der seit Beginn
+abgegebenen Batterieenergie mit dem bewerteten Ladeaufwand:
+
+```text
+Wirtschaftlicher Wirkungsgrad =
+  Wert der Batterieentladung
+  ÷ (Netzladekosten + PV-Opportunitätskosten)
+  × 100
+```
+
+* unter 100 %: Der bewertete Ladeaufwand ist noch nicht vollständig gedeckt.
+* 100 %: Der bewertete Ladeaufwand ist genau gedeckt.
+* über 100 %: Die Batterie hat einen wirtschaftlichen Mehrwert erzielt.
+
+Der Sensor wird erst verfügbar, wenn seit Beginn mindestens 0,1 kWh Ladeenergie
+und 0,1 kWh Entladeenergie erfasst wurden. Ein nicht positiver Ladeaufwand, etwa
+bei ausschließlich kostenloser oder negativ vergüteter Ladeenergie, besitzt
+keinen endlichen Kostendeckungsgrad und wird daher nicht als erfundene
+Prozentzahl dargestellt. Der Wert „seit Start“ ist aussagekräftiger als ein
+Tageswert, weil Lade- und Entladevorgänge über Mitternacht reichen können.
+
+---
+
 ## Ø Tagespreis
 
 Der durchschnittliche Tagespreis wird aus den verfügbaren Preisprognosedaten berechnet.

--- a/docs/anleitung.md
+++ b/docs/anleitung.md
@@ -1006,13 +1006,14 @@ Die adaptive Peak-Erkennung erkennt teure Preisfenster.
 
 Dabei wird nicht nur ein fixer Preis betrachtet, sondern das Preisniveau des Tages.
 
-Der Peak-Faktor bestimmt, ab wann ein Preis als Peak gilt.
+Der Peakpreis-Aufschlag bestimmt, wie viel Prozent ein Preis über dem
+Tagesdurchschnitt liegen muss, damit er als Peak gilt.
 
 Formel:
 
 ```text
 Peak-Schwelle = max(
-  Durchschnittspreis × Peak-Faktor,
+  Durchschnittspreis × (1 + Peakpreis-Aufschlag / 100),
   Durchschnittspreis + 0,03 €
 )
 ```
@@ -1020,13 +1021,13 @@ Peak-Schwelle = max(
 Standardwert:
 
 ```text
-1.35
+35 %
 ```
 
-| Peak-Faktor | Wirkung                         |
-| ----------- | ------------------------------- |
-| niedriger   | erkennt mehr Peaks              |
-| höher       | erkennt nur starke Preisspitzen |
+| Peakpreis-Aufschlag | Wirkung                         |
+| ------------------- | ------------------------------- |
+| niedriger           | erkennt mehr Peaks              |
+| höher               | erkennt nur starke Preisspitzen |
 
 ---
 
@@ -1853,16 +1854,19 @@ SoC-Schwelle, ab der eine Notladung ausgelöst werden kann.
 
 ---
 
-## Peak-Faktor
+## Peakpreis-Aufschlag
 
-Bestimmt, wie empfindlich adaptive Preispeaks erkannt werden.
+Bestimmt in Prozent, wie weit ein Preis über dem Tagesniveau liegen muss, damit
+er als adaptiver Preispeak erkannt wird. Beispiel: Der bisherige Faktor 1,27
+wird in der Oberfläche als 27 % angezeigt.
 
 ---
 
-## Tal-Faktor
+## Talpreis-Abschlag
 
-Bestimmt, wie günstig ein Preis relativ zum Tagesniveau sein muss, damit er als
-Talpreis bewertet wird. Ein niedrigerer Wert verlangt ein deutlicheres Preistal.
+Bestimmt in Prozent, wie weit ein Preis unter dem Tagesniveau liegen muss, damit
+er als Talpreis bewertet wird. Ein höherer Abschlag verlangt ein deutlicheres
+Preistal. Beispiel: Der bisherige Faktor 0,85 wird als 15 % angezeigt.
 
 ---
 
@@ -2569,7 +2573,7 @@ Mögliche Ursachen:
 
 * keine Preisprognose vorhanden
 * aktueller Preis fehlt
-* Peak-Faktor zu hoch
+* Peakpreis-Aufschlag zu hoch
 * Tagespreise sind sehr gleichmäßig
 * Preis liegt nicht weit genug über dem Tagesdurchschnitt
 
@@ -2869,7 +2873,7 @@ Empfohlen:
 
 * Automatikmodus
 * Preisverlauf vollständig prüfen
-* Peak-Faktor passend wählen
+* Peakpreis-Aufschlag passend wählen
 * Gewinnmarge nicht zu niedrig setzen
 * sehr-billig-Schwelle nutzen
 * Lernplanung aktivieren

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1005,25 +1005,26 @@ Adaptive peak detection detects expensive price windows.
 
 Not only a fixed price is taken into account, but also the daily price level.
 
-The peak factor determines when a price is considered a peak.
+The peak price markup determines how many percent above the daily average a
+price must be before it is considered a peak.
 
 Formula:
 
 ```text
-Peak-Schwelle = max(
-  Durchschnittspreis × Peak-Faktor,
-  Durchschnittspreis + 0,03 €
+Peak threshold = max(
+  Average price × (1 + peak price markup / 100),
+  Average price + €0.03
 )
 ```
 
 Default value:
 
 ```text
-1.35
+35%
 ```
 
-| Peak factor | Effect |
-| ----------- | ------------------------------- |
+| Peak price markup | Effect |
+| ----------------- | ------------------------------- |
 | lower | detects more peaks |
 | higher | only detects strong price spikes |
 
@@ -1852,16 +1853,19 @@ SoC threshold above which emergency charging can be triggered.
 
 ---
 
-## Peak factor
+## Peak price markup
 
-Determines how sensitively adaptive price peaks are detected.
+Determines, as a percentage, how far a price must be above the daily level to
+be detected as an adaptive price peak. For example, the previous factor 1.27 is
+shown as 27% in the UI.
 
 ---
 
-## Valley factor
+## Valley price discount
 
-Determines how cheap a price must be relative to the daily level in order to be considered
-valley price is assessed. A lower value requires a more significant price valley.
+Determines, as a percentage, how far a price must be below the daily level to be
+considered a valley price. A higher discount requires a more significant price
+valley. For example, the previous factor 0.85 is shown as 15% in the UI.
 
 ---
 
@@ -2558,7 +2562,7 @@ Possible causes:
 
 * no price forecast available
 * current price is missing
-* Peak factor too high
+* Peak price markup too high
 * Daily prices are very consistent
 * Price is not far enough above the daily average
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1420,6 +1420,34 @@ Energy increase permanently weighted.
 
 ---
 
+## Economic efficiency since start
+
+This sensor does not measure the technical efficiency of the battery and
+inverter. The device-level Zendure-HA sensor remains responsible for that value.
+
+Instead, BSFAI compares the economic value of discharged battery energy since
+the start of accounting with the valued charging input:
+
+```text
+Economic efficiency =
+  Value of battery discharge
+  ÷ (grid charging cost + PV opportunity cost)
+  × 100
+```
+
+* below 100%: The valued charging input has not yet been fully recovered.
+* 100%: The valued charging input is exactly recovered.
+* above 100%: The battery has generated additional economic value.
+
+The sensor becomes available only after at least 0.1 kWh of both charging and
+discharging have been recorded since the start. A non-positive charging input,
+for example exclusively free or negatively priced charging energy, has no finite
+cost-recovery ratio and is therefore not represented by an invented percentage.
+The since-start value is more meaningful than a daily value because charging and
+discharging can span midnight.
+
+---
+
 ## Ø Daily price
 
 The average daily price is calculated from the available price forecast data.

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -13,7 +13,7 @@ COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
 
 
 class DebugIntegrationContractTests(unittest.TestCase):
-    def test_manifest_and_runtime_version_match_v460_beta5_release(self) -> None:
+    def test_manifest_and_runtime_version_match_v460_rc1_release(self) -> None:
         manifest_version = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )["version"]
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "4.6.0-Beta5")
+        self.assertEqual(manifest_version, "4.6.0-RC1")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_economic_efficiency.py
+++ b/tests/test_economic_efficiency.py
@@ -1,0 +1,54 @@
+"""Tests for the BSFAI economic efficiency sensor calculation."""
+
+from __future__ import annotations
+
+from support import bootstrap
+
+
+bootstrap()
+
+from custom_components.battery_smartflow_ai.economic_efficiency import (  # noqa: E402
+    economic_efficiency_pct,
+)
+
+
+def _efficiency(**overrides: float) -> float | None:
+    values = {
+        "grid_charge_cost": 1.0,
+        "pv_opportunity_cost": 0.0,
+        "battery_benefit": 0.0,
+        "charged_energy_kwh": 1.0,
+        "discharged_energy_kwh": 1.0,
+    }
+    values.update(overrides)
+    return economic_efficiency_pct(**values)
+
+
+def test_one_hundred_percent_means_cost_recovery() -> None:
+    assert _efficiency(battery_benefit=0.0) == 100.0
+
+
+def test_positive_battery_benefit_exceeds_one_hundred_percent() -> None:
+    assert _efficiency(battery_benefit=0.3) == 130.0
+
+
+def test_negative_battery_benefit_is_below_cost_recovery() -> None:
+    assert _efficiency(battery_benefit=-0.1) == 90.0
+
+
+def test_grid_and_pv_input_values_are_both_included() -> None:
+    assert _efficiency(
+        grid_charge_cost=0.6,
+        pv_opportunity_cost=0.4,
+        battery_benefit=0.25,
+    ) == 125.0
+
+
+def test_result_waits_for_meaningful_charge_and_discharge_energy() -> None:
+    assert _efficiency(charged_energy_kwh=0.09) is None
+    assert _efficiency(discharged_energy_kwh=0.09) is None
+
+
+def test_free_or_negative_input_value_has_no_finite_recovery_ratio() -> None:
+    assert _efficiency(grid_charge_cost=0.0, pv_opportunity_cost=0.0) is None
+    assert _efficiency(grid_charge_cost=-0.1, pv_opportunity_cost=0.0) is None

--- a/tests/test_economics.py
+++ b/tests/test_economics.py
@@ -325,6 +325,37 @@ def test_battery_values_use_separate_daily_midnight_energy() -> None:
     assert engine.total_snapshot().pv_opportunity_cost == pytest.approx(0.002)
 
 
+def test_total_economic_efficiency_uses_only_valued_energy_flows() -> None:
+    engine = EconomicsEngine(currency="EUR")
+    charge = EconomicEnergyFlows(grid_to_battery_kwh=1.0)
+    engine.record_grid_flows(
+        flows=charge,
+        import_price=_price(MarketPriceDirection.IMPORT, 0.20),
+        export_price=_price(MarketPriceDirection.EXPORT, 0.08),
+    )
+    engine.record_battery_value_flows(
+        flows=charge,
+        import_price=_price(MarketPriceDirection.IMPORT, 0.20),
+        export_price=_price(MarketPriceDirection.EXPORT, 0.08),
+    )
+
+    discharge = EconomicEnergyFlows(battery_to_home_kwh=1.0)
+    engine.record_grid_flows(
+        flows=discharge,
+        import_price=_price(MarketPriceDirection.IMPORT, 0.30),
+        export_price=_price(MarketPriceDirection.EXPORT, 0.08),
+    )
+    engine.record_battery_value_flows(
+        flows=discharge,
+        import_price=_price(MarketPriceDirection.IMPORT, 0.30),
+        export_price=_price(MarketPriceDirection.EXPORT, 0.08),
+    )
+
+    assert engine.total_economic_efficiency_pct() == 150.0
+    restored = EconomicsEngine.from_state(engine.to_state(), currency="EUR")
+    assert restored.total_economic_efficiency_pct() == 150.0
+
+
 def test_missing_import_price_skips_only_import_dependent_money_flows() -> None:
     missing_import = replace(
         _price(MarketPriceDirection.IMPORT, 0.30),

--- a/tests/test_economics_sensor_structure.py
+++ b/tests/test_economics_sensor_structure.py
@@ -31,6 +31,7 @@ PRICE_KEYS = {
     "economics_average_export_price",
     "economics_average_battery_discharge_value",
 }
+EFFICIENCY_KEYS = {"economics_total_economic_efficiency_pct"}
 MIGRATED_KEYS = {
     "price_daily_average",
     "current_peak_threshold",
@@ -72,9 +73,10 @@ def test_all_new_economics_sensors_use_the_virtual_device() -> None:
         *(f"economics_{period}_{value}" for period in ("daily", "total") for value in MONEY_VALUES),
         *(f"economics_{period}_{value}" for period in ("daily", "total") for value in ENERGY_VALUES),
         *PRICE_KEYS,
+        *EFFICIENCY_KEYS,
     }
 
-    assert len(expected) == 24
+    assert len(expected) == 25
     for key in expected:
         assert key in descriptions
         assert _source(descriptions[key]["economics_device"]) == "True"
@@ -107,6 +109,10 @@ def test_money_and_energy_statistics_use_safe_state_classes() -> None:
             "SensorDeviceClass.MONETARY"
         ):
             assert _source(item["state_class"]) == "SensorStateClass.TOTAL", key
+
+    efficiency = descriptions["economics_total_economic_efficiency_pct"]
+    assert _source(efficiency["native_unit_of_measurement"]) == repr("%")
+    assert _source(efficiency["state_class"]) == "SensorStateClass.MEASUREMENT"
 
 
 def test_translated_names_form_alphabetical_groups() -> None:

--- a/tests/test_factor_display.py
+++ b/tests/test_factor_display.py
@@ -1,0 +1,56 @@
+"""Tests for user-facing market factor percentages."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from support import bootstrap
+
+
+bootstrap()
+
+from custom_components.battery_smartflow_ai.factor_display import (  # noqa: E402
+    discount_pct_to_valley_factor,
+    markup_pct_to_peak_factor,
+    peak_factor_to_markup_pct,
+    valley_factor_to_discount_pct,
+)
+
+def test_existing_peak_factor_is_shown_as_markup_percent() -> None:
+    assert peak_factor_to_markup_pct(1.27) == 27.0
+
+
+def test_existing_valley_factor_is_shown_as_discount_percent() -> None:
+    assert valley_factor_to_discount_pct(0.85) == 15.0
+
+
+def test_peak_markup_percent_round_trips_to_internal_factor() -> None:
+    assert markup_pct_to_peak_factor(27.0) == 1.27
+    assert peak_factor_to_markup_pct(markup_pct_to_peak_factor(27.0)) == 27.0
+
+
+def test_valley_discount_percent_round_trips_to_internal_factor() -> None:
+    assert discount_pct_to_valley_factor(15.0) == 0.85
+    assert valley_factor_to_discount_pct(discount_pct_to_valley_factor(15.0)) == 15.0
+
+
+def test_default_factors_have_clear_percentage_values() -> None:
+    assert peak_factor_to_markup_pct(1.35) == 35.0
+    assert valley_factor_to_discount_pct(0.85) == 15.0
+
+
+def test_factor_number_entities_use_user_facing_percentages() -> None:
+    source = (
+        Path(__file__).resolve().parents[1]
+        / "custom_components"
+        / "battery_smartflow_ai"
+        / "number.py"
+    ).read_text(encoding="utf-8")
+
+    assert 'factor_percentage_kind="peak_markup"' in source
+    assert 'factor_percentage_kind="valley_discount"' in source
+    assert source.count('native_unit_of_measurement="%"') >= 6
+    assert "peak_factor_to_markup_pct(value)" in source
+    assert "valley_factor_to_discount_pct(value)" in source
+    assert "markup_pct_to_peak_factor(value)" in source
+    assert "discount_pct_to_valley_factor(value)" in source

--- a/tests/test_maintenance_431.py
+++ b/tests/test_maintenance_431.py
@@ -988,6 +988,63 @@ class Maintenance431Tests(unittest.TestCase):
         self.assertEqual(input_command.input_limit_w, 1300.0)
         self.assertEqual(output_command.output_limit_w, 1300.0)
 
+    def test_idle_stops_live_output_when_internal_cache_is_already_zero(self) -> None:
+        command = DeviceCommandBuilder().build(
+            intent=StrategyIntent(
+                intent="idle",
+                requested_mode="idle",
+                requested_power_w=0.0,
+                reason="learned_charge_window_wait",
+            ),
+            arbiter=ModeArbiterResult(
+                requested_mode="idle",
+                resolved_mode="idle",
+                allowed=True,
+                reason="learned_charge_window_wait",
+            ),
+            power=PowerControllerResult(
+                final_power_w=0.0,
+                reason="idle_zero_power",
+            ),
+            current_ac_mode="output",
+            last_input_limit_w=0.0,
+            last_output_limit_w=0.0,
+            current_output_limit_w=667.0,
+        )
+
+        self.assertTrue(command.should_write_output)
+        self.assertFalse(command.skipped)
+        self.assertEqual(command.output_limit_w, 0.0)
+        self.assertEqual(command.metadata["current_output_limit_w"], 667.0)
+
+    def test_idle_does_not_repeat_zero_when_live_output_is_already_zero(self) -> None:
+        command = DeviceCommandBuilder().build(
+            intent=StrategyIntent(
+                intent="idle",
+                requested_mode="idle",
+                requested_power_w=0.0,
+                reason="learned_charge_window_wait",
+            ),
+            arbiter=ModeArbiterResult(
+                requested_mode="idle",
+                resolved_mode="idle",
+                allowed=True,
+                reason="learned_charge_window_wait",
+            ),
+            power=PowerControllerResult(
+                final_power_w=0.0,
+                reason="idle_zero_power",
+            ),
+            current_ac_mode="output",
+            last_input_limit_w=0.0,
+            last_output_limit_w=0.0,
+            current_output_limit_w=0.0,
+        )
+
+        self.assertFalse(command.should_write_output)
+        self.assertTrue(command.skipped)
+        self.assertEqual(command.skip_reason, "unchanged_within_tolerance")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Inhalt

Dieser Release Candidate bündelt die nach Beta5 vorbereiteten Änderungen:

### Automatischer Nullleistungs-Stopp

- behebt den neuen Folgefall aus dem geschlossenen Issue #254
- eine korrekte automatische Leerlaufentscheidung sendet jetzt 0 W, wenn die reale Zendure-Ausgangsbegrenzung noch aktiv ist, obwohl der interne Cache bereits 0 W enthält
- ein real bereits gestopptes Gerät erhält keine unnötigen Wiederholungsbefehle

### Anwenderfreundliche Marktpreisregler

- Peak-Faktor wird als **Peakpreis-Aufschlag in Prozent** angezeigt
- Tal-Faktor wird als **Talpreis-Abschlag in Prozent** angezeigt
- vorhandene Werte bleiben intern vollständig kompatibel: `1,27` wird zu `27 %`, `0,85` zu `15 %`
- Oberfläche und Dokumentation sind in Deutsch, Englisch, Französisch und Niederländisch angepasst

### Wirtschaftlicher Wirkungsgrad

- neuer Sensor **Bilanz seit Start – Wirtschaftlicher Wirkungsgrad** auf dem virtuellen Gerät Wirtschaft & Preise
- 100 % bedeutet wirtschaftliche Kostendeckung, Werte darüber zeigen zusätzlichen wirtschaftlichen Mehrwert
- getrennt vom technischen Zendure-HA-Wirkungsgrad
- erst ab jeweils 0,1 kWh wirtschaftlich bewerteter Lade- und Entladeenergie verfügbar
- basiert auf der persistierten V4.6-Wirtschaftsbilanz und bleibt über Neustarts erhalten

### Release

- Laufzeit- und Manifestversion auf `4.6.0-RC1` erhöht
- weiterhin als Pre-Release vorgesehen

## Validierung

- 312 Tests bestanden
- 326 Untertests bestanden
- gezielte Regressionen für den realen 667-W-Folgefall
- Umrechnung und Rückumrechnung der Prozentregler geprüft
- wirtschaftlicher Wirkungsgrad unter, bei und über Kostendeckung geprüft
- Persistenz, Übersetzungen, Sensorstruktur, Syntax und Diff geprüft

Addresses the follow-up reported in #254 without reopening or changing the already confirmed manual-standby fix.