### PR TITLE
Release 4.6.0-RC7

### DIFF
--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -25,7 +25,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "4.6.0-RC6"
+INTEGRATION_VERSION = "4.6.0-RC7"
 
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,

--- a/custom_components/battery_smartflow_ai/learned_planning.py
+++ b/custom_components/battery_smartflow_ai/learned_planning.py
@@ -817,19 +817,51 @@ def choose_deadline(
 
     now_local = _as_local(now)
 
-    future_prices = [
+    remaining_prices = [
         p for p in price_points
-        if _as_local(p.start) > now_local and _as_local(p.end) > now_local
+        if _as_local(p.end) > now_local
     ]
 
-    if future_prices:
-        prices = [float(p.price) for p in future_prices]
+    if remaining_prices:
+        prices = [float(p.price) for p in remaining_prices]
         learned_peak_threshold = peak_threshold(prices, 1.35)
 
         peak_candidates = [
-            p for p in future_prices
+            p for p in remaining_prices
             if float(p.price) >= learned_peak_threshold
         ]
+
+        # RC7: Do not invent a "before peak" deadline inside a peak that is
+        # already active. The former future-only scan discarded the current
+        # slot and repeatedly treated the next equally expensive 15-minute
+        # slot as a new upcoming peak. Near SoC reserve this made learned
+        # planning alternate between expensive grid charging and the correctly
+        # selected economic discharge every few minutes.
+        active_peak = next(
+            (
+                point
+                for point in peak_candidates
+                if _as_local(point.start) <= now_local < _as_local(point.end)
+            ),
+            None,
+        )
+
+        if active_peak is not None:
+            active_peak_end = _as_local(active_peak.end)
+            for point in sorted(
+                peak_candidates,
+                key=lambda item: _as_local(item.start),
+            ):
+                point_start = _as_local(point.start)
+                point_end = _as_local(point.end)
+                if point_start <= active_peak_end and point_end > active_peak_end:
+                    active_peak_end = point_end
+
+            peak_candidates = [
+                point
+                for point in peak_candidates
+                if _as_local(point.start) >= active_peak_end
+            ]
 
         if peak_candidates:
             first_peak = min(peak_candidates, key=lambda p: _as_local(p.start))

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": [],
-  "version": "4.6.0-RC6"
+  "version": "4.6.0-RC7"
 }

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "4.6.0-RC6")
+        self.assertEqual(manifest_version, "4.6.0-RC7")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_rc7_active_peak_regressions.py
+++ b/tests/test_rc7_active_peak_regressions.py
@@ -1,0 +1,83 @@
+"""RC7 regressions from Beat's RC6 active-peak trace in Discussion #123."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import unittest
+
+from support import bootstrap
+
+
+bootstrap()
+
+from custom_components.battery_smartflow_ai.learned_planning import (  # noqa: E402
+    DEADLINE_REASON_BEFORE_PEAK_WINDOW,
+    choose_deadline,
+)
+from custom_components.battery_smartflow_ai.market_price import (  # noqa: E402
+    MarketPricePoint,
+)
+
+
+class Rc7ActivePeakRegressionTests(unittest.TestCase):
+    def test_active_peak_is_not_reintroduced_as_next_slot_deadline(self) -> None:
+        """10:55 inside one high-price block must not target 11:00 again."""
+
+        now = datetime(2026, 8, 26, 10, 55, tzinfo=timezone.utc)
+        start = datetime(2026, 8, 26, 10, 45, tzinfo=timezone.utc)
+        prices = [
+            MarketPricePoint(
+                start=start + timedelta(minutes=15 * index),
+                end=start + timedelta(minutes=15 * (index + 1)),
+                price=price,
+            )
+            for index, price in enumerate(
+                (0.388,) * 4
+                + (0.238,) * 20
+                + (0.500,) * 2
+            )
+        ]
+
+        deadline, reason = choose_deadline(
+            now=now,
+            price_points=prices,
+            forecast=None,
+        )
+
+        self.assertEqual(reason, DEADLINE_REASON_BEFORE_PEAK_WINDOW)
+        self.assertEqual(
+            deadline,
+            datetime(2026, 8, 26, 16, 45, tzinfo=timezone.utc),
+        )
+
+    def test_future_peak_remains_a_valid_deadline(self) -> None:
+        """The fix must preserve normal preparation for an upcoming peak."""
+
+        now = datetime(2026, 8, 26, 10, 55, tzinfo=timezone.utc)
+        start = datetime(2026, 8, 26, 10, 45, tzinfo=timezone.utc)
+        prices = [
+            MarketPricePoint(
+                start=start + timedelta(minutes=15 * index),
+                end=start + timedelta(minutes=15 * (index + 1)),
+                price=price,
+            )
+            for index, price in enumerate(
+                (0.238, 0.238, 0.238, 0.238, 0.450, 0.450)
+            )
+        ]
+
+        deadline, reason = choose_deadline(
+            now=now,
+            price_points=prices,
+            forecast=None,
+        )
+
+        self.assertEqual(reason, DEADLINE_REASON_BEFORE_PEAK_WINDOW)
+        self.assertEqual(
+            deadline,
+            datetime(2026, 8, 26, 11, 45, tzinfo=timezone.utc),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Zusammenfassung

- verhindert, dass ein bereits laufender Hochpreisblock mit jedem folgenden 15-Minuten-Slot erneut als zukünftiger Peak erkannt wird
- beseitigt dadurch den in Beats RC6-Debug-Paket belegten Wechsel zwischen teurer lernbasierter Netzladung und wirtschaftlicher Entladung
- überspringt den zusammenhängenden aktuell aktiven Peakblock und plant erst wieder auf einen tatsächlich späteren Peak
- erhält die normale Vorbereitung auf zukünftige Peakfenster sowie sämtliche Schutz- und Notladepfade
- hebt die Version auf `4.6.0-RC7` an

## Feldbezug

Beats [neuer RC6-Beitrag in Diskussion #123](https://github.com/PalmManiac/battery-smartflow-ai/discussions/123#discussioncomment-18160076) zeigt um 10:55 Uhr bei 19 % SoC und 0,388 €/kWh wiederholte Netzladeimpulse. Das Debug-Paket belegt `learned_charge_window_latest_start_reached` beziehungsweise `charge_commit_active`, obwohl gleichzeitig eine wirtschaftliche Entladung zulässig ist.

Die Ursache lag in der Deadline-Suche: Der aktuelle Preis-Slot wurde verworfen. War der Hochpreisblock bereits aktiv, erschien der nächste gleich teure Slot deshalb fälschlich als neuer bevorstehender Peak. Kleine Reserveabweichungen eröffneten dadurch immer wieder neue Mini-Ladebindungen.

## Prüfung

- `332 passed, 326 subtests passed`
- fokussierte RC7-, RC6-, Wartungs- und Planungstests erfolgreich
- Python-Kompilierung erfolgreich
- Manifest, Strings und Übersetzungen als JSON geprüft
- `git diff --check` ohne Fehler