### PR TITLE
Release 4.6.0

### DIFF
--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -25,7 +25,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "4.6.0-RC7"
+INTEGRATION_VERSION = "4.6.0"
 
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": [],
-  "version": "4.6.0-RC7"
+  "version": "4.6.0"
 }

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "4.6.0-RC7")
+        self.assertEqual(manifest_version, "4.6.0")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:


### PR DESCRIPTION
## Zusammenfassung

- finalisiert den vollständig geprüften RC7-Stand als `4.6.0`
- ändert ausschließlich Manifest-, Laufzeit- und Test-Version von `4.6.0-RC7` auf `4.6.0`
- enthält keine zusätzlichen Funktionsänderungen gegenüber RC7

## Release-Basis

- RC7-Merge: `7aade2c3236064796b882ecc9b4594b03a8d6f61`
- RC7 HACS/Hassfest und Pages erfolgreich
- letzter gemeldeter RC6-Fehler reproduziert, in RC7 gezielt korrigiert und mit Gegenprobe abgesichert
- seit RC7-Veröffentlichung keine neue Fehlermeldung in Diskussion #123; Installation wurde bestätigt

## Prüfung

- `332 passed, 326 subtests passed`
- Python-Kompilierung erfolgreich
- Manifest, Strings und Übersetzungen als JSON geprüft
- `git diff --check` ohne Fehler
- Diff umfasst ausschließlich drei Versionsangaben