### PR TITLE
Release 4.6.0-RC2

### DIFF
--- a/custom_components/battery_smartflow_ai/ai_status.py
+++ b/custom_components/battery_smartflow_ai/ai_status.py
@@ -1,0 +1,45 @@
+"""Pure mapping from strategy decisions to the visible AI status."""
+
+from __future__ import annotations
+
+from .const import (
+    AI_MODE_MANUAL,
+    AI_STATUS_CHARGE_SURPLUS,
+    AI_STATUS_COVER_DEFICIT,
+    AI_STATUS_EMERGENCY_CHARGE,
+    AI_STATUS_EXPENSIVE_DISCHARGE,
+    AI_STATUS_MANUAL,
+    AI_STATUS_PRICE_CHARGE,
+    AI_STATUS_STANDBY,
+    AI_STATUS_VERY_EXPENSIVE_FORCE,
+)
+
+
+def map_ai_status(ai_mode: str, action: str, reason: str) -> str:
+    """Return the translated status key for one strategy decision."""
+
+    if ai_mode == AI_MODE_MANUAL:
+        return AI_STATUS_MANUAL
+    if action == "passthrough" or reason == "pv_house_load_passthrough":
+        return AI_STATUS_STANDBY
+    if action == "emergency":
+        return AI_STATUS_EMERGENCY_CHARGE
+    if action == "charge":
+        if reason == "pv_surplus_charge":
+            return AI_STATUS_CHARGE_SURPLUS
+        if (
+            "valley" in reason
+            or "planning" in reason
+            or "price" in reason
+            or reason.startswith("learned_charge_window_")
+            or reason == "summer_peak_reserve_charge"
+        ):
+            return AI_STATUS_PRICE_CHARGE
+        return AI_STATUS_CHARGE_SURPLUS
+    if action == "discharge":
+        if "very_expensive" in reason or "adaptive_peak" in reason:
+            return AI_STATUS_VERY_EXPENSIVE_FORCE
+        if "price" in reason:
+            return AI_STATUS_EXPENSIVE_DISCHARGE
+        return AI_STATUS_COVER_DEFICIT
+    return AI_STATUS_STANDBY

--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -25,7 +25,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "4.6.0-RC1"
+INTEGRATION_VERSION = "4.6.0-RC2"
 
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,

--- a/custom_components/battery_smartflow_ai/coordinator.py
+++ b/custom_components/battery_smartflow_ai/coordinator.py
@@ -12,6 +12,7 @@ from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
 
+from .ai_status import map_ai_status
 from .const import (
     DOMAIN,
     UPDATE_INTERVAL,
@@ -98,14 +99,6 @@ from .const import (
     # statuses
     STATUS_OK,
     STATUS_SENSOR_INVALID,
-    AI_STATUS_STANDBY,
-    AI_STATUS_CHARGE_SURPLUS,
-    AI_STATUS_PRICE_CHARGE,
-    AI_STATUS_COVER_DEFICIT,
-    AI_STATUS_EXPENSIVE_DISCHARGE,
-    AI_STATUS_VERY_EXPENSIVE_FORCE,
-    AI_STATUS_EMERGENCY_CHARGE,
-    AI_STATUS_MANUAL,
     RECO_STANDBY,
     RECO_CHARGE,
     RECO_DISCHARGE,
@@ -3556,30 +3549,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         return season
 
     def _map_ai_status(self, ai_mode: str, action: str, reason: str) -> str:
-        if ai_mode == AI_MODE_MANUAL:
-            return AI_STATUS_MANUAL
-        if action == "passthrough" or reason == "pv_house_load_passthrough":
-            return AI_STATUS_STANDBY
-        if action == "emergency":
-            return AI_STATUS_EMERGENCY_CHARGE
-        if action == "charge":
-            if reason == "pv_surplus_charge":
-                return AI_STATUS_CHARGE_SURPLUS
-            if (
-                "valley" in reason
-                or "planning" in reason
-                or "price" in reason
-                or reason == "summer_peak_reserve_charge"
-            ):
-                return AI_STATUS_PRICE_CHARGE
-            return AI_STATUS_CHARGE_SURPLUS
-        if action == "discharge":
-            if "very_expensive" in reason or "adaptive_peak" in reason:
-                return AI_STATUS_VERY_EXPENSIVE_FORCE
-            if "price" in reason:
-                return AI_STATUS_EXPENSIVE_DISCHARGE
-            return AI_STATUS_COVER_DEFICIT
-        return AI_STATUS_STANDBY
+        return map_ai_status(ai_mode, action, reason)
 
     def _map_reco(self, action: str) -> str:
         if action == "passthrough":

--- a/custom_components/battery_smartflow_ai/learned_planning.py
+++ b/custom_components/battery_smartflow_ai/learned_planning.py
@@ -885,10 +885,7 @@ def optimize_charge_window(
 
     weights = _triangle_weights(window_slots)
 
-    best_start: datetime | None = None
-    best_end: datetime | None = None
-    best_score: float | None = None
-    best_prices: list[float] = []
+    candidates: list[tuple[float, datetime, datetime, list[float]]] = []
 
     for idx in range(0, len(future) - window_slots + 1):
         window = future[idx: idx + window_slots]
@@ -908,20 +905,9 @@ def optimize_charge_window(
         prices = [float(p.price) for p in window]
         score = sum(price * weight for price, weight in zip(prices, weights))
 
-        if best_score is None or score < best_score:
-            best_score = score
-            best_start = start
-            best_end = end
-            best_prices = prices
-        elif best_score is not None and math.isclose(score, best_score, rel_tol=0.0, abs_tol=0.000001):
-            # Tie breaker: later start wins.
-            if best_start is None or start > best_start:
-                best_score = score
-                best_start = start
-                best_end = end
-                best_prices = prices
+        candidates.append((score, start, end, prices))
 
-    if best_start is None or best_end is None:
+    if not candidates:
         return (
             now_local,
             now_local + timedelta(minutes=window_slots * SLOT_MINUTES),
@@ -930,6 +916,36 @@ def optimize_charge_window(
             [],
             LEARNED_REASON_DEADLINE_TOO_CLOSE_START_NOW,
         )
+
+    best_score = min(candidate[0] for candidate in candidates)
+    cheapest = [
+        candidate
+        for candidate in candidates
+        if math.isclose(
+            candidate[0],
+            best_score,
+            rel_tol=0.0,
+            abs_tol=0.000001,
+        )
+    ]
+
+    # Equal-cost windows used to be pushed as close to the deadline as possible.
+    # Keep a safety reserve after charging instead: aim up to one hour before the
+    # latest equal-cost start, without moving farther than the midpoint of the
+    # available tie range. This remains stable while waiting and still gives every
+    # real price difference priority over timing comfort.
+    earliest_start = min(candidate[1] for candidate in cheapest)
+    latest_start = max(candidate[1] for candidate in cheapest)
+    tied_span = latest_start - earliest_start
+    end_reserve = min(timedelta(hours=1), tied_span / 2)
+    preferred_start = latest_start - end_reserve
+    _, best_start, best_end, best_prices = min(
+        cheapest,
+        key=lambda candidate: (
+            abs((candidate[1] - preferred_start).total_seconds()),
+            candidate[1],
+        ),
+    )
 
     return best_start, best_end, best_score, weights, best_prices, None
 

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": [],
-  "version": "4.6.0-RC1"
+  "version": "4.6.0-RC2"
 }

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -13,7 +13,7 @@ COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
 
 
 class DebugIntegrationContractTests(unittest.TestCase):
-    def test_manifest_and_runtime_version_match_v460_rc1_release(self) -> None:
+    def test_manifest_and_runtime_version_match_v460_rc2_release(self) -> None:
         manifest_version = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )["version"]
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "4.6.0-RC1")
+        self.assertEqual(manifest_version, "4.6.0-RC2")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_rc2_charge_window_regressions.py
+++ b/tests/test_rc2_charge_window_regressions.py
@@ -1,0 +1,83 @@
+"""RC2 regressions for learned AC charge planning and status display."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import unittest
+
+from support import bootstrap
+
+
+bootstrap()
+
+from custom_components.battery_smartflow_ai.const import (  # noqa: E402
+    AI_MODE_AUTOMATIC,
+    AI_STATUS_PRICE_CHARGE,
+)
+from custom_components.battery_smartflow_ai.ai_status import (  # noqa: E402
+    map_ai_status,
+)
+from custom_components.battery_smartflow_ai.learned_planning import (  # noqa: E402
+    optimize_charge_window,
+)
+from custom_components.battery_smartflow_ai.market_price import (  # noqa: E402
+    MarketPricePoint,
+)
+
+
+class Rc2ChargeWindowRegressionTests(unittest.TestCase):
+    def test_equal_price_overnight_window_keeps_end_reserve(self) -> None:
+        start = datetime(2026, 8, 23, 23, 0, tzinfo=timezone.utc)
+        deadline = start + timedelta(hours=7)
+        points = [
+            MarketPricePoint(
+                start=start + timedelta(minutes=15 * index),
+                end=start + timedelta(minutes=15 * (index + 1)),
+                price=0.10,
+            )
+            for index in range(28)
+        ]
+
+        selected_start, selected_end, *_ = optimize_charge_window(
+            now=start,
+            deadline=deadline,
+            price_points=points,
+            window_slots=20,
+        )
+
+        self.assertEqual(selected_start, start + timedelta(hours=1))
+        self.assertEqual(selected_end, deadline - timedelta(hours=1))
+
+    def test_lower_price_still_beats_timing_reserve(self) -> None:
+        start = datetime(2026, 8, 23, 23, 0, tzinfo=timezone.utc)
+        points = [
+            MarketPricePoint(
+                start=start + timedelta(minutes=15 * index),
+                end=start + timedelta(minutes=15 * (index + 1)),
+                price=0.20 if index < 4 else 0.10,
+            )
+            for index in range(12)
+        ]
+
+        selected_start, selected_end, *_ = optimize_charge_window(
+            now=start,
+            deadline=start + timedelta(hours=3),
+            price_points=points,
+            window_slots=8,
+        )
+
+        self.assertEqual(selected_start, start + timedelta(hours=1))
+        self.assertEqual(selected_end, start + timedelta(hours=3))
+
+    def test_learned_ac_charge_is_shown_as_price_charge(self) -> None:
+        status = map_ai_status(
+            AI_MODE_AUTOMATIC,
+            "charge",
+            "learned_charge_window_active",
+        )
+
+        self.assertEqual(status, AI_STATUS_PRICE_CHARGE)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Zusammenfassung

- verteilt bei gleich teuren gelernten AC-Ladefenstern automatisch Zeitreserve vor dem Planungsende, statt immer das späteste Fenster zu wählen
- zeigt gelerntes AC-Laden als preisgesteuertes Laden statt fälschlich als PV-Überschuss an
- hebt die Integration auf `4.6.0-RC2` an

Bezug: Discussion #123

## Validierung

- `315 passed, 326 subtests passed`
- neue Regressionstests für gleich teure Nachtfenster, echten Preisvorrang und die AI-Statusanzeige