### PR TITLE
Release 4.6.0-RC4

### DIFF
--- a/custom_components/battery_smartflow_ai/automatic_strategy.py
+++ b/custom_components/battery_smartflow_ai/automatic_strategy.py
@@ -10,6 +10,40 @@ def _clamp01(value: float) -> float:
     return max(0.0, min(1.0, float(value)))
 
 
+def forecast_supports_early_pv_passthrough(
+    *,
+    forecast_status: str,
+    pv_outlook: str,
+    remaining_today_kwh: float,
+    battery_capacity_kwh: float,
+    soc: float,
+    soc_max: float,
+) -> bool:
+    """Return whether forecast PV exceeds the battery's remaining headroom."""
+
+    if str(forecast_status or "").strip().lower() != "available":
+        return False
+    if str(pv_outlook or "").strip().lower() not in {
+        "good",
+        "high",
+        "very_good",
+        "excellent",
+        "gut",
+    }:
+        return False
+
+    capacity = max(0.0, float(battery_capacity_kwh or 0.0))
+    if capacity <= 0.0:
+        return False
+
+    free_capacity_kwh = capacity * max(
+        0.0,
+        float(soc_max) - float(soc),
+    ) / 100.0
+
+    return float(remaining_today_kwh or 0.0) > free_capacity_kwh + 0.25
+
+
 class AutomaticStrategy:
     """Build the high-level context for the unified automatic strategy.
 
@@ -279,6 +313,7 @@ class AutomaticStrategy:
         reserve_reason: str,
         pv_weight: float,
         pv_reason: str,
+        grid_import_w: float,
     ) -> tuple[bool, str]:
         """Return whether Automatic may consider economic discharge.
 
@@ -296,6 +331,7 @@ class AutomaticStrategy:
         if (
             pv_reason == "pv_covers_house_load"
             and float(pv_weight) >= 0.85
+            and float(grid_import_w or 0.0) <= 120.0
         ):
             return False, "pv_covers_load_blocks_discharge"
 
@@ -553,6 +589,7 @@ class AutomaticStrategy:
         pv_outlook: str = "unknown",
         forecast_remaining_today_kwh: float = 0.0,
         forecast_tomorrow_kwh: float = 0.0,
+        grid_import_w: float = 0.0,
         metadata: dict[str, Any] | None = None,
     ) -> StrategyContext:
         """Return the current automatic-strategy context."""
@@ -639,6 +676,7 @@ class AutomaticStrategy:
             reserve_reason=reserve_reason,
             pv_weight=pv_weight,
             pv_reason=pv_reason,
+            grid_import_w=float(grid_import_w or 0.0),
         )
         (
             automatic_peak_reserve_allowed,

--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -25,7 +25,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "4.6.0-RC3"
+INTEGRATION_VERSION = "4.6.0-RC4"
 
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,

--- a/custom_components/battery_smartflow_ai/coordinator.py
+++ b/custom_components/battery_smartflow_ai/coordinator.py
@@ -155,7 +155,10 @@ from .economics import (
     EnergyAccumulator,
     priceable_energy_flows,
 )
-from .automatic_strategy import AutomaticStrategy
+from .automatic_strategy import (
+    AutomaticStrategy,
+    forecast_supports_early_pv_passthrough,
+)
 from .strategy_adapter import decision_to_strategy_intent
 from .strategy_state import ChargeCommitState
 from .mode_arbiter import ModeArbiter, build_mode_arbiter_config
@@ -3028,6 +3031,10 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         cell_voltage_emergency_active: bool,
         additional_battery_charge_w: float,
         pv_charge_latched: bool,
+        forecast_status: str,
+        pv_outlook: str,
+        forecast_remaining_today_kwh: float,
+        battery_capacity_kwh: float,
     ) -> tuple[bool, float, str]:
         enabled = bool(profile.get("PV_HOUSELOAD_PASSTHROUGH", False))
 
@@ -3141,6 +3148,14 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             battery_near_full = bool(
                 float(soc) >= full_soc_release_threshold
             )
+            forecast_surplus_expected = forecast_supports_early_pv_passthrough(
+                forecast_status=str(forecast_status),
+                pv_outlook=str(pv_outlook),
+                remaining_today_kwh=float(forecast_remaining_today_kwh or 0.0),
+                battery_capacity_kwh=float(battery_capacity_kwh or 0.0),
+                soc=float(soc),
+                soc_max=float(soc_max),
+            )
             forced = bool(
                 mppt_clips_without_output
                 and daylight_available
@@ -3206,7 +3221,11 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 )
                 stop_reason = "full_battery_pv_passthrough"
 
-            elif mppt_clips_without_output and not battery_near_full:
+            elif (
+                mppt_clips_without_output
+                and not battery_near_full
+                and not forecast_surplus_expected
+            ):
                 active = False
                 export_counter = 0
                 target_w = 0.0
@@ -3254,7 +3273,10 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     and enough_house_load
                     and useful_target
                     and export_val < float(pv_charge_start_export_w or 0.0)
-                    and import_val <= max(250.0, house_val * 0.50)
+                    and (
+                        forecast_surplus_expected
+                        or import_val <= max(250.0, house_val * 0.50)
+                    )
                 ):
                     active = True
                     self._persist["pv_houseload_passthrough_started_ts"] = (
@@ -4117,6 +4139,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 forecast_tomorrow_kwh=float(
                     forecast_summary.tomorrow_kwh
                 ),
+                grid_import_w=float(grid_import or 0.0),
                 metadata={
                     "legacy_season_mode": str(season),
                     "grid_import_w": round(
@@ -4226,6 +4249,12 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         cell_voltage_emergency_active=bool(cell_voltage_emergency_active),
                         additional_battery_charge_w=float(additional_battery_charge_w or 0.0),
                         pv_charge_latched=bool(pv_charge_latched),
+                        forecast_status=str(forecast_summary.status),
+                        pv_outlook=str(forecast_summary.pv_outlook),
+                        forecast_remaining_today_kwh=float(
+                            forecast_summary.remaining_today_kwh
+                        ),
+                        battery_capacity_kwh=float(battery_capacity_kwh),
                     )
                 )
 

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": [],
-  "version": "4.6.0-RC3"
+  "version": "4.6.0-RC4"
 }

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -13,7 +13,7 @@ COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
 
 
 class DebugIntegrationContractTests(unittest.TestCase):
-    def test_manifest_and_runtime_version_match_v460_rc3_release(self) -> None:
+    def test_manifest_and_runtime_version_match_v460_rc4_release(self) -> None:
         manifest_version = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )["version"]
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "4.6.0-RC3")
+        self.assertEqual(manifest_version, "4.6.0-RC4")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_rc4_pv_grid_regressions.py
+++ b/tests/test_rc4_pv_grid_regressions.py
@@ -1,0 +1,73 @@
+"""RC4 regressions from the SF800Pro trace in Discussion #123."""
+
+from __future__ import annotations
+
+import unittest
+
+from support import bootstrap
+
+
+bootstrap()
+
+from custom_components.battery_smartflow_ai.automatic_strategy import (  # noqa: E402
+    AutomaticStrategy,
+    forecast_supports_early_pv_passthrough,
+)
+
+
+class Rc4PvGridRegressionTests(unittest.TestCase):
+    def test_real_grid_import_overrides_dc_pv_cover_assumption(self) -> None:
+        allowed, reason = AutomaticStrategy()._automatic_discharge_permission(
+            price_weight=1.0,
+            price_reason="very_expensive_price_range",
+            reserve_weight=0.4,
+            reserve_reason="reserve_normal",
+            pv_weight=0.95,
+            pv_reason="pv_covers_house_load",
+            grid_import_w=842.0,
+        )
+
+        self.assertTrue(allowed)
+        self.assertEqual(reason, "economic_discharge_context_allowed")
+
+    def test_small_grid_import_still_allows_pv_discharge_block(self) -> None:
+        allowed, reason = AutomaticStrategy()._automatic_discharge_permission(
+            price_weight=1.0,
+            price_reason="very_expensive_price_range",
+            reserve_weight=0.4,
+            reserve_reason="reserve_normal",
+            pv_weight=0.95,
+            pv_reason="pv_covers_house_load",
+            grid_import_w=40.0,
+        )
+
+        self.assertFalse(allowed)
+        self.assertEqual(reason, "pv_covers_load_blocks_discharge")
+
+    def test_good_forecast_exceeding_headroom_enables_early_passthrough(self) -> None:
+        self.assertTrue(
+            forecast_supports_early_pv_passthrough(
+                forecast_status="available",
+                pv_outlook="good",
+                remaining_today_kwh=2.433,
+                battery_capacity_kwh=3.84,
+                soc=63.0,
+                soc_max=100.0,
+            )
+        )
+
+    def test_forecast_inside_headroom_keeps_battery_priority(self) -> None:
+        self.assertFalse(
+            forecast_supports_early_pv_passthrough(
+                forecast_status="available",
+                pv_outlook="good",
+                remaining_today_kwh=1.2,
+                battery_capacity_kwh=3.84,
+                soc=63.0,
+                soc_max=100.0,
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Zusammenfassung

Behebt den durch Beats RC3-Diagnoseaufzeichnung in Discussion #123 bestätigten DC-PV-/Netzflusskonflikt beim SF800Pro:

- hohe DC-seitige PV-Leistung sperrt wirtschaftliche Entladung nur noch bei tatsächlich kleinem Netzbezug (bis 120 W)
- deutlicher realer Netzbezug bleibt maßgeblich und verhindert den Wechsel zwischen `adaptive_peak_discharge` und `pv_covers_load_blocks_discharge`
- die SF800Pro-PV-Hauslast-Durchleitung darf vor „Akku fast voll“ starten, wenn gute Rest-PV-Prognose die freie Akkukapazität um mehr als 0,25 kWh übersteigt
- Schutzgrenzen, Zusatzbatterie-Sperren, SoC-Schutz und bestehende Durchleitungs-Hysterese bleiben erhalten
- Version auf `4.6.0-RC4`

## Validierung

- `322 passed, 326 subtests passed`
- Regression mit 842 W Netzbezug und hoher DC-PV
- Gegenprobe mit nur 40 W Restbezug
- Prognosetest mit 2,433 kWh Rest-PV, 3,84 kWh Akku und 63 % SoC
- Gegenprobe bei Rest-PV innerhalb der freien Akkukapazität

Bezug: https://github.com/PalmManiac/battery-smartflow-ai/discussions/123#discussioncomment-18133546