### PR TITLE
Release 4.6.0-RC5

### DIFF
--- a/custom_components/battery_smartflow_ai/automatic_strategy.py
+++ b/custom_components/battery_smartflow_ai/automatic_strategy.py
@@ -44,6 +44,37 @@ def forecast_supports_early_pv_passthrough(
     return float(remaining_today_kwh or 0.0) > free_capacity_kwh + 0.25
 
 
+def maintain_active_economic_discharge(
+    *,
+    automatic_mode_active: bool,
+    strategy_active: bool,
+    strategy_allows_discharge: bool,
+    effective_price_reached: bool,
+    previous_regulation_state: str,
+    active_output_w: float,
+) -> bool:
+    """Keep self-reducing grid import from cancelling active discharge.
+
+    An SF800Pro can report net battery charging while simultaneously supplying
+    AC output from its DC bus. Therefore the commanded output, rather than the
+    signed battery-power sensor alone, identifies an active discharge cycle.
+    The hold is only inherited from a real discharge state; PV passthrough must
+    not accidentally become an economic discharge latch.
+    """
+
+    inherited_active_discharge = bool(
+        str(previous_regulation_state) == "discharge_active"
+        and float(active_output_w or 0.0) > 0.0
+    )
+
+    return bool(
+        automatic_mode_active
+        and strategy_active
+        and effective_price_reached
+        and (strategy_allows_discharge or inherited_active_discharge)
+    )
+
+
 class AutomaticStrategy:
     """Build the high-level context for the unified automatic strategy.
 

--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -25,7 +25,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "4.6.0-RC4"
+INTEGRATION_VERSION = "4.6.0-RC5"
 
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,

--- a/custom_components/battery_smartflow_ai/coordinator.py
+++ b/custom_components/battery_smartflow_ai/coordinator.py
@@ -158,6 +158,7 @@ from .economics import (
 from .automatic_strategy import (
     AutomaticStrategy,
     forecast_supports_early_pv_passthrough,
+    maintain_active_economic_discharge,
 )
 from .strategy_adapter import decision_to_strategy_intent
 from .strategy_state import ChargeCommitState
@@ -4510,16 +4511,29 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 ai_mode == AI_MODE_SUMMER
             )
 
-            automatic_economic_hold_active = bool(
-                ai_mode == AI_MODE_AUTOMATIC
-                and automatic_strategy_context.active
-                and bool(
+            previous_regulation_state = str(
+                self._persist.get("regulation_active_state", "none") or "none"
+            )
+
+            last_output_w = max(
+                0.0,
+                float(self._persist.get("last_set_output_w", 0.0) or 0.0),
+            )
+
+            automatic_economic_hold_active = maintain_active_economic_discharge(
+                automatic_mode_active=(ai_mode == AI_MODE_AUTOMATIC),
+                strategy_active=bool(automatic_strategy_context.active),
+                strategy_allows_discharge=bool(
                     automatic_strategy_context.metadata.get(
                         "automatic_discharge_allowed",
                         False,
                     )
-                )
-                and self._engine._is_effective_discharge_price_reached(ctx)
+                ),
+                effective_price_reached=(
+                    self._engine._is_effective_discharge_price_reached(ctx)
+                ),
+                previous_regulation_state=previous_regulation_state,
+                active_output_w=last_output_w,
             )
 
             discharge_hold_mode_active = bool(
@@ -4538,6 +4552,11 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     )
                     or 0.0
                 ),
+            )
+
+            active_discharge_output_w = max(
+                previous_discharge_w,
+                last_output_w,
             )
 
             stable_export_cycles = int(
@@ -4587,7 +4606,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     "state_idle",
                     "standby",
                 }
-                and previous_discharge_w > 0.0
+                and active_discharge_output_w > 0.0
                 and float(soc) > float(soc_min)
                 and not bool(discharge_blocked_by_soc_min)
                 and not bool(cell_voltage_discharge_blocked)
@@ -4599,7 +4618,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 hold_discharge_w = max(
                     self._engine._discharge_keepalive_w(ctx),
                     min(
-                        previous_discharge_w,
+                        active_discharge_output_w,
                         float(max_discharge),
                     ),
                 )

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": [],
-  "version": "4.6.0-RC4"
+  "version": "4.6.0-RC5"
 }

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "4.6.0-RC4")
+        self.assertEqual(manifest_version, "4.6.0-RC5")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_rc5_discharge_feedback_regressions.py
+++ b/tests/test_rc5_discharge_feedback_regressions.py
@@ -1,0 +1,119 @@
+"""RC5 regressions from the SF800Pro RC4 trace in Discussion #123."""
+
+from __future__ import annotations
+
+import unittest
+
+from support import bootstrap
+
+
+bootstrap()
+
+from custom_components.battery_smartflow_ai.automatic_strategy import (  # noqa: E402
+    AutomaticStrategy,
+    maintain_active_economic_discharge,
+)
+
+
+class Rc5DischargeFeedbackRegressionTests(unittest.TestCase):
+    def test_active_discharge_survives_its_own_grid_import_reduction(self) -> None:
+        strategy = AutomaticStrategy()
+
+        started, _ = strategy._automatic_discharge_permission(
+            price_weight=1.0,
+            price_reason="very_expensive_price_range",
+            reserve_weight=0.4,
+            reserve_reason="reserve_normal",
+            pv_weight=0.95,
+            pv_reason="pv_covers_house_load",
+            grid_import_w=620.0,
+        )
+        reduced_import_allowed, reduced_import_reason = (
+            strategy._automatic_discharge_permission(
+                price_weight=1.0,
+                price_reason="very_expensive_price_range",
+                reserve_weight=0.4,
+                reserve_reason="reserve_normal",
+                pv_weight=0.95,
+                pv_reason="pv_covers_house_load",
+                grid_import_w=88.0,
+            )
+        )
+
+        self.assertTrue(started)
+        self.assertFalse(reduced_import_allowed)
+        self.assertEqual(
+            reduced_import_reason,
+            "pv_covers_load_blocks_discharge",
+        )
+        self.assertTrue(
+            maintain_active_economic_discharge(
+                automatic_mode_active=True,
+                strategy_active=True,
+                strategy_allows_discharge=reduced_import_allowed,
+                effective_price_reached=True,
+                previous_regulation_state="discharge_active",
+                active_output_w=531.0,
+            )
+        )
+
+    def test_dc_charge_measurement_does_not_hide_commanded_ac_output(self) -> None:
+        measured_battery_discharge_w = 0.0
+        last_commanded_output_w = 507.0
+
+        active_output_w = max(
+            measured_battery_discharge_w,
+            last_commanded_output_w,
+        )
+
+        self.assertTrue(
+            maintain_active_economic_discharge(
+                automatic_mode_active=True,
+                strategy_active=True,
+                strategy_allows_discharge=False,
+                effective_price_reached=True,
+                previous_regulation_state="discharge_active",
+                active_output_w=active_output_w,
+            )
+        )
+
+    def test_passthrough_output_does_not_create_economic_discharge_hold(self) -> None:
+        self.assertFalse(
+            maintain_active_economic_discharge(
+                automatic_mode_active=True,
+                strategy_active=True,
+                strategy_allows_discharge=False,
+                effective_price_reached=True,
+                previous_regulation_state="passthrough_active",
+                active_output_w=789.0,
+            )
+        )
+
+    def test_real_exit_conditions_disable_the_hold_context(self) -> None:
+        common = {
+            "automatic_mode_active": True,
+            "strategy_active": True,
+            "strategy_allows_discharge": False,
+            "previous_regulation_state": "discharge_active",
+            "active_output_w": 531.0,
+        }
+
+        self.assertFalse(
+            maintain_active_economic_discharge(
+                **common,
+                effective_price_reached=False,
+            )
+        )
+        self.assertFalse(
+            maintain_active_economic_discharge(
+                **{
+                    **common,
+                    "automatic_mode_active": False,
+                    "effective_price_reached": True,
+                }
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Zusammenfassung

Behebt den mit Beats RC4-Debug-Paket in Diskussion #123 bestätigten Rückkopplungseffekt beim SF800Pro:

- eine bereits aktive wirtschaftliche Entladung bleibt bestehen, wenn sie selbst den realen Netzbezug unter die RC4-Startgrenze senkt
- die Halteentscheidung berücksichtigt die tatsächlich gesetzte AC-Ausgangsleistung; eine gleichzeitige DC-seitige Netto-Akkuladung kann den aktiven Ausgang nicht mehr verbergen
- nur ein zuvor echter Zustand `discharge_active` darf die Haltefunktion erben; reine PV-Hauslast-Durchleitung wird nicht fälschlich festgehalten
- Preisgrenze, Automatikmodus, SoC-, Zellspannungs- und weitere Schutzbedingungen bleiben maßgeblich
- bestätigter Export bleibt der reguläre Ausgang aus der Haltefunktion
- Version auf `4.6.0-RC5`

Die von Beat beschriebene nächtliche Verschiebung des Ladefensters ist in den vorhandenen Paketen nicht enthalten und wird daher in diesem fokussierten RC nicht spekulativ verändert.

## Regressionen

- Start der Entladung bei 620 W realem Netzbezug
- stabiler Weiterlauf nach selbst erzeugten 88 W Restbezug
- SF800Pro-Gegenprobe: 0 W gemessene Nettoentladung bei 507 W gesetztem AC-Ausgang
- PV-Passthrough mit 789 W erzeugt keine wirtschaftliche Entladebindung
- Preis- und Modusabbruch lösen die Bindung weiterhin

## Validierung

- fokussiert: `14 passed`
- vollständig: `326 passed, 326 subtests passed`
- Python-Kompilierung erfolgreich
- Manifest-JSON gültig
- `git diff --check`

Bezug: https://github.com/PalmManiac/battery-smartflow-ai/discussions/123#discussioncomment-18150522
