### PR TITLE
Release 4.6.0-RC6

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ New and improved capabilities include:
 * explicit peak, valley, effective and economic discharge thresholds
 * bounded JSON debug recordings that can be exported for support without
   permanently filling Home Assistant Recorder with large diagnostic attributes
+* schedulable debug recordings through the existing Home Assistant start and
+  stop actions
+* compact **Control context: PV / Price / Manual** instead of misleading
+  summer and winter labels
 
 Existing settings, learned data and accumulated economic values are preserved
 when updating. The detailed meaning of every new value is explained in the
@@ -645,6 +649,10 @@ Neue und verbesserte Fähigkeiten:
 * transparente Peak-, Valley-, effektive und ökonomische Entladeschwellen
 * begrenzte JSON-Debug-Aufzeichnungen für den Support, ohne den
   Home-Assistant-Recorder dauerhaft mit großen Diagnoseattributen zu füllen
+* zeitgesteuerte Debug-Aufzeichnungen über die vorhandenen Home-Assistant-
+  Aktionen zum Starten und Stoppen
+* kompakter **Regelungskontext: PV / Preis / Manuell** statt missverständlicher
+  Sommer- und Winterbezeichnungen
 
 Vorhandene Einstellungen, Lerndaten und bereits aufsummierte Wirtschaftswerte
 bleiben beim Update erhalten. Alle neuen Werte werden ausführlich in der

--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -25,7 +25,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "4.6.0-RC5"
+INTEGRATION_VERSION = "4.6.0-RC6"
 
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,

--- a/custom_components/battery_smartflow_ai/learned_planning.py
+++ b/custom_components/battery_smartflow_ai/learned_planning.py
@@ -55,6 +55,7 @@ MIN_CORE_WINDOW_DAYS = 4
 MIN_DATA_COVERAGE = 0.80
 
 DEFAULT_FALLBACK_CHARGE_POWER_W = 1200.0
+DEFAULT_PLANNING_CHARGE_EFFICIENCY = 0.90
 MIN_EFFECTIVE_CHARGE_POWER_W = 100.0
 
 MIN_LEARNED_CHARGE_POWER_SAMPLE_W = 300.0
@@ -689,7 +690,14 @@ def effective_charge_power_w(
         candidates.append(DEFAULT_FALLBACK_CHARGE_POWER_W)
 
     power = min(v for v in candidates if v > 0) if any(v > 0 for v in candidates) else 0.0
-    return max(0.0, float(power))
+
+    # Device input power is not fully stored as usable battery energy. Keep the
+    # physical command ceiling unchanged, but schedule against a conservative
+    # net value so inverter and cell losses cannot make the plan finish late.
+    return max(
+        0.0,
+        float(power) * DEFAULT_PLANNING_CHARGE_EFFICIENCY,
+    )
 
 
 def available_charge_power_w(
@@ -760,7 +768,10 @@ def requested_charge_power_w(
     if remaining_hours <= 0.0:
         return available_power
 
-    required_power = (required_kwh / remaining_hours) * 1000.0
+    required_net_power = (required_kwh / remaining_hours) * 1000.0
+    required_power = (
+        required_net_power / DEFAULT_PLANNING_CHARGE_EFFICIENCY
+    )
     return min(
         available_power,
         max(MIN_EFFECTIVE_CHARGE_POWER_W, required_power),
@@ -929,16 +940,17 @@ def optimize_charge_window(
         )
     ]
 
-    # Equal-cost windows used to be pushed as close to the deadline as possible.
-    # Keep a safety reserve after charging instead: aim up to one hour before the
-    # latest equal-cost start, without moving farther than the midpoint of the
-    # available tie range. This remains stable while waiting and still gives every
-    # real price difference priority over timing comfort.
+    # Keep equal-cost windows stable while time advances. Basing the preferred
+    # start on the midpoint of the *remaining* tie range moved the plan by one
+    # slot whenever an old price slot expired (01:15 -> 01:30 -> 01:45 in the
+    # RC5 field trace). Anchor it to a fixed one-hour reserve before the latest
+    # equal-cost start instead. Real price differences still take precedence.
     earliest_start = min(candidate[1] for candidate in cheapest)
     latest_start = max(candidate[1] for candidate in cheapest)
-    tied_span = latest_start - earliest_start
-    end_reserve = min(timedelta(hours=1), tied_span / 2)
-    preferred_start = latest_start - end_reserve
+    preferred_start = max(
+        earliest_start,
+        latest_start - timedelta(hours=1),
+    )
     _, best_start, best_end, best_prices = min(
         cheapest,
         key=lambda candidate: (
@@ -1079,12 +1091,12 @@ def build_learned_charge_plan(
             decision_reason=LEARNED_REASON_NOT_READY,
         )
 
-    # The learned value remains a conservative scheduling estimate. The core
-    # economic window, however, is sized with the actually available limit so
-    # a self-learned low value cannot stretch the cheap window and cap INPUT.
+    # Size the economic window with net storable power. The separate available
+    # power remains the physical command ceiling, so planning losses can make
+    # the window start earlier without reducing the device's permitted INPUT.
     core_window_slots = required_window_slots(
         required_charge_energy_kwh=required_kwh,
-        available_charge_power_w_value=available_power_w,
+        available_charge_power_w_value=eff_power_w,
     )
 
     start, end, score, weights, selected_prices, optimizer_reason = optimize_charge_window(

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": [],
-  "version": "4.6.0-RC5"
+  "version": "4.6.0-RC6"
 }

--- a/custom_components/battery_smartflow_ai/sensor.py
+++ b/custom_components/battery_smartflow_ai/sensor.py
@@ -1191,7 +1191,7 @@ _SENSOR_DESCRIPTIONS: tuple[ZendureSensorEntityDescription, ...] = (
         runtime_key="season_mode",
         device_class=SensorDeviceClass.ENUM,
         options=SEASON_MODE_ENUMS,
-        icon="mdi:weather-partly-snowy",
+        icon="mdi:tune-variant",
     ),
     ZendureSensorEntityDescription(
         key="soc_limit_status",

--- a/custom_components/battery_smartflow_ai/strings.json
+++ b/custom_components/battery_smartflow_ai/strings.json
@@ -54,7 +54,7 @@
           "additional_battery_charge_entity": "Optional sensor of a second battery system. If this sensor reports positive charge power, Battery SmartFlow AI blocks discharging.",
           "additional_battery_discharge_entity": "Optional sensor of a second battery system. If this sensor reports positive discharge power, Battery SmartFlow AI blocks charging to avoid battery-to-battery charging.",
           "capacity_entity": "Optional sensor with automatically calculated available battery capacity in kWh, for example from the Zendure integration. If set, it overrides the manual calculation.",
-          "installed_pv_wp": "Installed theoretical PV module power of the system in Wp. This value is used for relative summer/winter thresholds and other PV-related logic.",
+          "installed_pv_wp": "Installed theoretical PV module power of the system in Wp. This value is used for relative PV-context thresholds and other PV-related logic.",
           "pv_entity": "Sensor with the current PV power in watts. Used to detect surplus.",
           "pv_forecast_today_entity": "Optional sensor with today's PV daily forecast, for example from Solcast PV Forecast. The forecast is only an additional planning input and is not required for the integration.",
           "pv_forecast_tomorrow_entity": "Optional sensor with tomorrow's PV daily forecast, for example from Solcast PV Forecast. The forecast is only an additional planning input and is not required for the integration.",
@@ -140,7 +140,7 @@
           "additional_battery_charge_entity": "Optional sensor of a second battery system. If this sensor reports positive charge power, Battery SmartFlow AI blocks discharging.",
           "additional_battery_discharge_entity": "Optional sensor of a second battery system. If this sensor reports positive discharge power, Battery SmartFlow AI blocks charging to avoid battery-to-battery charging.",
           "capacity_entity": "Optional sensor with automatically calculated available battery capacity in kWh, for example from the Zendure integration. If set, it overrides the manual calculation.",
-          "installed_pv_wp": "Installed theoretical PV module power of the system in Wp. This value is used for relative summer/winter thresholds and other PV-related logic.",
+          "installed_pv_wp": "Installed theoretical PV module power of the system in Wp. This value is used for relative PV-context thresholds and other PV-related logic.",
           "pv_entity": "Sensor with the current PV power in watts.",
           "pv_forecast_today_entity": "Optional sensor with today's PV daily forecast, for example from Solcast PV Forecast. The forecast is only an additional planning input and is not required for the integration.",
           "pv_forecast_tomorrow_entity": "Optional sensor with tomorrow's PV daily forecast, for example from Solcast PV Forecast. The forecast is only an additional planning input and is not required for the integration.",
@@ -179,7 +179,7 @@
           "installed_pv_wp": "Installed PV power (Wp)"
         },
         "data_description": {
-          "installed_pv_wp": "Installed theoretical PV module power of the system in Wp. This value is used for relative summer/winter thresholds and other PV-related logic."
+          "installed_pv_wp": "Installed theoretical PV module power of the system in Wp. This value is used for relative PV-context thresholds and other PV-related logic."
         }
       },
       "debug_start": {
@@ -613,11 +613,11 @@
         }
       },
       "season_mode": {
-        "name": "Detected operating mode",
+        "name": "Control context",
         "state": {
-          "winter": "Winter operation",
-          "summer": "Summer operation",
-          "manual": "Manual operation"
+          "winter": "Price",
+          "summer": "PV",
+          "manual": "Manual"
         }
       },
       "soc_limit_status": {

--- a/custom_components/battery_smartflow_ai/translations/de.json
+++ b/custom_components/battery_smartflow_ai/translations/de.json
@@ -55,7 +55,7 @@
           "offgrid_power_entity": "Optionaler Sensor für die Leistung der Zendure-Off-Grid-/Inselsteckdose. Positive Werte werden als aktive Last an der Inselsteckdose interpretiert.",
           "offgrid_mode_entity": "Optionaler Select-Sensor für den Off-Grid-Modus der Zendure-Off-Grid-/Inselsteckdose. Der Modus wird nur gelesen und niemals von Battery SmartFlow AI gesetzt.",
           "capacity_entity": "Optionaler Sensor mit der automatisch berechneten verfügbaren Batteriekapazität in kWh (z. B. aus der Zendure-Integration). Falls gesetzt, überschreibt er die manuelle Berechnung.",
-          "installed_pv_wp": "Installierte theoretische PV-Modulleistung der Anlage in Wp. Dieser Wert wird künftig für relative Sommer-/Winter-Schwellen und weitere PV-bezogene Logik verwendet.",
+          "installed_pv_wp": "Installierte theoretische PV-Modulleistung der Anlage in Wp. Dieser Wert wird für relative PV-Kontextschwellen und weitere PV-bezogene Logik verwendet.",
           "pv_entity": "Sensor mit der aktuellen PV-Leistung in Watt. Wird zur Erkennung von Überschuss verwendet.",
 		  "feed_in_tariff": "Vergütung pro eingespeister kWh in ganzer Währung. Sie dient als Rückfallwert, wenn kein gültiger dynamischer Einspeisepreis verfügbar ist.",
           "dynamic_feed_in_price_entity": "Optionaler numerischer Home-Assistant-Sensor für den aktuellen dynamischen Einspeisepreis. Ein gültiger Sensorwert einschließlich null oder eines negativen Preises hat Vorrang vor der festen Einspeisevergütung.",
@@ -141,7 +141,7 @@
           "offgrid_power_entity": "Optionaler Sensor für die Leistung der Zendure-Off-Grid-/Inselsteckdose. Positive Werte werden als aktive Last an der Inselsteckdose interpretiert.",
           "offgrid_mode_entity": "Optionaler Select-Sensor für den Off-Grid-Modus der Zendure-Off-Grid-/Inselsteckdose. Der Modus wird nur gelesen und niemals von Battery SmartFlow AI gesetzt.",
           "capacity_entity": "Optionaler Sensor mit der automatisch berechneten verfügbaren Batteriekapazität in kWh (z. B. aus der Zendure-Integration). Falls gesetzt, überschreibt er die manuelle Berechnung.",
-          "installed_pv_wp": "Installierte theoretische PV-Modulleistung der Anlage in Wp. Dieser Wert wird künftig für relative Sommer-/Winter-Schwellen und weitere PV-bezogene Logik verwendet.",
+          "installed_pv_wp": "Installierte theoretische PV-Modulleistung der Anlage in Wp. Dieser Wert wird für relative PV-Kontextschwellen und weitere PV-bezogene Logik verwendet.",
           "pv_entity": "Sensor mit der aktuellen PV-Leistung in Watt.",
 		  "feed_in_tariff": "Vergütung pro eingespeister kWh in ganzer Währung. Sie dient als Rückfallwert, wenn kein gültiger dynamischer Einspeisepreis verfügbar ist.",
           "dynamic_feed_in_price_entity": "Optionaler numerischer Home-Assistant-Sensor für den aktuellen dynamischen Einspeisepreis. Ein gültiger Sensorwert einschließlich null oder eines negativen Preises hat Vorrang vor der festen Einspeisevergütung.",
@@ -178,7 +178,7 @@
           "installed_pv_wp": "Installierte PV-Leistung (Wp)"
         },
         "data_description": {
-          "installed_pv_wp": "Installierte theoretische PV-Modulleistung der Anlage in Wp. Dieser Wert wird für relative Sommer-/Winter-Schwellen und weitere PV-bezogene Logik verwendet."
+          "installed_pv_wp": "Installierte theoretische PV-Modulleistung der Anlage in Wp. Dieser Wert wird für relative PV-Kontextschwellen und weitere PV-bezogene Logik verwendet."
         }
       },
       "debug_start": {
@@ -608,11 +608,11 @@
         }
       },
       "season_mode": {
-        "name": "Erkannter Betriebsmodus",
+        "name": "Regelungskontext",
         "state": {
-          "winter": "Winterbetrieb",
-          "summer": "Sommerbetrieb",
-          "manual": "Manueller Betrieb"
+          "winter": "Preis",
+          "summer": "PV",
+          "manual": "Manuell"
         }
       },
       "soc_limit_status": {

--- a/custom_components/battery_smartflow_ai/translations/en.json
+++ b/custom_components/battery_smartflow_ai/translations/en.json
@@ -53,7 +53,7 @@
           "additional_battery_charge_entity": "Optional sensor of a second battery system. If this sensor reports positive charge power, Battery SmartFlow AI blocks discharging.",
           "additional_battery_discharge_entity": "Optional sensor of a second battery system. If this sensor reports positive discharge power, Battery SmartFlow AI blocks charging to avoid battery-to-battery charging.",
           "capacity_entity": "Optional sensor with automatically calculated available battery capacity in kWh, for example from the Zendure integration. If set, it overrides the manual calculation.",
-          "installed_pv_wp": "Installed theoretical PV module power of the system in Wp. This value is used for relative summer/winter thresholds and other PV-related logic.",
+          "installed_pv_wp": "Installed theoretical PV module power of the system in Wp. This value is used for relative PV-context thresholds and other PV-related logic.",
           "pv_entity": "Sensor with the current PV power in watts. Used to detect surplus.",
           "pv_forecast_today_entity": "Optional sensor with today's PV daily forecast, for example from Solcast PV Forecast. The forecast is only an additional planning input and is not required for the integration.",
           "pv_forecast_tomorrow_entity": "Optional sensor with tomorrow's PV daily forecast, for example from Solcast PV Forecast. The forecast is only an additional planning input and is not required for the integration.",
@@ -139,7 +139,7 @@
           "additional_battery_charge_entity": "Optional sensor of a second battery system. If this sensor reports positive charge power, Battery SmartFlow AI blocks discharging.",
           "additional_battery_discharge_entity": "Optional sensor of a second battery system. If this sensor reports positive discharge power, Battery SmartFlow AI blocks charging to avoid battery-to-battery charging.",
           "capacity_entity": "Optional sensor with automatically calculated available battery capacity in kWh, for example from the Zendure integration. If set, it overrides the manual calculation.",
-          "installed_pv_wp": "Installed theoretical PV module power of the system in Wp. This value is used for relative summer/winter thresholds and other PV-related logic.",
+          "installed_pv_wp": "Installed theoretical PV module power of the system in Wp. This value is used for relative PV-context thresholds and other PV-related logic.",
           "pv_entity": "Sensor with the current PV power in watts.",
           "pv_forecast_today_entity": "Optional sensor with today's PV daily forecast, for example from Solcast PV Forecast. The forecast is only an additional planning input and is not required for the integration.",
           "pv_forecast_tomorrow_entity": "Optional sensor with tomorrow's PV daily forecast, for example from Solcast PV Forecast. The forecast is only an additional planning input and is not required for the integration.",
@@ -178,7 +178,7 @@
           "installed_pv_wp": "Installed PV power (Wp)"
         },
         "data_description": {
-          "installed_pv_wp": "Installed theoretical PV module power of the system in Wp. This value is used for relative summer/winter thresholds and other PV-related logic."
+          "installed_pv_wp": "Installed theoretical PV module power of the system in Wp. This value is used for relative PV-context thresholds and other PV-related logic."
         }
       },
       "debug_start": {
@@ -608,11 +608,11 @@
         }
       },
       "season_mode": {
-        "name": "Detected operating mode",
+        "name": "Control context",
         "state": {
-          "winter": "Winter operation",
-          "summer": "Summer operation",
-          "manual": "Manual operation"
+          "winter": "Price",
+          "summer": "PV",
+          "manual": "Manual"
         }
       },
       "soc_limit_status": {

--- a/custom_components/battery_smartflow_ai/translations/fr.json
+++ b/custom_components/battery_smartflow_ai/translations/fr.json
@@ -53,7 +53,7 @@
           "additional_battery_charge_entity": "Capteur optionnel d’un second système de batterie. Si ce capteur indique une puissance de charge positive, Battery SmartFlow AI bloque la décharge.",
           "additional_battery_discharge_entity": "Capteur optionnel d’un second système de batterie. Si ce capteur indique une puissance de décharge positive, Battery SmartFlow AI bloque la charge afin d’éviter une charge batterie-à-batterie.",
           "capacity_entity": "Capteur optionnel de capacité batterie disponible calculée automatiquement en kWh, par exemple depuis l’intégration Zendure. S’il est défini, il remplace le calcul manuel.",
-          "installed_pv_wp": "Puissance théorique des modules PV installés en Wp. Cette valeur est utilisée pour les seuils été/hiver relatifs et d’autres logiques liées au PV.",
+          "installed_pv_wp": "Puissance théorique des modules PV installés en Wp. Cette valeur est utilisée pour les seuils relatifs du contexte PV et d’autres logiques liées au PV.",
           "pv_entity": "Capteur de puissance PV actuelle en watts. Utilisé pour détecter le surplus.",
           "pv_forecast_today_entity": "Capteur optionnel avec la prévision journalière PV pour aujourd’hui, par exemple Solcast PV Forecast. La prévision n’est qu’une entrée de planification supplémentaire et n’est pas obligatoire.",
           "pv_forecast_tomorrow_entity": "Capteur optionnel avec la prévision journalière PV pour demain, par exemple Solcast PV Forecast. La prévision n’est qu’une entrée de planification supplémentaire et n’est pas obligatoire.",
@@ -139,7 +139,7 @@
           "additional_battery_charge_entity": "Capteur optionnel d’un second système de batterie. Si ce capteur indique une puissance de charge positive, Battery SmartFlow AI bloque la décharge.",
           "additional_battery_discharge_entity": "Capteur optionnel d’un second système de batterie. Si ce capteur indique une puissance de décharge positive, Battery SmartFlow AI bloque la charge afin d’éviter une charge batterie-à-batterie.",
           "capacity_entity": "Capteur optionnel de capacité batterie disponible calculée automatiquement en kWh, par exemple depuis l’intégration Zendure. S’il est défini, il remplace le calcul manuel.",
-          "installed_pv_wp": "Puissance théorique des modules PV installés en Wp. Cette valeur est utilisée pour les seuils été/hiver relatifs et d’autres logiques liées au PV.",
+          "installed_pv_wp": "Puissance théorique des modules PV installés en Wp. Cette valeur est utilisée pour les seuils relatifs du contexte PV et d’autres logiques liées au PV.",
           "pv_entity": "Capteur de puissance PV actuelle en watts.",
           "pv_forecast_today_entity": "Capteur optionnel avec la prévision journalière PV pour aujourd’hui, par exemple Solcast PV Forecast. La prévision n’est qu’une entrée de planification supplémentaire et n’est pas obligatoire.",
           "pv_forecast_tomorrow_entity": "Capteur optionnel avec la prévision journalière PV pour demain, par exemple Solcast PV Forecast. La prévision n’est qu’une entrée de planification supplémentaire et n’est pas obligatoire.",
@@ -178,7 +178,7 @@
           "installed_pv_wp": "Puissance PV installée (Wp)"
         },
         "data_description": {
-          "installed_pv_wp": "Puissance théorique des modules PV installés en Wp. Cette valeur est utilisée pour les seuils été/hiver relatifs et d’autres logiques liées au PV."
+          "installed_pv_wp": "Puissance théorique des modules PV installés en Wp. Cette valeur est utilisée pour les seuils relatifs du contexte PV et d’autres logiques liées au PV."
         }
       },
       "debug_start": {
@@ -608,11 +608,11 @@
         }
       },
       "season_mode": {
-        "name": "Mode de fonctionnement détecté",
+        "name": "Contexte de régulation",
         "state": {
-          "winter": "Mode hiver",
-          "summer": "Mode été",
-          "manual": "Mode manuel"
+          "winter": "Prix",
+          "summer": "PV",
+          "manual": "Manuel"
         }
       },
       "soc_limit_status": {

--- a/custom_components/battery_smartflow_ai/translations/nl.json
+++ b/custom_components/battery_smartflow_ai/translations/nl.json
@@ -53,7 +53,7 @@
           "additional_battery_charge_entity": "Optionele sensor van een tweede batterijsysteem. Als deze sensor positief laadvermogen meldt, blokkeert Battery SmartFlow AI het ontladen.",
           "additional_battery_discharge_entity": "Optionele sensor van een tweede batterijsysteem. Als deze sensor positief ontlaadvermogen meldt, blokkeert Battery SmartFlow AI het laden, zodat er geen batterij-naar-batterij-laden ontstaat.",
           "capacity_entity": "Optionele sensor met automatisch berekende beschikbare batterijcapaciteit in kWh, bijvoorbeeld uit de Zendure-integratie. Indien ingesteld, overschrijft deze de handmatige berekening.",
-          "installed_pv_wp": "Theoretisch geïnstalleerd PV-modulevermogen van de installatie in Wp. Deze waarde wordt gebruikt voor relatieve zomer-/winterdrempels en andere PV-logica.",
+          "installed_pv_wp": "Theoretisch geïnstalleerd PV-modulevermogen van de installatie in Wp. Deze waarde wordt gebruikt voor relatieve PV-contextdrempels en andere PV-logica.",
           "pv_entity": "Sensor met het actuele PV-vermogen in watt. Wordt gebruikt om overschot te herkennen.",
           "pv_forecast_today_entity": "Optionele sensor met de PV-dagvoorspelling voor vandaag, bijvoorbeeld uit Solcast PV Forecast. De voorspelling is alleen een extra planningsinput en geen vereiste.",
           "pv_forecast_tomorrow_entity": "Optionele sensor met de PV-dagvoorspelling voor morgen, bijvoorbeeld uit Solcast PV Forecast. De voorspelling is alleen een extra planningsinput en geen vereiste.",
@@ -139,7 +139,7 @@
           "additional_battery_charge_entity": "Optionele sensor van een tweede batterijsysteem. Als deze sensor positief laadvermogen meldt, blokkeert Battery SmartFlow AI het ontladen.",
           "additional_battery_discharge_entity": "Optionele sensor van een tweede batterijsysteem. Als deze sensor positief ontlaadvermogen meldt, blokkeert Battery SmartFlow AI het laden, zodat er geen batterij-naar-batterij-laden ontstaat.",
           "capacity_entity": "Optionele sensor met automatisch berekende beschikbare batterijcapaciteit in kWh, bijvoorbeeld uit de Zendure-integratie. Indien ingesteld, overschrijft deze de handmatige berekening.",
-          "installed_pv_wp": "Theoretisch geïnstalleerd PV-modulevermogen van de installatie in Wp. Deze waarde wordt gebruikt voor relatieve zomer-/winterdrempels en andere PV-logica.",
+          "installed_pv_wp": "Theoretisch geïnstalleerd PV-modulevermogen van de installatie in Wp. Deze waarde wordt gebruikt voor relatieve PV-contextdrempels en andere PV-logica.",
           "pv_entity": "Sensor met het actuele PV-vermogen in watt.",
           "pv_forecast_today_entity": "Optionele sensor met de PV-dagvoorspelling voor vandaag, bijvoorbeeld uit Solcast PV Forecast. De voorspelling is alleen een extra planningsinput en geen vereiste.",
           "pv_forecast_tomorrow_entity": "Optionele sensor met de PV-dagvoorspelling voor morgen, bijvoorbeeld uit Solcast PV Forecast. De voorspelling is alleen een extra planningsinput en geen vereiste.",
@@ -178,7 +178,7 @@
           "installed_pv_wp": "Geïnstalleerd PV-vermogen (Wp)"
         },
         "data_description": {
-          "installed_pv_wp": "Theoretisch geïnstalleerd PV-modulevermogen van de installatie in Wp. Deze waarde wordt gebruikt voor relatieve zomer-/winterdrempels en andere PV-logica."
+          "installed_pv_wp": "Theoretisch geïnstalleerd PV-modulevermogen van de installatie in Wp. Deze waarde wordt gebruikt voor relatieve PV-contextdrempels en andere PV-logica."
         }
       },
       "debug_start": {
@@ -608,11 +608,11 @@
         }
       },
       "season_mode": {
-        "name": "Herkende bedrijfsmodus",
+        "name": "Regelcontext",
         "state": {
-          "winter": "Winterbedrijf",
-          "summer": "Zomerbedrijf",
-          "manual": "Handmatig bedrijf"
+          "winter": "Prijs",
+          "summer": "PV",
+          "manual": "Handmatig"
         }
       },
       "soc_limit_status": {

--- a/docs/anleitung.md
+++ b/docs/anleitung.md
@@ -1636,15 +1636,18 @@ Dieser Wert ist bei Support-Anfragen sehr wichtig.
 
 ---
 
-## Erkannter Betriebsmodus
+## Regelungskontext
 
-Zeigt den internen Kontextwert `summer`, `winter` oder `manual`.
+Zeigt kurz, welcher weiche Gewichtungskontext gerade gilt:
+
+* **PV** – die aktuelle PV-Lage erhält mehr Gewicht
+* **Preis** – Preisfenster und Reserve erhalten mehr Gewicht
+* **Manuell** – der manuelle Betrieb ist aktiv
 
 > [!NOTE]
-> Dieser Sensor ist kein auswählbarer Betriebsmodus. In der Automatik dienen
-> `summer` und `winter` nur noch als weicher Diagnosekontext; sie schalten keine
-> getrennten Strategien um. Die auswählbaren Modi sind Automatik, Autarkie und
-> Manuell.
+> Der Regelungskontext ist kein auswählbarer Betriebsmodus und keine erkannte
+> Jahreszeit. Auch im Sommer kann bei schwacher PV-Lage **Preis** erscheinen.
+> Die auswählbaren Betriebsmodi bleiben Automatik, Autarkie und Manuell.
 
 ---
 
@@ -2085,6 +2088,31 @@ Bestätigung quittiert.
 > erwartet wird. Für kurze Regelungsprobleme reichen meist 10 Minuten. Für
 > Ladeplanung, Ladefenster oder wechselnde Preise sind 30 bis 120 Minuten oft
 > aussagekräftiger.
+
+### Aufzeichnung zeitgesteuert starten
+
+Die vorhandenen Home-Assistant-Aktionen
+`battery_smartflow_ai.start_debug_recording` und
+`battery_smartflow_ai.stop_debug_recording` können auch in Automationen
+verwendet werden. Dieses Beispiel startet um 00:30 Uhr automatisch eine
+zweistündige Aufzeichnung:
+
+```yaml
+alias: BSFAI Debug-Aufzeichnung nachts starten
+triggers:
+  - trigger: time
+    at: "00:30:00"
+actions:
+  - action: battery_smartflow_ai.start_debug_recording
+    data:
+      duration_minutes: "120"
+mode: single
+```
+
+Bei nur einem BSFAI-Konfigurationseintrag ist keine `entry_id` erforderlich.
+Bei mehreren Einträgen muss die gewünschte Konfiguration zusätzlich in den
+Aktionsdaten ausgewählt werden. Die Aufzeichnung endet nach der gewählten Dauer
+automatisch; der Stop-Dienst ist nur für ein vorzeitiges Ende nötig.
 
 ### Fortschritt beobachten
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1637,15 +1637,19 @@ This value is very important for support requests.
 
 ---
 
-## Detected operating mode
+## Control context
 
-Shows the internal context value `summer`, `winter`, or `manual`.
+Briefly shows which soft weighting context currently applies:
+
+* **PV** – the current PV situation receives more weight
+* **Price** – price windows and battery reserve receive more weight
+* **Manual** – manual operation is active
 
 > [!NOTE]
-> This sensor is not a selectable operating mode. Serve in automation
-> `summer` and `winter` only as a soft diagnostic context; they don't switch
-> separate strategies. The selectable modes are automatic, self-sufficiency and
-> Manually.
+> The control context is neither a selectable operating mode nor a detected
+> season. **Price** can therefore appear during summer when current PV
+> conditions are weak. The selectable modes remain Automatic, Autarky and
+> Manual.
 
 ---
 
@@ -2082,6 +2086,30 @@ required. Home Assistant confirms that recording has started.
 > Start recording shortly before the unusual behavior is expected. Ten minutes
 > is usually sufficient for short control problems. For charge planning,
 > charging windows or changing prices, 30 to 120 minutes is often more useful.
+
+### Start a recording on a schedule
+
+The existing Home Assistant actions
+`battery_smartflow_ai.start_debug_recording` and
+`battery_smartflow_ai.stop_debug_recording` can also be used in automations.
+This example automatically starts a two-hour recording at 00:30:
+
+```yaml
+alias: Start BSFAI debug recording at night
+triggers:
+  - trigger: time
+    at: "00:30:00"
+actions:
+  - action: battery_smartflow_ai.start_debug_recording
+    data:
+      duration_minutes: "120"
+mode: single
+```
+
+No `entry_id` is required when only one BSFAI config entry exists. With
+multiple entries, select the intended config entry in the action data. The
+recording ends automatically after the selected duration; the stop action is
+only needed to end it early.
 
 ### Monitor progress
 

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "4.6.0-RC5")
+        self.assertEqual(manifest_version, "4.6.0-RC6")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_dev9_scenarios.py
+++ b/tests/test_dev9_scenarios.py
@@ -485,7 +485,7 @@ class Dev9Point1ChargePowerScenarios(unittest.TestCase):
             available_charge_power_w_value=2400.0,
         )
 
-        self.assertEqual(requested, 2320.0)
+        self.assertEqual(requested, 2400.0)
 
     def test_learned_rule_uses_request_instead_of_learned_estimate(self) -> None:
         plan = SimpleNamespace(
@@ -547,8 +547,8 @@ class Dev9Point1ChargePowerScenarios(unittest.TestCase):
         )
 
         self.assertEqual(plan.mode, "charge")
-        self.assertEqual(plan.effective_charge_power_w, 1161.0)
-        self.assertGreater(plan.requested_charge_power_w, 1161.0)
+        self.assertEqual(plan.effective_charge_power_w, 1044.9)
+        self.assertGreater(plan.requested_charge_power_w, 0.0)
         self.assertLessEqual(plan.requested_charge_power_w, 2400.0)
 
     def test_only_unthrottled_samples_define_reachable_power(self) -> None:

--- a/tests/test_rc6_night_planning_regressions.py
+++ b/tests/test_rc6_night_planning_regressions.py
@@ -1,0 +1,118 @@
+"""RC6 regressions from Beat's RC5 overnight trace in Discussion #123."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import json
+from pathlib import Path
+import unittest
+
+from support import bootstrap
+
+
+bootstrap()
+
+from custom_components.battery_smartflow_ai.learned_planning import (  # noqa: E402
+    compute_window_slots,
+    effective_charge_power_w,
+    optimize_charge_window,
+    requested_charge_power_w,
+    required_window_slots,
+)
+from custom_components.battery_smartflow_ai.market_price import (  # noqa: E402
+    MarketPricePoint,
+)
+
+
+class Rc6NightPlanningRegressionTests(unittest.TestCase):
+    def _overnight_prices(self) -> list[MarketPricePoint]:
+        start = datetime(2026, 8, 25, 23, 0, tzinfo=timezone.utc)
+        return [
+            MarketPricePoint(
+                start=start + timedelta(minutes=15 * index),
+                end=start + timedelta(minutes=15 * (index + 1)),
+                price=0.2386 if index < 28 else 0.3047,
+            )
+            for index in range(40)
+        ]
+
+    def test_equal_price_preference_is_anchored_before_latest_start(self) -> None:
+        points = self._overnight_prices()
+        deadline = datetime(2026, 8, 26, 9, 0, tzinfo=timezone.utc)
+
+        starts = []
+        for now in (
+            datetime(2026, 8, 26, 0, 31, tzinfo=timezone.utc),
+            datetime(2026, 8, 26, 1, 0, tzinfo=timezone.utc),
+        ):
+            selected_start, *_ = optimize_charge_window(
+                now=now,
+                deadline=deadline,
+                price_points=points,
+                window_slots=16,
+            )
+            starts.append(selected_start)
+
+        self.assertEqual(starts[0], datetime(2026, 8, 26, 1, 0, tzinfo=timezone.utc))
+        self.assertEqual(starts[1], starts[0])
+
+    def test_800_w_device_limit_plans_with_720_w_net_power(self) -> None:
+        net_power = effective_charge_power_w(
+            profile_charge_limit_w=800.0,
+            learned_typical_charge_power_w=999.0,
+            current_effective_charge_cap_w=800.0,
+        )
+
+        self.assertEqual(net_power, 720.0)
+        self.assertEqual(
+            required_window_slots(
+                required_charge_energy_kwh=3.072,
+                available_charge_power_w_value=net_power,
+            ),
+            18,
+        )
+        self.assertEqual(
+            compute_window_slots(
+                required_charge_energy_kwh=3.072,
+                effective_charge_power_w_value=net_power,
+            ),
+            (20, 300),
+        )
+
+    def test_requested_input_compensates_for_storage_losses(self) -> None:
+        start = datetime(2026, 8, 26, 1, 0, tzinfo=timezone.utc)
+        end = start + timedelta(hours=4, minutes=30)
+
+        requested = requested_charge_power_w(
+            required_charge_energy_kwh=3.072,
+            now=start,
+            window_start=start,
+            window_end=end,
+            available_charge_power_w_value=800.0,
+        )
+
+        self.assertAlmostEqual(requested, 758.52, places=2)
+        self.assertLessEqual(requested, 800.0)
+
+    def test_control_context_uses_short_non_seasonal_labels(self) -> None:
+        root = Path(__file__).resolve().parents[1]
+        expected = {
+            "de": ("Regelungskontext", "PV", "Preis", "Manuell"),
+            "en": ("Control context", "PV", "Price", "Manual"),
+            "fr": ("Contexte de régulation", "PV", "Prix", "Manuel"),
+            "nl": ("Regelcontext", "PV", "Prijs", "Handmatig"),
+        }
+
+        for language, labels in expected.items():
+            payload = json.loads(
+                (root / "custom_components" / "battery_smartflow_ai" / "translations" / f"{language}.json").read_text(encoding="utf-8")
+            )
+            context = payload["entity"]["sensor"]["season_mode"]
+            self.assertEqual(context["name"], labels[0])
+            self.assertEqual(context["state"]["summer"], labels[1])
+            self.assertEqual(context["state"]["winter"], labels[2])
+            self.assertEqual(context["state"]["manual"], labels[3])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Zusammenfassung

- verankert gleichpreisige Nachtladefenster stabil, sodass der geplante Start beim Fortschreiten der Zeit nicht mehr slotweise nach hinten wandert
- berücksichtigt für die Planung konservativ 90 % speicherbare Ladeenergie, während die physische Ladeleistungsgrenze unverändert bleibt
- benennt den bisherigen Saisonmodus anwenderfreundlich in `Regelungskontext` mit `PV`, `Preis` und `Manuell` um; interne Enum-Werte bleiben kompatibel
- dokumentiert die zeitgesteuerte Debug-Aufzeichnung über die bereits vorhandenen Home-Assistant-Aktionen
- hebt die Version auf `4.6.0-RC6` an

Die in RC5 stabilisierte Entladeregelung bleibt unverändert.

## Feldbezug

Die Änderungen basieren auf Beats RC5-Nachtprotokoll in [Diskussion #123](https://github.com/PalmManiac/battery-smartflow-ai/discussions/123#discussioncomment-18157564): Das Entladen lief stabil bis zum SoC-Minimum, während das gleichpreisige Ladefenster mehrfach nach hinten wanderte und die reale Ladung wegen Umwandlungsverlusten hinter dem verlustfreien Plan zurückblieb.

## Prüfung

- `330 passed, 326 subtests passed`
- Python-Kompilierung erfolgreich
- Manifest, Strings und alle Übersetzungsdateien als JSON geprüft
- deutsche und englische Anleitung: jeweils 204 Überschriften und 56 Code-Fences
- lokale Dokumentlinks geprüft
- `git diff --check` ohne Fehler