### PR TITLE
Release 4.6.0-RC3

### DIFF
--- a/custom_components/battery_smartflow_ai/ai_status.py
+++ b/custom_components/battery_smartflow_ai/ai_status.py
@@ -15,31 +15,47 @@ from .const import (
 )
 
 
-def map_ai_status(ai_mode: str, action: str, reason: str) -> str:
+def map_ai_status(
+    ai_mode: str,
+    action: str,
+    reason: str,
+    *,
+    source_reason: str | None = None,
+) -> str:
     """Return the translated status key for one strategy decision."""
+
+    effective_reason = str(reason or "")
+    if effective_reason == "charge_commit_active" and source_reason:
+        effective_reason = str(source_reason)
 
     if ai_mode == AI_MODE_MANUAL:
         return AI_STATUS_MANUAL
-    if action == "passthrough" or reason == "pv_house_load_passthrough":
+    if (
+        action == "passthrough"
+        or effective_reason == "pv_house_load_passthrough"
+    ):
         return AI_STATUS_STANDBY
     if action == "emergency":
         return AI_STATUS_EMERGENCY_CHARGE
     if action == "charge":
-        if reason == "pv_surplus_charge":
+        if effective_reason == "pv_surplus_charge":
             return AI_STATUS_CHARGE_SURPLUS
         if (
-            "valley" in reason
-            or "planning" in reason
-            or "price" in reason
-            or reason.startswith("learned_charge_window_")
-            or reason == "summer_peak_reserve_charge"
+            "valley" in effective_reason
+            or "planning" in effective_reason
+            or "price" in effective_reason
+            or effective_reason.startswith("learned_charge_window_")
+            or effective_reason == "summer_peak_reserve_charge"
         ):
             return AI_STATUS_PRICE_CHARGE
         return AI_STATUS_CHARGE_SURPLUS
     if action == "discharge":
-        if "very_expensive" in reason or "adaptive_peak" in reason:
+        if (
+            "very_expensive" in effective_reason
+            or "adaptive_peak" in effective_reason
+        ):
             return AI_STATUS_VERY_EXPENSIVE_FORCE
-        if "price" in reason:
+        if "price" in effective_reason:
             return AI_STATUS_EXPENSIVE_DISCHARGE
         return AI_STATUS_COVER_DEFICIT
     return AI_STATUS_STANDBY

--- a/custom_components/battery_smartflow_ai/charge_commit_policy.py
+++ b/custom_components/battery_smartflow_ai/charge_commit_policy.py
@@ -59,16 +59,34 @@ def learned_plan_charge_need_satisfied(
 def learned_plan_may_complete_active_commit(
     *, commit: ChargeCommitState, learned_charge_plan: Any | None,
 ) -> bool:
-    """Keep a targeted active binding independent of falling live demand."""
+    """Complete a forced learned binding once its live energy need is gone.
+
+    Before the latest start, a targeted binding remains a stable snapshot and
+    ignores a temporarily falling live need. Once it is forced, however, a
+    current zero-energy plan proves that the deadline is already covered. The
+    stale target must then not keep buying grid energy until the deadline.
+    """
     if (
         bool(commit.active)
         and str(commit.commit_type or "") == "learned"
         and commit.target_soc is not None
+        and str(commit.phase or "") != "forced"
     ):
         return False
     return learned_plan_charge_need_satisfied(
         commit_type=str(commit.commit_type or ""),
         learned_charge_plan=learned_charge_plan,
+    )
+
+
+def preserved_learned_commit_power(
+    *, requested_power_w: float, max_charge_w: float,
+) -> float:
+    """Clamp, but never replan, the power of an active learned binding."""
+
+    return max(
+        0.0,
+        min(float(requested_power_w or 0.0), float(max_charge_w or 0.0)),
     )
 
 

--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -25,7 +25,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "4.6.0-RC2"
+INTEGRATION_VERSION = "4.6.0-RC3"
 
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,

--- a/custom_components/battery_smartflow_ai/coordinator.py
+++ b/custom_components/battery_smartflow_ai/coordinator.py
@@ -134,6 +134,7 @@ from .charge_commit_policy import (
     learned_commit_price_phase,
     learned_commit_should_yield_to_discharge,
     learned_plan_may_complete_active_commit,
+    preserved_learned_commit_power,
 )
 from .battery_protection import (
     cell_voltage_emergency_minimum_elapsed,
@@ -1465,26 +1466,15 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         commit=commit,
                     )
 
-                # Dev9.1: A binding restored from Dev9 may still contain the
-                # self-limited learned value (for example 1161 W). Refresh an
-                # active/forced learned binding directly from the newly
-                # calculated energy/window request, even when the base decision
-                # temporarily exposes another reason.
-                replanned_power_w = _to_float(
-                    getattr(
-                        learned_charge_plan,
-                        "requested_charge_power_w",
-                        None,
-                    ),
-                    None,
+                # The target, timing and power form one planning snapshot. A
+                # shrinking live need must not taper the stored 800 W request to
+                # the planner's 100 W minimum while the old target SoC remains.
+                commit.requested_power_w = preserved_learned_commit_power(
+                    requested_power_w=float(commit.requested_power_w or 0.0),
+                    max_charge_w=float(max_charge_w),
                 )
-                if replanned_power_w is not None and replanned_power_w > 0.0:
-                    commit.requested_power_w = min(
-                        float(replanned_power_w),
-                        float(max_charge_w),
-                    )
-                    commit.updated_at = now_utc
-                    self._store_charge_commit(commit)
+                commit.updated_at = now_utc
+                self._store_charge_commit(commit)
 
             # If the same charge reason is still present, refresh power and
             # price-window timeout for optional price commits.
@@ -3549,7 +3539,17 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         return season
 
     def _map_ai_status(self, ai_mode: str, action: str, reason: str) -> str:
-        return map_ai_status(ai_mode, action, reason)
+        source_reason = None
+        if reason == "charge_commit_active":
+            source_reason = str(
+                self._persist.get("charge_commit_source_reason", "") or ""
+            )
+        return map_ai_status(
+            ai_mode,
+            action,
+            reason,
+            source_reason=source_reason,
+        )
 
     def _map_reco(self, action: str) -> str:
         if action == "passthrough":

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": [],
-  "version": "4.6.0-RC2"
+  "version": "4.6.0-RC3"
 }

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -13,7 +13,7 @@ COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
 
 
 class DebugIntegrationContractTests(unittest.TestCase):
-    def test_manifest_and_runtime_version_match_v460_rc2_release(self) -> None:
+    def test_manifest_and_runtime_version_match_v460_rc3_release(self) -> None:
         manifest_version = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )["version"]
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "4.6.0-RC2")
+        self.assertEqual(manifest_version, "4.6.0-RC3")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_maintenance_431.py
+++ b/tests/test_maintenance_431.py
@@ -28,6 +28,7 @@ from custom_components.battery_smartflow_ai.charge_commit_policy import (  # noq
     learned_commit_should_yield_to_discharge,
     learned_plan_may_complete_active_commit,
     learned_plan_charge_need_satisfied,
+    preserved_learned_commit_power,
 )
 from custom_components.battery_smartflow_ai.decision_engine import (  # noqa: E402
     advance_pv_charge_hysteresis,
@@ -177,6 +178,43 @@ class Maintenance431Tests(unittest.TestCase):
                 commit=commit,
                 learned_charge_plan=plan,
             )
+        )
+
+    def test_forced_targeted_binding_stops_when_live_need_is_zero(self) -> None:
+        plan = SimpleNamespace(
+            status="ready",
+            decision_reason="learned_charge_window_no_charge_needed",
+            required_charge_energy_kwh=0.0,
+        )
+        commit = ChargeCommitState(
+            active=True,
+            phase="forced",
+            commit_type="learned",
+            target_soc=98.0,
+            requested_power_w=100.0,
+        )
+
+        self.assertTrue(
+            learned_plan_may_complete_active_commit(
+                commit=commit,
+                learned_charge_plan=plan,
+            )
+        )
+
+    def test_active_binding_keeps_snapshot_power_when_live_need_shrinks(self) -> None:
+        self.assertEqual(
+            preserved_learned_commit_power(
+                requested_power_w=800.0,
+                max_charge_w=800.0,
+            ),
+            800.0,
+        )
+        self.assertEqual(
+            preserved_learned_commit_power(
+                requested_power_w=800.0,
+                max_charge_w=600.0,
+            ),
+            600.0,
         )
 
     def test_active_learned_binding_ignores_later_price_increase(self) -> None:

--- a/tests/test_rc2_charge_window_regressions.py
+++ b/tests/test_rc2_charge_window_regressions.py
@@ -78,6 +78,16 @@ class Rc2ChargeWindowRegressionTests(unittest.TestCase):
 
         self.assertEqual(status, AI_STATUS_PRICE_CHARGE)
 
+    def test_bound_learned_charge_uses_original_reason_for_status(self) -> None:
+        status = map_ai_status(
+            AI_MODE_AUTOMATIC,
+            "charge",
+            "charge_commit_active",
+            source_reason="learned_charge_window_active",
+        )
+
+        self.assertEqual(status, AI_STATUS_PRICE_CHARGE)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Zusammenfassung

Behebt die durch Beats RC2-Diagnoseaufzeichnungen in Discussion #123 bestätigten Probleme eines aktiven lernbasierten AC-Ladeauftrags:

- bewahrt die ursprüngliche Ladeleistung des gebundenen Plans, statt sie durch sinkenden Live-Restbedarf bis auf 100 W herunterzuregeln
- beendet einen bereits erzwungenen Lernauftrag, sobald die aktuelle Planung eindeutig 0 kWh Restladebedarf meldet
- löst `charge_commit_active` für die sichtbare AI-Statusanzeige auf den ursprünglichen Ladegrund auf
- hebt die Integration auf `4.6.0-RC3` an

## Validierung

- `318 passed, 326 subtests passed`
- Regression: 800-W-Snapshot bleibt 800 W und respektiert spätere Benutzerbegrenzungen
- Regression: erzwungener Zielauftrag endet bei 0 kWh Live-Restbedarf
- Regression: gebundener Lernauftrag erscheint als preisgesteuertes Laden

Bezug: https://github.com/PalmManiac/battery-smartflow-ai/discussions/123#discussioncomment-18131181