### PR TITLE
V4.7.0: Gemeinsame Core-Datenmodelle konsolidieren

### DIFF
--- a/custom_components/battery_smartflow_ai/core/__init__.py
+++ b/custom_components/battery_smartflow_ai/core/__init__.py
@@ -1,0 +1,1 @@
+"""Platform-independent Battery SmartFlow AI core."""

--- a/custom_components/battery_smartflow_ai/core/models/__init__.py
+++ b/custom_components/battery_smartflow_ai/core/models/__init__.py
@@ -1,0 +1,65 @@
+"""Canonical platform-independent models shared across the BSFAI core."""
+
+from .device import DeviceCapabilities
+from .market import (
+    MarketPrice,
+    MarketPriceDirection,
+    MarketPriceForecast,
+    MarketPricePoint,
+    MarketPriceValidity,
+)
+from .regulation import (
+    AutomaticStrategyResult,
+    ChargeSourceAllocation,
+    DeviceCommand,
+    GridHistoryState,
+    ModeArbiterResult,
+    PowerControllerResult,
+    RegulationRuntimeState,
+    StrategyContext,
+    StrategyIntent,
+)
+from .states import (
+    AdditionalBatteryState,
+    BatteryState,
+    GridState,
+    MeasuredValue,
+    OffGridState,
+    PVState,
+    ValueValidity,
+)
+from .strategy import (
+    ChargeCommitState,
+    StrategicState,
+    StrategyDecision,
+    VisibleState,
+)
+
+__all__ = [
+    "AdditionalBatteryState",
+    "AutomaticStrategyResult",
+    "BatteryState",
+    "ChargeCommitState",
+    "ChargeSourceAllocation",
+    "DeviceCapabilities",
+    "DeviceCommand",
+    "GridHistoryState",
+    "GridState",
+    "MarketPrice",
+    "MarketPriceDirection",
+    "MarketPriceForecast",
+    "MarketPricePoint",
+    "MarketPriceValidity",
+    "MeasuredValue",
+    "ModeArbiterResult",
+    "OffGridState",
+    "PVState",
+    "PowerControllerResult",
+    "RegulationRuntimeState",
+    "StrategicState",
+    "StrategyContext",
+    "StrategyDecision",
+    "StrategyIntent",
+    "ValueValidity",
+    "VisibleState",
+]

--- a/custom_components/battery_smartflow_ai/core/models/device.py
+++ b/custom_components/battery_smartflow_ai/core/models/device.py
@@ -1,0 +1,41 @@
+"""Neutral device capability models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True, slots=True)
+class DeviceCapabilities:
+    """Capabilities consumed by the core without identifying a manufacturer."""
+
+    max_input_w: float
+    max_output_w: float
+    supports_passthrough: bool = False
+    supports_fast_mode_switch: bool = False
+    supports_offgrid_socket: bool = False
+    supports_offgrid_input: bool = False
+    offgrid_max_internal_supply_w: float = 0.0
+
+    @classmethod
+    def from_profile(cls, profile: Mapping[str, Any]) -> DeviceCapabilities:
+        """Adapt the existing V4.6 profile mapping without changing its schema."""
+
+        return cls(
+            max_input_w=float(profile.get("MAX_INPUT_W", 0.0) or 0.0),
+            max_output_w=float(profile.get("MAX_OUTPUT_W", 0.0) or 0.0),
+            supports_passthrough=bool(profile.get("SUPPORTS_PASSTHROUGH", False)),
+            supports_fast_mode_switch=bool(
+                profile.get("SUPPORTS_FAST_MODE_SWITCH", False)
+            ),
+            supports_offgrid_socket=bool(
+                profile.get("SUPPORTS_OFFGRID_SOCKET", False)
+            ),
+            supports_offgrid_input=bool(
+                profile.get("SUPPORTS_OFFGRID_INPUT", False)
+            ),
+            offgrid_max_internal_supply_w=float(
+                profile.get("OFFGRID_MAX_INTERNAL_SUPPLY_W", 0.0) or 0.0
+            ),
+        )

--- a/custom_components/battery_smartflow_ai/core/models/market.py
+++ b/custom_components/battery_smartflow_ai/core/models/market.py
@@ -1,0 +1,83 @@
+"""Canonical core market-price models shared by import and export prices.
+
+The models in this module deliberately contain no Home Assistant or provider
+knowledge. Price sources and adapters are responsible for normalizing their
+input before constructing these immutable values.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+
+
+class MarketPriceDirection(StrEnum):
+    """Direction in which energy crosses the grid connection."""
+
+    IMPORT = "import"
+    EXPORT = "export"
+
+
+class MarketPriceValidity(StrEnum):
+    """Normalized reason why a market price is or is not usable."""
+
+    VALID = "valid"
+    MISSING = "missing"
+    UNKNOWN = "unknown"
+    UNAVAILABLE = "unavailable"
+    STALE = "stale"
+    INVALID = "invalid"
+
+
+@dataclass(frozen=True, slots=True)
+class MarketPricePoint:
+    """One normalized market price interval in active currency per kWh."""
+
+    start: datetime
+    end: datetime
+    price: float
+
+
+@dataclass(frozen=True, slots=True)
+class MarketPriceForecast:
+    """Optional normalized price intervals supplied by one market source."""
+
+    points: tuple[MarketPricePoint, ...]
+    timestamp: datetime | None = None
+
+    @classmethod
+    def empty(cls, *, timestamp: datetime | None = None) -> MarketPriceForecast:
+        """Return an explicit empty forecast without inventing price data."""
+
+        return cls(points=(), timestamp=timestamp)
+
+
+@dataclass(frozen=True, slots=True)
+class MarketPrice:
+    """Current import or export price and its optional normalized forecast.
+
+    ``current_price`` is expressed in ``unit`` and may legitimately be zero or
+    negative. Missing and unavailable values remain ``None`` and are described
+    by ``validity``; they are never replaced with a synthetic zero price.
+    """
+
+    direction: MarketPriceDirection
+    current_price: float | None
+    currency: str
+    unit: str
+    timestamp: datetime | None
+    source: str
+    validity: MarketPriceValidity
+    is_dynamic: bool
+    is_fallback: bool
+    forecast: MarketPriceForecast | None = None
+
+    @property
+    def valid(self) -> bool:
+        """Return whether a real current price is available for calculations."""
+
+        return (
+            self.validity is MarketPriceValidity.VALID
+            and self.current_price is not None
+        )

--- a/custom_components/battery_smartflow_ai/core/models/regulation.py
+++ b/custom_components/battery_smartflow_ai/core/models/regulation.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Literal
+
+
+StrategyIntentType = Literal[
+    "idle",
+    "pv_charge",
+    "planned_charge",
+    "manual_charge",
+    "emergency_charge",
+    "cover_deficit",
+    "peak_discharge",
+    "arbitrage_discharge",
+    "manual_discharge",
+    "manual_constant_discharge",
+    "passthrough",
+]
+
+RequestedMode = Literal[
+    "input",
+    "output",
+    "idle",
+]
+
+ResolvedMode = Literal[
+    "input",
+    "output",
+    "idle",
+    "hold",
+    "ramp_down_output",
+    "ramp_down_input",
+]
+
+RegulationState = Literal[
+    "none",
+    "pv_charge_active",
+    "discharge_active",
+    "passthrough_active",
+    "neutral_hold",
+]
+
+CommandSkipReason = Literal[
+    "none",
+    "unchanged",
+    "change_too_small",
+    "invalid_entity",
+    "cooldown_active",
+    "mode_hold_active",
+]
+
+AutomaticWeighting = Literal[
+    "inactive",
+    "pv_oriented",
+    "balanced",
+    "price_oriented",
+    "reserve_oriented",
+]
+
+SeasonContext = Literal[
+    "neutral",
+    "summer_like",
+    "winter_like",
+]
+
+PvHandoverPolicy = Literal[
+    "default",
+    "fast",
+    "stable",
+]
+
+
+@dataclass
+class StrategyIntent:
+    """Strategic intent produced from the Decision Engine result.
+
+    This is the semantic bridge between the existing Decision Engine and the
+    new technical regulation layer.
+
+    Important:
+    INPUT is not enough as a meaning. PV charging, planned grid charging and
+    emergency charging are all INPUT technically, but they need different
+    regulation behavior.
+    """
+
+    intent: StrategyIntentType
+    requested_mode: RequestedMode
+    requested_power_w: float | None
+    reason: str
+
+    priority: int = 0
+    allow_mode_switch: bool = True
+    force: bool = False
+
+    # V4.3.0-dev5.7:
+    # Technical handover behavior for PV charging.
+    #
+    # fast:
+    #   Strategic PV confirmation is sufficient. The technical layer should
+    #   avoid repeating the same export confirmation unnecessarily.
+    #
+    # stable:
+    #   Preserve stronger technical hysteresis because continuous house-load
+    #   coverage has priority and clouds must not cause INPUT/OUTPUT flapping.
+    #
+    # default:
+    #   Conservative compatibility behavior.
+    pv_handover_policy: PvHandoverPolicy = "default"
+    load_coverage_priority: bool = False
+
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class AutomaticStrategyResult:
+    """High-level weighting result produced by the automatic strategy."""
+
+    active: bool = False
+
+    weighting: AutomaticWeighting = "inactive"
+    season_context: SeasonContext = "neutral"
+
+    pv_weight: float = 0.0
+    price_weight: float = 0.0
+    reserve_weight: float = 0.0
+    forecast_weight: float = 0.0
+
+    reason: str = "not_evaluated"
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+# Compatibility name used by V4.6 callers.  It is an output/result, not the
+# runtime input model introduced by Issue #268.
+StrategyContext = AutomaticStrategyResult
+
+
+@dataclass
+class GridHistoryState:
+    """Short signed grid history used by the ModeArbiter and PowerController.
+
+    Internal convention:
+    grid_power_w > 0  = grid import / Netzbezug
+    grid_power_w < 0  = grid export / Einspeisung
+    """
+
+    grid_now_w: float = 0.0
+    grid_avg_short_w: float = 0.0
+    grid_avg_medium_w: float = 0.0
+    grid_delta_w: float = 0.0
+
+    stable_import_cycles: int = 0
+    stable_export_cycles: int = 0
+    near_target_cycles: int = 0
+
+    fast_load_rise_detected: bool = False
+    fast_load_drop_detected: bool = False
+
+    post_load_drop_hold_active: bool = False
+    post_output_overshoot_hold_active: bool = False
+
+
+@dataclass
+class ModeArbiterResult:
+    """Result of the technical mode permission layer."""
+
+    requested_mode: RequestedMode
+    resolved_mode: ResolvedMode
+
+    allowed: bool
+    reason: str
+
+    active_regulation_state: RegulationState = "none"
+    active_hold_remaining_s: float = 0.0
+    cooldown_remaining_s: float = 0.0
+
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class PowerControllerResult:
+    """Result of the technical power calculation layer."""
+
+    raw_target_w: float = 0.0
+    limited_target_w: float = 0.0
+    applied_step_w: float = 0.0
+    final_power_w: float = 0.0
+
+    profile_limited: bool = False
+    step_limited: bool = False
+
+    reason: str = "none"
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ChargeSourceAllocation:
+    """Calculated source split for an active strategic AC charge binding.
+
+    V4.4.0-dev8:
+    Source allocation plus the effective total AC input command. The device
+    cannot distinguish PV power from grid power at its AC input.
+
+    total_target_w:
+        Strategic total battery charge target.
+
+    pv_available_w:
+        Estimated PV power remaining after house load.
+
+    pv_allocated_w:
+        PV contribution assigned to the total charge target.
+
+    grid_requested_w:
+        Remaining AC/grid contribution required to reach the total target.
+
+    device_input_w:
+        Total AC input power to request from the battery. This includes the PV
+        contribution and must never be replaced by the grid contribution alone.
+
+    unfilled_w:
+        Part of the total target that cannot be covered because the grid input
+        limit is lower than the required remaining power.
+    """
+
+    active: bool = False
+
+    total_target_w: float = 0.0
+    pv_available_w: float = 0.0
+    pv_allocated_w: float = 0.0
+    grid_requested_w: float = 0.0
+    device_input_w: float = 0.0
+    unfilled_w: float = 0.0
+
+    pv_share_pct: float = 0.0
+    grid_share_pct: float = 0.0
+
+    reason: str = "inactive"
+
+
+@dataclass
+class DeviceCommand:
+    """Neutral device command produced by the core regulation layer."""
+
+    ac_mode: Literal["input", "output"]
+    input_limit_w: float = 0.0
+    output_limit_w: float = 0.0
+
+    reason: str = "none"
+
+    should_write_mode: bool = True
+    should_write_input: bool = True
+    should_write_output: bool = True
+
+    skipped: bool = False
+    skip_reason: CommandSkipReason = "none"
+
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class RegulationRuntimeState:
+    """Persistable runtime state for the new technical regulation layer."""
+
+    last_resolved_mode: ResolvedMode = "idle"
+    last_requested_mode: RequestedMode = "idle"
+
+    last_ac_mode: str | None = None
+    last_input_limit_w: float = 0.0
+    last_output_limit_w: float = 0.0
+
+    last_mode_change_ts: datetime | None = None
+    last_command_ts: datetime | None = None
+
+    active_regulation_state: RegulationState = "none"
+    active_state_started_ts: datetime | None = None
+
+    post_load_drop_hold_until: datetime | None = None
+    post_output_overshoot_hold_until: datetime | None = None
+
+    pv_charge_latch_started_ts: datetime | None = None
+    discharge_latch_started_ts: datetime | None = None
+    passthrough_latch_started_ts: datetime | None = None
+
+    skipped_write_reason: str = "none"

--- a/custom_components/battery_smartflow_ai/core/models/states.py
+++ b/custom_components/battery_smartflow_ai/core/models/states.py
@@ -1,0 +1,109 @@
+"""Neutral measured states shared by BSFAI core areas.
+
+These models deliberately keep measurement validity separate from the numeric
+value.  Adapters translate platform-specific states such as ``unknown`` and
+``unavailable`` before constructing them.  Issue #268 will compose these
+parts into the single runtime input; this module does not introduce a second
+aggregate context.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+from typing import Generic, TypeVar
+
+
+ValueT = TypeVar("ValueT")
+
+
+class ValueValidity(StrEnum):
+    """Platform-neutral availability and data-quality classification."""
+
+    VALID = "valid"
+    MISSING = "missing"
+    UNKNOWN = "unknown"
+    UNAVAILABLE = "unavailable"
+    STALE = "stale"
+    INVALID = "invalid"
+
+
+@dataclass(frozen=True, slots=True)
+class MeasuredValue(Generic[ValueT]):
+    """A normalized value with explicit validity and optional observation time."""
+
+    value: ValueT | None
+    validity: ValueValidity
+    observed_at: datetime | None = None
+
+    @property
+    def valid(self) -> bool:
+        """Return whether the value is usable by core calculations."""
+
+        return self.validity is ValueValidity.VALID and self.value is not None
+
+    @classmethod
+    def available(
+        cls,
+        value: ValueT,
+        *,
+        observed_at: datetime | None = None,
+    ) -> MeasuredValue[ValueT]:
+        """Construct a valid normalized measurement."""
+
+        return cls(value=value, validity=ValueValidity.VALID, observed_at=observed_at)
+
+    @classmethod
+    def absent(
+        cls,
+        validity: ValueValidity,
+        *,
+        observed_at: datetime | None = None,
+    ) -> MeasuredValue[ValueT]:
+        """Construct a measurement without inventing a fallback value."""
+
+        if validity is ValueValidity.VALID:
+            raise ValueError("an absent measurement cannot be valid")
+        return cls(value=None, validity=validity, observed_at=observed_at)
+
+
+@dataclass(frozen=True, slots=True)
+class BatteryState:
+    """Normalized battery measurements; limits remain configuration."""
+
+    soc_pct: MeasuredValue[float]
+    charge_power_w: MeasuredValue[float]
+    discharge_power_w: MeasuredValue[float]
+
+
+@dataclass(frozen=True, slots=True)
+class GridState:
+    """Normalized grid flow using positive import and positive export values."""
+
+    import_power_w: MeasuredValue[float]
+    export_power_w: MeasuredValue[float]
+
+
+@dataclass(frozen=True, slots=True)
+class PVState:
+    """Normalized PV production and house-load measurements."""
+
+    production_power_w: MeasuredValue[float]
+    house_load_power_w: MeasuredValue[float]
+
+
+@dataclass(frozen=True, slots=True)
+class OffGridState:
+    """Optional off-grid socket measurements without HA entity information."""
+
+    active: MeasuredValue[bool]
+    output_power_w: MeasuredValue[float]
+
+
+@dataclass(frozen=True, slots=True)
+class AdditionalBatteryState:
+    """Optional external battery flows normalized to positive magnitudes."""
+
+    charge_power_w: MeasuredValue[float]
+    discharge_power_w: MeasuredValue[float]

--- a/custom_components/battery_smartflow_ai/core/models/strategy.py
+++ b/custom_components/battery_smartflow_ai/core/models/strategy.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import StrEnum
+from typing import Any, Literal
+
+
+class StrategicState(StrEnum):
+    PROTECTION = "protection"
+    EMERGENCY_CHARGE = "emergency_charge"
+
+    MANUAL_CHARGE = "manual_charge"
+    MANUAL_DISCHARGE = "manual_discharge"
+    MANUAL_IDLE = "manual_idle"
+
+    AC_CHARGE_COMMITTED = "ac_charge_committed"
+    AC_CHARGE_PLANNED = "ac_charge_planned"
+    AC_CHARGE_PRICE = "ac_charge_price"
+    AC_CHARGE_LEARNED = "ac_charge_learned"
+    AC_CHARGE_RESERVE = "ac_charge_reserve"
+
+    PV_SURPLUS_CHARGE = "pv_surplus_charge"
+
+    LOAD_COVERAGE = "load_coverage"
+    ECONOMIC_DISCHARGE = "economic_discharge"
+    OFFGRID_SUPPORT = "offgrid_support"
+    PASSTHROUGH = "passthrough"
+
+    HOLD = "hold"
+    IDLE_READY = "idle_ready"
+    IDLE_SAFE = "idle_safe"
+
+
+class VisibleState(StrEnum):
+    READY = "ready"
+    SAFE_IDLE = "safe_idle"
+    PROTECTION_ACTIVE = "protection_active"
+    EMERGENCY_CHARGE = "emergency_charge"
+    MANUAL = "manual"
+
+    GRID_CHARGE = "grid_charge"
+    PV_CHARGE = "pv_charge"
+    RESERVE_CHARGE = "reserve_charge"
+
+    AUTARKY_COVER = "autarky_cover"
+    LOAD_COVERAGE = "load_coverage"
+    ECONOMIC_DISCHARGE = "economic_discharge"
+
+    WAITING_FOR_CHARGE_WINDOW = "waiting_for_charge_window"
+    WAITING_BLOCKED = "waiting_blocked"
+    HOLD = "hold"
+
+
+RequestedMode = Literal["input", "output", "idle"]
+
+ChargeCommitPhase = Literal[
+    "waiting",
+    "active",
+    "forced",
+    "completed",
+    "aborted",
+]
+
+
+@dataclass
+class StrategyDecision:
+    """Normalized strategic result before technical regulation."""
+    state: StrategicState
+    visible_state: VisibleState
+    requested_mode: RequestedMode
+    requested_power_w: float | None
+    strategic_reason: str
+    source_reason: str
+    source_action: str
+    source_ac_mode: str
+    priority: int
+    target_soc: float | None = None
+    allow_mode_switch: bool = True
+    force: bool = False
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ChargeCommitState:
+    """Persistable neutral lifecycle state for a committed charge plan."""
+    active: bool = False
+
+    # Runtime phase of the charge binding.
+    #
+    # waiting:
+    #   The plan remains valid, but AC charging is currently paused.
+    #
+    # active:
+    #   AC charging is currently economically permitted.
+    #
+    # forced:
+    #   The latest possible start has been reached. Charging must continue
+    #   so the required energy can still be available before the deadline.
+    #
+    # completed / aborted:
+    #   Terminal diagnostic states. The persisted active flag is False.
+    phase: ChargeCommitPhase = "waiting"
+
+    commit_type: str = "none"
+    source_state: str = ""
+    source_reason: str = ""
+    strategic_reason: str = ""
+
+    target_soc: float | None = None
+    max_soc: float | None = None
+
+    started_at: datetime | None = None
+    updated_at: datetime | None = None
+    valid_until: datetime | None = None
+
+    # Planning timestamps.
+    optimal_start: datetime | None = None
+    latest_start: datetime | None = None
+    deadline: datetime | None = None
+
+    # Economic boundary for planned/learned charging.
+    acceptable_price_per_kwh: float | None = None
+
+    requested_power_w: float | None = None
+    allow_pv_blend: bool = True
+    abort_reason: str = "none"

--- a/custom_components/battery_smartflow_ai/market_price/models.py
+++ b/custom_components/battery_smartflow_ai/market_price/models.py
@@ -1,83 +1,17 @@
-"""Canonical market price models shared by import and export prices.
+"""Compatibility exports for canonical core market-price models."""
 
-The models in this module deliberately contain no Home Assistant or provider
-knowledge. Price sources and adapters are responsible for normalizing their
-input before constructing these immutable values.
-"""
+from ..core.models.market import (
+    MarketPrice,
+    MarketPriceDirection,
+    MarketPriceForecast,
+    MarketPricePoint,
+    MarketPriceValidity,
+)
 
-from __future__ import annotations
-
-from dataclasses import dataclass
-from datetime import datetime
-from enum import StrEnum
-
-
-class MarketPriceDirection(StrEnum):
-    """Direction in which energy crosses the grid connection."""
-
-    IMPORT = "import"
-    EXPORT = "export"
-
-
-class MarketPriceValidity(StrEnum):
-    """Normalized reason why a market price is or is not usable."""
-
-    VALID = "valid"
-    MISSING = "missing"
-    UNKNOWN = "unknown"
-    UNAVAILABLE = "unavailable"
-    STALE = "stale"
-    INVALID = "invalid"
-
-
-@dataclass(frozen=True, slots=True)
-class MarketPricePoint:
-    """One normalized market price interval in active currency per kWh."""
-
-    start: datetime
-    end: datetime
-    price: float
-
-
-@dataclass(frozen=True, slots=True)
-class MarketPriceForecast:
-    """Optional normalized price intervals supplied by one market source."""
-
-    points: tuple[MarketPricePoint, ...]
-    timestamp: datetime | None = None
-
-    @classmethod
-    def empty(cls, *, timestamp: datetime | None = None) -> MarketPriceForecast:
-        """Return an explicit empty forecast without inventing price data."""
-
-        return cls(points=(), timestamp=timestamp)
-
-
-@dataclass(frozen=True, slots=True)
-class MarketPrice:
-    """Current import or export price and its optional normalized forecast.
-
-    ``current_price`` is expressed in ``unit`` and may legitimately be zero or
-    negative. Missing and unavailable values remain ``None`` and are described
-    by ``validity``; they are never replaced with a synthetic zero price.
-    """
-
-    direction: MarketPriceDirection
-    current_price: float | None
-    currency: str
-    unit: str
-    timestamp: datetime | None
-    source: str
-    validity: MarketPriceValidity
-    is_dynamic: bool
-    is_fallback: bool
-    forecast: MarketPriceForecast | None = None
-
-    @property
-    def valid(self) -> bool:
-        """Return whether a real current price is available for calculations."""
-
-        return (
-            self.validity is MarketPriceValidity.VALID
-            and self.current_price is not None
-        )
+__all__ = [
+    "MarketPrice",
+    "MarketPriceDirection",
+    "MarketPriceForecast",
+    "MarketPricePoint",
+    "MarketPriceValidity",
+]

--- a/custom_components/battery_smartflow_ai/regulation_models.py
+++ b/custom_components/battery_smartflow_ai/regulation_models.py
@@ -1,280 +1,46 @@
-from __future__ import annotations
+"""Compatibility exports for the neutral core regulation models.
 
-from dataclasses import dataclass, field
-from datetime import datetime
-from typing import Any, Literal
+New core code imports from :mod:`.core.models.regulation`. The historic
+module path remains available while V4.7 migrates existing callers in bounded
+steps.
+"""
 
+from .core.models.regulation import (
+    AutomaticWeighting,
+    AutomaticStrategyResult,
+    ChargeSourceAllocation,
+    CommandSkipReason,
+    DeviceCommand,
+    GridHistoryState,
+    ModeArbiterResult,
+    PowerControllerResult,
+    PvHandoverPolicy,
+    RegulationRuntimeState,
+    RegulationState,
+    RequestedMode,
+    ResolvedMode,
+    SeasonContext,
+    StrategyContext,
+    StrategyIntent,
+    StrategyIntentType,
+)
 
-StrategyIntentType = Literal[
-    "idle",
-    "pv_charge",
-    "planned_charge",
-    "manual_charge",
-    "emergency_charge",
-    "cover_deficit",
-    "peak_discharge",
-    "arbitrage_discharge",
-    "manual_discharge",
-    "manual_constant_discharge",
-    "passthrough",
+__all__ = [
+    "AutomaticStrategyResult",
+    "AutomaticWeighting",
+    "ChargeSourceAllocation",
+    "CommandSkipReason",
+    "DeviceCommand",
+    "GridHistoryState",
+    "ModeArbiterResult",
+    "PowerControllerResult",
+    "PvHandoverPolicy",
+    "RegulationRuntimeState",
+    "RegulationState",
+    "RequestedMode",
+    "ResolvedMode",
+    "SeasonContext",
+    "StrategyContext",
+    "StrategyIntent",
+    "StrategyIntentType",
 ]
-
-RequestedMode = Literal[
-    "input",
-    "output",
-    "idle",
-]
-
-ResolvedMode = Literal[
-    "input",
-    "output",
-    "idle",
-    "hold",
-    "ramp_down_output",
-    "ramp_down_input",
-]
-
-RegulationState = Literal[
-    "none",
-    "pv_charge_active",
-    "discharge_active",
-    "passthrough_active",
-    "neutral_hold",
-]
-
-CommandSkipReason = Literal[
-    "none",
-    "unchanged",
-    "change_too_small",
-    "invalid_entity",
-    "cooldown_active",
-    "mode_hold_active",
-]
-
-AutomaticWeighting = Literal[
-    "inactive",
-    "pv_oriented",
-    "balanced",
-    "price_oriented",
-    "reserve_oriented",
-]
-
-SeasonContext = Literal[
-    "neutral",
-    "summer_like",
-    "winter_like",
-]
-
-PvHandoverPolicy = Literal[
-    "default",
-    "fast",
-    "stable",
-]
-
-
-@dataclass
-class StrategyIntent:
-    """Strategic intent produced from the Decision Engine result.
-
-    This is the semantic bridge between the existing Decision Engine and the
-    new technical regulation layer.
-
-    Important:
-    INPUT is not enough as a meaning. PV charging, planned grid charging and
-    emergency charging are all INPUT technically, but they need different
-    regulation behavior.
-    """
-
-    intent: StrategyIntentType
-    requested_mode: RequestedMode
-    requested_power_w: float | None
-    reason: str
-
-    priority: int = 0
-    allow_mode_switch: bool = True
-    force: bool = False
-
-    # V4.3.0-dev5.7:
-    # Technical handover behavior for PV charging.
-    #
-    # fast:
-    #   Strategic PV confirmation is sufficient. The technical layer should
-    #   avoid repeating the same export confirmation unnecessarily.
-    #
-    # stable:
-    #   Preserve stronger technical hysteresis because continuous house-load
-    #   coverage has priority and clouds must not cause INPUT/OUTPUT flapping.
-    #
-    # default:
-    #   Conservative compatibility behavior.
-    pv_handover_policy: PvHandoverPolicy = "default"
-    load_coverage_priority: bool = False
-
-    metadata: dict[str, Any] = field(default_factory=dict)
-    
-
-@dataclass
-class StrategyContext:
-    """High-level context consumed by the unified automatic strategy."""
-
-    active: bool = False
-
-    weighting: AutomaticWeighting = "inactive"
-    season_context: SeasonContext = "neutral"
-
-    pv_weight: float = 0.0
-    price_weight: float = 0.0
-    reserve_weight: float = 0.0
-    forecast_weight: float = 0.0
-
-    reason: str = "not_evaluated"
-    metadata: dict[str, Any] = field(default_factory=dict)
-
-
-@dataclass
-class GridHistoryState:
-    """Short signed grid history used by the ModeArbiter and PowerController.
-
-    Internal convention:
-    grid_power_w > 0  = grid import / Netzbezug
-    grid_power_w < 0  = grid export / Einspeisung
-    """
-
-    grid_now_w: float = 0.0
-    grid_avg_short_w: float = 0.0
-    grid_avg_medium_w: float = 0.0
-    grid_delta_w: float = 0.0
-
-    stable_import_cycles: int = 0
-    stable_export_cycles: int = 0
-    near_target_cycles: int = 0
-
-    fast_load_rise_detected: bool = False
-    fast_load_drop_detected: bool = False
-
-    post_load_drop_hold_active: bool = False
-    post_output_overshoot_hold_active: bool = False
-
-
-@dataclass
-class ModeArbiterResult:
-    """Result of the technical mode permission layer."""
-
-    requested_mode: RequestedMode
-    resolved_mode: ResolvedMode
-
-    allowed: bool
-    reason: str
-
-    active_regulation_state: RegulationState = "none"
-    active_hold_remaining_s: float = 0.0
-    cooldown_remaining_s: float = 0.0
-
-    metadata: dict[str, Any] = field(default_factory=dict)
-
-
-@dataclass
-class PowerControllerResult:
-    """Result of the technical power calculation layer."""
-
-    raw_target_w: float = 0.0
-    limited_target_w: float = 0.0
-    applied_step_w: float = 0.0
-    final_power_w: float = 0.0
-
-    profile_limited: bool = False
-    step_limited: bool = False
-
-    reason: str = "none"
-    metadata: dict[str, Any] = field(default_factory=dict)
-
-
-@dataclass
-class ChargeSourceAllocation:
-    """Calculated source split for an active strategic AC charge binding.
-
-    V4.4.0-dev8:
-    Source allocation plus the effective total AC input command. The device
-    cannot distinguish PV power from grid power at its AC input.
-
-    total_target_w:
-        Strategic total battery charge target.
-
-    pv_available_w:
-        Estimated PV power remaining after house load.
-
-    pv_allocated_w:
-        PV contribution assigned to the total charge target.
-
-    grid_requested_w:
-        Remaining AC/grid contribution required to reach the total target.
-
-    device_input_w:
-        Total AC input power to request from the battery. This includes the PV
-        contribution and must never be replaced by the grid contribution alone.
-
-    unfilled_w:
-        Part of the total target that cannot be covered because the grid input
-        limit is lower than the required remaining power.
-    """
-
-    active: bool = False
-
-    total_target_w: float = 0.0
-    pv_available_w: float = 0.0
-    pv_allocated_w: float = 0.0
-    grid_requested_w: float = 0.0
-    device_input_w: float = 0.0
-    unfilled_w: float = 0.0
-
-    pv_share_pct: float = 0.0
-    grid_share_pct: float = 0.0
-
-    reason: str = "inactive"
-
-
-@dataclass
-class DeviceCommand:
-    """Final command that may be written to Home Assistant/Zendure entities."""
-
-    ac_mode: Literal["input", "output"]
-    input_limit_w: float = 0.0
-    output_limit_w: float = 0.0
-
-    reason: str = "none"
-
-    should_write_mode: bool = True
-    should_write_input: bool = True
-    should_write_output: bool = True
-
-    skipped: bool = False
-    skip_reason: CommandSkipReason = "none"
-
-    metadata: dict[str, Any] = field(default_factory=dict)
-
-
-@dataclass
-class RegulationRuntimeState:
-    """Persistable runtime state for the new technical regulation layer."""
-
-    last_resolved_mode: ResolvedMode = "idle"
-    last_requested_mode: RequestedMode = "idle"
-
-    last_ac_mode: str | None = None
-    last_input_limit_w: float = 0.0
-    last_output_limit_w: float = 0.0
-
-    last_mode_change_ts: datetime | None = None
-    last_command_ts: datetime | None = None
-
-    active_regulation_state: RegulationState = "none"
-    active_state_started_ts: datetime | None = None
-
-    post_load_drop_hold_until: datetime | None = None
-    post_output_overshoot_hold_until: datetime | None = None
-
-    pv_charge_latch_started_ts: datetime | None = None
-    discharge_latch_started_ts: datetime | None = None
-    passthrough_latch_started_ts: datetime | None = None
-
-    skipped_write_reason: str = "none"

--- a/custom_components/battery_smartflow_ai/strategy_state.py
+++ b/custom_components/battery_smartflow_ai/strategy_state.py
@@ -1,125 +1,19 @@
-from __future__ import annotations
+"""Compatibility exports for neutral core strategy state models."""
 
-from dataclasses import dataclass, field
-from datetime import datetime
-from enum import StrEnum
-from typing import Any, Literal
+from .core.models.strategy import (
+    ChargeCommitPhase,
+    ChargeCommitState,
+    RequestedMode,
+    StrategicState,
+    StrategyDecision,
+    VisibleState,
+)
 
-
-class StrategicState(StrEnum):
-    PROTECTION = "protection"
-    EMERGENCY_CHARGE = "emergency_charge"
-
-    MANUAL_CHARGE = "manual_charge"
-    MANUAL_DISCHARGE = "manual_discharge"
-    MANUAL_IDLE = "manual_idle"
-
-    AC_CHARGE_COMMITTED = "ac_charge_committed"
-    AC_CHARGE_PLANNED = "ac_charge_planned"
-    AC_CHARGE_PRICE = "ac_charge_price"
-    AC_CHARGE_LEARNED = "ac_charge_learned"
-    AC_CHARGE_RESERVE = "ac_charge_reserve"
-
-    PV_SURPLUS_CHARGE = "pv_surplus_charge"
-
-    LOAD_COVERAGE = "load_coverage"
-    ECONOMIC_DISCHARGE = "economic_discharge"
-    OFFGRID_SUPPORT = "offgrid_support"
-    PASSTHROUGH = "passthrough"
-
-    HOLD = "hold"
-    IDLE_READY = "idle_ready"
-    IDLE_SAFE = "idle_safe"
-
-
-class VisibleState(StrEnum):
-    READY = "ready"
-    SAFE_IDLE = "safe_idle"
-    PROTECTION_ACTIVE = "protection_active"
-    EMERGENCY_CHARGE = "emergency_charge"
-    MANUAL = "manual"
-
-    GRID_CHARGE = "grid_charge"
-    PV_CHARGE = "pv_charge"
-    RESERVE_CHARGE = "reserve_charge"
-
-    AUTARKY_COVER = "autarky_cover"
-    LOAD_COVERAGE = "load_coverage"
-    ECONOMIC_DISCHARGE = "economic_discharge"
-
-    WAITING_FOR_CHARGE_WINDOW = "waiting_for_charge_window"
-    WAITING_BLOCKED = "waiting_blocked"
-    HOLD = "hold"
-
-
-RequestedMode = Literal["input", "output", "idle"]
-
-ChargeCommitPhase = Literal[
-    "waiting",
-    "active",
-    "forced",
-    "completed",
-    "aborted",
+__all__ = [
+    "ChargeCommitPhase",
+    "ChargeCommitState",
+    "RequestedMode",
+    "StrategicState",
+    "StrategyDecision",
+    "VisibleState",
 ]
-
-
-@dataclass
-class StrategyDecision:
-    state: StrategicState
-    visible_state: VisibleState
-    requested_mode: RequestedMode
-    requested_power_w: float | None
-    strategic_reason: str
-    source_reason: str
-    source_action: str
-    source_ac_mode: str
-    priority: int
-    target_soc: float | None = None
-    allow_mode_switch: bool = True
-    force: bool = False
-    metadata: dict[str, Any] = field(default_factory=dict)
-
-
-@dataclass
-class ChargeCommitState:
-    active: bool = False
-
-    # Runtime phase of the charge binding.
-    #
-    # waiting:
-    #   The plan remains valid, but AC charging is currently paused.
-    #
-    # active:
-    #   AC charging is currently economically permitted.
-    #
-    # forced:
-    #   The latest possible start has been reached. Charging must continue
-    #   so the required energy can still be available before the deadline.
-    #
-    # completed / aborted:
-    #   Terminal diagnostic states. The persisted active flag is False.
-    phase: ChargeCommitPhase = "waiting"
-
-    commit_type: str = "none"
-    source_state: str = ""
-    source_reason: str = ""
-    strategic_reason: str = ""
-
-    target_soc: float | None = None
-    max_soc: float | None = None
-
-    started_at: datetime | None = None
-    updated_at: datetime | None = None
-    valid_until: datetime | None = None
-
-    # Planning timestamps.
-    optimal_start: datetime | None = None
-    latest_start: datetime | None = None
-    deadline: datetime | None = None
-
-    # Economic boundary for planned/learned charging.
-    acceptable_price_per_kwh: float | None = None
-
-    requested_power_w: float | None = None
-    allow_pv_blend: bool = True
-    abort_reason: str = "none"

--- a/docs/architecture/core-models-v4.7.0.md
+++ b/docs/architecture/core-models-v4.7.0.md
@@ -1,0 +1,169 @@
+# V4.7.0: Gemeinsame Core-Datenmodelle
+
+- Status: Implementierungsentscheidung für Issue #267
+- Basis: `main` nach Merge von PR #293
+- Zielarchitektur: `core-ha-target-architecture-v4.7.0.md`
+- Scope: neutrale Modellgrenzen und kompatible Konsolidierung, kein RuntimeSnapshot
+
+## Ergebnis
+
+Gemeinsam verwendete, plattformunabhängige Modelle besitzen ab #267 den
+kanonischen Importpfad:
+
+```python
+from custom_components.battery_smartflow_ai.core.models import ...
+```
+
+Die bisherigen Pfade bleiben während der schrittweisen V4.7-Migration als
+Kompatibilitätsfassaden erhalten. Sie definieren keine zweiten Klassen, sondern
+exportieren dieselben Klassenobjekte.
+
+## Kanonische Modellgruppen
+
+### Messwerte und fachliche Teilzustände
+
+`core/models/states.py` definiert:
+
+- `ValueValidity`
+- `MeasuredValue[T]`
+- `BatteryState`
+- `GridState`
+- `PVState`
+- `OffGridState`
+- `AdditionalBatteryState`
+
+`MeasuredValue` trennt den Wert von seiner fachlichen Verwendbarkeit. Damit
+bleiben insbesondere folgende Fälle unterscheidbar:
+
+- echter numerischer Wert `0`
+- fehlender Wert
+- unbekannter Wert
+- nicht verfügbarer Wert
+- veralteter Wert
+- ungültiger Wert
+
+Die Modelle enthalten keine Entity-ID, HA-State-Objekte, Registries, Services
+oder Übersetzungsschlüssel. Der spätere HA-Adapter ist dafür verantwortlich,
+Home-Assistant-Zustände in diese neutralen Kategorien zu übersetzen.
+
+Die Teilzustände werden in #267 noch nicht zu einem weiteren Sammelkontext
+zusammengesetzt. Issue #268 führt genau eine zentrale Runtime-Eingabe ein und
+ordnet dort auch Zeitstempel, Konfiguration, Forecast und Teilzustände zu.
+
+### Strategie und Regelung
+
+Die vorhandenen Modelle aus `regulation_models.py` und `strategy_state.py`
+liegen kanonisch unter `core/models/`:
+
+- `StrategyDecision`
+- `StrategyIntent`
+- `AutomaticStrategyResult`
+- `ChargeCommitState`
+- `ModeArbiterResult`
+- `PowerControllerResult`
+- `ChargeSourceAllocation`
+- `DeviceCommand`
+- `GridHistoryState`
+- `RegulationRuntimeState`
+
+Der bisherige Name `StrategyContext` bleibt als Alias für
+`AutomaticStrategyResult` erhalten. Das Modell ist das Ergebnis der
+AutomaticStrategy und keine zweite Runtime-Eingabe. Diese Einordnung verhindert
+eine Doppelung mit dem in #268 entstehenden Eingabemodell.
+
+`StrategyIntent` bleibt die fachliche gewünschte Wirkung. `DeviceCommand`
+bleibt der technisch freigegebene neutrale Gerätebefehl. Die vorhandenen
+Schreibflags des Commands werden in #267 nicht verändert; ihre endgültige
+Zuordnung zur Core-/Backend-Grenze gehört zu #269.
+
+### Marktpreise
+
+Die bereits in V4.5/V4.6 konsolidierten Marktpreismodelle sind kanonische
+Core-Modelle:
+
+- `MarketPrice`
+- `MarketPriceDirection`
+- `MarketPriceValidity`
+- `MarketPricePoint`
+- `MarketPriceForecast`
+
+Es entsteht kein zusätzliches `MarketState`, das dieselben Informationen nur
+noch einmal verpackt. Insbesondere bleiben echter Nullpreis, negative Preise
+und fehlende oder nicht verfügbare Preise unterscheidbar.
+
+Der historische Importpfad `market_price.models` bleibt kompatibel und
+exportiert dieselben Klassenobjekte.
+
+### Wirtschaft
+
+Die vorhandenen neutralen Modelle in `economics.py` bleiben gültig:
+
+- `EconomicEnergyFlows`
+- `PriceableEnergyFlows`
+- `EconomicPowerFlows`
+- `EnergyAccumulatorSnapshot`
+- `EnergyAccumulationResult`
+- `EconomicsSnapshot`
+
+Sie werden in #267 nicht durch ein allgemeines `EconomicsState` dupliziert.
+Die spätere physische Zuordnung des Economics-Lifecycles und seiner Persistenz
+erfolgt mit dem dafür vorgesehenen Issue #276.
+
+### Planung
+
+Die vorhandenen Planungsmodelle wie `LearnedChargePlan`,
+`LearningReadiness` und normalisierte Marktpreisintervalle werden nicht in ein
+inhaltsleeres `PlanningState` kopiert. Issue #268 bindet die tatsächlich von
+der Decision Engine benötigten Planungsdaten in die zentrale Eingabe ein.
+
+### Gerätefähigkeiten
+
+`DeviceCapabilities` beschreibt ausschließlich Fähigkeiten und technische
+Grenzen, die der Core benötigt:
+
+- maximale Eingangs- und Ausgangsleistung
+- Passthrough-Unterstützung
+- schneller Moduswechsel
+- Off-Grid-Socket und Off-Grid-Input
+- interne Off-Grid-Versorgungsgrenze
+
+Das Modell enthält weder Hersteller noch Modellname noch Entity- oder
+Serviceinformationen. `from_profile()` bildet das bestehende V4.6-Profil-
+Dictionary verlustfrei auf diese Teilmenge ab. Das Profil-Dictionary selbst
+bleibt in #267 unverändert; seine schrittweise Typisierung gehört zu #272.
+
+## Kompatibilitätsregeln
+
+- Bestehende Imports aus `regulation_models.py`, `strategy_state.py` und
+  `market_price/models.py` bleiben funktionsfähig.
+- Die Fassaden exportieren dieselben Klassenobjekte; es gibt keine parallelen
+  Dataclass-Definitionen und keine Konvertierung im laufenden Steuerungspfad.
+- Feldnamen, Standardwerte, Mutable-/Frozen-Verhalten und Command-Semantik der
+  bestehenden Modelle bleiben unverändert.
+- Store-, Config- und Diagnoseformate ändern sich nicht.
+- Der Coordinator baut in #267 noch keinen neuen Snapshot.
+- Kein Gerätelimit und keine Capability wird neu interpretiert.
+
+## Nachweis
+
+Die Core-Modelltests prüfen:
+
+- Instanziierung ohne Home-Assistant-Objekte
+- keine `homeassistant`-Imports unter `core/models/`
+- explizite Unterscheidung von `0` und nicht verfügbarem Wert
+- neutrale Abbildung vorhandener Geräteprofile
+- Identität der alten und neuen Importpfade
+- unveränderte Marktpreissemantik für Nullpreise
+
+Die vollständige Regressionstestsuite schützt zusätzlich das bestehende
+Strategie-, Regelungs-, Marktpreis-, Wirtschafts- und Home-Assistant-Verhalten.
+
+## Bewusst nicht Teil von #267
+
+- kein `RuntimeSnapshot`; dieser entsteht in #268
+- keine Umstellung des Coordinators auf die neuen Teilzustände
+- keine neue Command-Ausführung oder DeviceBackend-Implementierung
+- keine StateStore- oder Clock-Abstraktion
+- keine vollständige Typisierung der Geräteprofile
+- keine Änderung an Planning- oder Economics-Lifecycle
+- keine neue Strategie, Regelung oder Geräteunterstützung

--- a/tests/test_core_models.py
+++ b/tests/test_core_models.py
@@ -1,0 +1,138 @@
+"""Contracts for the platform-independent V4.7 core models."""
+
+from __future__ import annotations
+
+import ast
+from datetime import datetime, timezone
+from pathlib import Path
+import unittest
+
+from support import PACKAGE_ROOT, bootstrap
+
+
+bootstrap()
+
+from custom_components.battery_smartflow_ai.core.models import (  # noqa: E402
+    AdditionalBatteryState,
+    AutomaticStrategyResult,
+    BatteryState,
+    DeviceCapabilities,
+    DeviceCommand,
+    GridState,
+    MarketPrice,
+    MarketPriceDirection,
+    MarketPriceValidity,
+    MeasuredValue,
+    OffGridState,
+    PVState,
+    StrategyContext,
+    StrategyIntent,
+    ValueValidity,
+)
+from custom_components.battery_smartflow_ai.market_price.models import (  # noqa: E402
+    MarketPrice as LegacyMarketPrice,
+)
+from custom_components.battery_smartflow_ai.regulation_models import (  # noqa: E402
+    DeviceCommand as LegacyDeviceCommand,
+    StrategyIntent as LegacyStrategyIntent,
+)
+
+
+NOW = datetime(2026, 8, 26, 12, 0, tzinfo=timezone.utc)
+
+
+class CoreModelTests(unittest.TestCase):
+    def test_measurement_keeps_absence_distinct_from_zero(self) -> None:
+        zero = MeasuredValue.available(0.0, observed_at=NOW)
+        unavailable = MeasuredValue[float].absent(
+            ValueValidity.UNAVAILABLE,
+            observed_at=NOW,
+        )
+
+        self.assertTrue(zero.valid)
+        self.assertEqual(zero.value, 0.0)
+        self.assertFalse(unavailable.valid)
+        self.assertIsNone(unavailable.value)
+
+    def test_absent_measurement_rejects_valid_status(self) -> None:
+        with self.assertRaises(ValueError):
+            MeasuredValue[float].absent(ValueValidity.VALID)
+
+    def test_central_states_are_constructible_without_ha_objects(self) -> None:
+        number = MeasuredValue.available(100.0)
+        missing_number = MeasuredValue[float].absent(ValueValidity.MISSING)
+        active = MeasuredValue.available(True)
+
+        battery = BatteryState(number, number, missing_number)
+        grid = GridState(number, missing_number)
+        pv = PVState(number, number)
+        offgrid = OffGridState(active, missing_number)
+        additional = AdditionalBatteryState(missing_number, missing_number)
+
+        self.assertTrue(battery.soc_pct.valid)
+        self.assertEqual(grid.import_power_w.value, 100.0)
+        self.assertEqual(pv.house_load_power_w.value, 100.0)
+        self.assertTrue(offgrid.active.value)
+        self.assertFalse(additional.charge_power_w.valid)
+
+    def test_device_capabilities_adapt_existing_profile_mapping(self) -> None:
+        capabilities = DeviceCapabilities.from_profile(
+            {
+                "label": "vendor-specific display name is adapter data",
+                "MAX_INPUT_W": 2400.0,
+                "MAX_OUTPUT_W": 800.0,
+                "SUPPORTS_PASSTHROUGH": True,
+                "SUPPORTS_FAST_MODE_SWITCH": True,
+                "SUPPORTS_OFFGRID_SOCKET": False,
+            }
+        )
+
+        self.assertEqual(capabilities.max_input_w, 2400.0)
+        self.assertEqual(capabilities.max_output_w, 800.0)
+        self.assertTrue(capabilities.supports_passthrough)
+        self.assertFalse(capabilities.supports_offgrid_socket)
+        self.assertFalse(hasattr(capabilities, "manufacturer"))
+
+    def test_strategy_and_command_legacy_paths_export_canonical_types(self) -> None:
+        self.assertIs(LegacyStrategyIntent, StrategyIntent)
+        self.assertIs(LegacyDeviceCommand, DeviceCommand)
+        self.assertIs(StrategyContext, AutomaticStrategyResult)
+
+    def test_market_price_legacy_path_exports_canonical_type(self) -> None:
+        price = MarketPrice(
+            direction=MarketPriceDirection.IMPORT,
+            current_price=0.0,
+            currency="EUR",
+            unit="EUR/kWh",
+            timestamp=NOW,
+            source="normalized",
+            validity=MarketPriceValidity.VALID,
+            is_dynamic=True,
+            is_fallback=False,
+        )
+
+        self.assertIs(LegacyMarketPrice, MarketPrice)
+        self.assertTrue(price.valid)
+        self.assertEqual(price.current_price, 0.0)
+
+    def test_core_model_files_do_not_import_home_assistant(self) -> None:
+        model_root = PACKAGE_ROOT / "core" / "models"
+        violations: list[str] = []
+
+        for path in sorted(model_root.glob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Import):
+                    names = [alias.name for alias in node.names]
+                elif isinstance(node, ast.ImportFrom):
+                    names = [node.module or ""]
+                else:
+                    continue
+                if any(name == "homeassistant" or name.startswith("homeassistant.") for name in names):
+                    violations.append(str(path.relative_to(PACKAGE_ROOT)))
+
+        self.assertEqual(violations, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Zusammenfassung

- führt `core.models` als kanonischen, Home-Assistant-unabhängigen Modellbereich ein
- definiert explizite Messwertgültigkeit sowie neutrale Battery-, Grid-, PV-, Off-Grid- und Zusatzakku-Zustände
- konsolidiert bestehende Strategie-, Regelungs- und Marktpreismodelle ohne parallele Klassendefinitionen
- ordnet `StrategyContext` als kompatiblen Alias des kanonischen `AutomaticStrategyResult` ein
- ergänzt eine herstellerneutrale `DeviceCapabilities`-Beschreibung mit Adapter für die bestehenden V4.6-Profil-Dictionaries
- hält historische Importpfade als Identitäts-wahrende Kompatibilitätsfassaden stabil

## Modellgrenzen

- echter Wert `0` bleibt von missing, unknown, unavailable, stale und invalid unterscheidbar
- `StrategyIntent` bleibt fachliche gewünschte Wirkung
- `DeviceCommand` bleibt technisch freigegebener neutraler Befehl
- vorhandene Marktpreis- und Wirtschaftsmodelle werden nicht durch zusätzliche Wrapper dupliziert
- kein `RuntimeSnapshot`: die einzige zentrale Runtime-Eingabe bleibt bewusst Issue #268 vorbehalten
- keine Coordinator-, Store-, Config-, Entity- oder Gerätepfad-Umstellung

## Validierung

- 7 neue Core-Modelltests
- keine `homeassistant`-Imports unter `core/models/`
- Identität alter und neuer Importpfade geprüft
- `git diff --check`
- `python -m unittest discover -s tests -v`: 274 Tests bestanden

Closes #267