### PR TITLE
V4.7.0: Neutralen RuntimeSnapshot als Core-Eingabe einführen

### DIFF
--- a/custom_components/battery_smartflow_ai/coordinator.py
+++ b/custom_components/battery_smartflow_ai/coordinator.py
@@ -110,10 +110,10 @@ from .device_profiles import DEVICE_PROFILES, merge_profile_with_overrides
 from .decision_engine import (
     advance_pv_charge_hysteresis,
     compute_pv_attributable_export_w,
-    DecisionContext,
     DecisionEngine,
     DecisionResult,
 )
+from .core.models.runtime import RuntimeSnapshot
 from .forecast import build_forecast_summary
 from .learned_planning import (
     LearningSample,
@@ -4259,7 +4259,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     )
                 )
 
-            ctx = DecisionContext(
+            ctx = RuntimeSnapshot(
                 now=now,
                 soc=soc,
                 soc_min=float(soc_min),
@@ -5952,7 +5952,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 reason=display_decision.reason,
             )
 
-            transparency_ctx = DecisionContext(
+            transparency_ctx = RuntimeSnapshot(
                 now=now,
                 soc=soc,
                 soc_min=float(soc_min),

--- a/custom_components/battery_smartflow_ai/core/models/__init__.py
+++ b/custom_components/battery_smartflow_ai/core/models/__init__.py
@@ -19,6 +19,7 @@ from .regulation import (
     StrategyContext,
     StrategyIntent,
 )
+from .runtime import AiMode, DecisionContext, RuntimeSnapshot
 from .states import (
     AdditionalBatteryState,
     BatteryState,
@@ -37,12 +38,14 @@ from .strategy import (
 
 __all__ = [
     "AdditionalBatteryState",
+    "AiMode",
     "AutomaticStrategyResult",
     "BatteryState",
     "ChargeCommitState",
     "ChargeSourceAllocation",
     "DeviceCapabilities",
     "DeviceCommand",
+    "DecisionContext",
     "GridHistoryState",
     "GridState",
     "MarketPrice",
@@ -56,6 +59,7 @@ __all__ = [
     "PVState",
     "PowerControllerResult",
     "RegulationRuntimeState",
+    "RuntimeSnapshot",
     "StrategicState",
     "StrategyContext",
     "StrategyDecision",

--- a/custom_components/battery_smartflow_ai/core/models/runtime.py
+++ b/custom_components/battery_smartflow_ai/core/models/runtime.py
@@ -1,0 +1,262 @@
+"""Central normalized runtime input for BSFAI core decisions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Literal
+
+from .device import DeviceCapabilities
+from .market import MarketPrice
+from .regulation import AutomaticStrategyResult
+from .states import (
+    AdditionalBatteryState,
+    BatteryState,
+    GridState,
+    MeasuredValue,
+    OffGridState,
+    PVState,
+    ValueValidity,
+)
+
+
+AiMode = Literal["automatic", "summer", "manual"]
+
+
+@dataclass
+class RuntimeSnapshot:
+    """One platform-neutral, normalized input for a core decision cycle.
+
+    The flat fields preserve the established Decision Engine contract while
+    typed views expose the shared models introduced by Issue #267. This avoids
+    a second aggregate context during the incremental V4.7 migration.
+    """
+
+    now: datetime
+
+    soc: float
+    soc_min: float
+    soc_max: float
+
+    emergency_soc: float
+    emergency_charge_w: float
+
+    max_charge_w: float
+    max_discharge_w: float
+
+    grid_import_w: float
+    grid_export_w: float
+    pv_w: float
+    house_load_w: float
+
+    avg_charge_price: float | None
+    expensive_threshold: float
+    very_expensive_threshold: float
+    profit_margin_pct: float
+
+    ai_mode: AiMode
+    manual_action: str | None
+    season: Literal["winter", "summer"]
+
+    profile: dict[str, Any]
+    prev_discharge_w: float
+    prev_charge_w: float
+
+    battery_capacity_kwh: float
+    battery_discharge_w: float = 0.0
+    last_output_w: float = 0.0
+
+    additional_battery_charge_w: float = 0.0
+    additional_battery_discharge_w: float = 0.0
+    pv_charge_start_export_w: float = 80.0
+
+    peak_factor: float = 1.35
+    valley_factor: float = 0.85
+    very_cheap_price: float | None = None
+
+    cell_voltage_emergency_active: bool = False
+    forecast: Any | None = None
+    learned_charge_plan: Any | None = None
+    learned_planning_enabled: bool = False
+    import_market_price: MarketPrice | None = None
+    export_market_price: MarketPrice | None = None
+
+    pv_charge_start_counter: int = 0
+    pv_charge_stop_counter: int = 0
+    forecast_wait_block_counter: int = 0
+    pv_charge_latched: bool = False
+
+    discharge_blocked_by_soc_min: bool = False
+    cell_voltage_discharge_blocked: bool = False
+
+    pv_houseload_passthrough_active: bool = False
+    pv_houseload_passthrough_target_w: float = 0.0
+    pv_houseload_passthrough_stop_reason: str = "none"
+
+    offgrid_power_w: float = 0.0
+    offgrid_mode: str = "not_configured"
+    offgrid_available: bool = False
+    offgrid_active: bool = False
+    offgrid_load_active: bool = False
+    offgrid_source_active: bool = False
+
+    automatic_strategy_active: bool = False
+    automatic_weighting: str = "inactive"
+    automatic_pv_weight: float = 0.0
+    automatic_price_weight: float = 0.0
+    automatic_reserve_weight: float = 0.0
+    automatic_forecast_weight: float = 0.0
+    automatic_discharge_allowed: bool = False
+    automatic_discharge_reason: str = "not_evaluated"
+    automatic_peak_reserve_allowed: bool = False
+    automatic_peak_reserve_reason: str = "not_evaluated"
+    automatic_valley_charge_allowed: bool = False
+    automatic_valley_charge_reason: str = "not_evaluated"
+    automatic_planning_allowed: bool = False
+    automatic_planning_reason: str = "not_evaluated"
+
+    grid_sensor_configured: bool = True
+    grid_sensor_valid: bool = True
+    pv_sensor_valid: bool = True
+    soc_limits_valid: bool = True
+    power_limits_valid: bool = True
+
+    @staticmethod
+    def _measured(
+        value: float,
+        *,
+        valid: bool,
+        observed_at: datetime,
+        invalid_status: ValueValidity = ValueValidity.INVALID,
+    ) -> MeasuredValue[float]:
+        if valid:
+            return MeasuredValue.available(float(value), observed_at=observed_at)
+        return MeasuredValue.absent(invalid_status, observed_at=observed_at)
+
+    @property
+    def battery(self) -> BatteryState:
+        """Return the normalized battery view for this cycle."""
+
+        return BatteryState(
+            soc_pct=self._measured(
+                self.soc,
+                valid=self.soc_limits_valid,
+                observed_at=self.now,
+            ),
+            charge_power_w=MeasuredValue.available(
+                max(0.0, self.prev_charge_w),
+                observed_at=self.now,
+            ),
+            discharge_power_w=MeasuredValue.available(
+                max(0.0, self.battery_discharge_w),
+                observed_at=self.now,
+            ),
+        )
+
+    @property
+    def grid(self) -> GridState:
+        """Return normalized grid flows with explicit sensor validity."""
+
+        invalid_status = (
+            ValueValidity.INVALID
+            if self.grid_sensor_configured
+            else ValueValidity.MISSING
+        )
+        return GridState(
+            import_power_w=self._measured(
+                self.grid_import_w,
+                valid=self.grid_sensor_valid,
+                observed_at=self.now,
+                invalid_status=invalid_status,
+            ),
+            export_power_w=self._measured(
+                self.grid_export_w,
+                valid=self.grid_sensor_valid,
+                observed_at=self.now,
+                invalid_status=invalid_status,
+            ),
+        )
+
+    @property
+    def pv(self) -> PVState:
+        """Return normalized PV and derived house-load measurements."""
+
+        return PVState(
+            production_power_w=self._measured(
+                self.pv_w,
+                valid=self.pv_sensor_valid,
+                observed_at=self.now,
+            ),
+            house_load_power_w=MeasuredValue.available(
+                max(0.0, self.house_load_w),
+                observed_at=self.now,
+            ),
+        )
+
+    @property
+    def offgrid(self) -> OffGridState:
+        """Return optional off-grid state without exposing entity metadata."""
+
+        if not self.offgrid_available:
+            return OffGridState(
+                active=MeasuredValue.absent(
+                    ValueValidity.MISSING,
+                    observed_at=self.now,
+                ),
+                output_power_w=MeasuredValue.absent(
+                    ValueValidity.MISSING,
+                    observed_at=self.now,
+                ),
+            )
+        return OffGridState(
+            active=MeasuredValue.available(self.offgrid_active, observed_at=self.now),
+            output_power_w=MeasuredValue.available(
+                max(0.0, self.offgrid_power_w),
+                observed_at=self.now,
+            ),
+        )
+
+    @property
+    def additional_battery(self) -> AdditionalBatteryState:
+        """Return normalized additional-battery flows."""
+
+        return AdditionalBatteryState(
+            charge_power_w=MeasuredValue.available(
+                max(0.0, self.additional_battery_charge_w),
+                observed_at=self.now,
+            ),
+            discharge_power_w=MeasuredValue.available(
+                max(0.0, self.additional_battery_discharge_w),
+                observed_at=self.now,
+            ),
+        )
+
+    @property
+    def capabilities(self) -> DeviceCapabilities:
+        """Return the manufacturer-neutral capability subset of the profile."""
+
+        return DeviceCapabilities.from_profile(self.profile)
+
+    @property
+    def automatic_strategy(self) -> AutomaticStrategyResult:
+        """Return the typed AutomaticStrategy result carried by the snapshot."""
+
+        return AutomaticStrategyResult(
+            active=self.automatic_strategy_active,
+            weighting=self.automatic_weighting,  # type: ignore[arg-type]
+            pv_weight=self.automatic_pv_weight,
+            price_weight=self.automatic_price_weight,
+            reserve_weight=self.automatic_reserve_weight,
+            forecast_weight=self.automatic_forecast_weight,
+            reason=self.automatic_discharge_reason,
+            metadata={
+                "automatic_discharge_allowed": self.automatic_discharge_allowed,
+                "automatic_peak_reserve_allowed": self.automatic_peak_reserve_allowed,
+                "automatic_valley_charge_allowed": self.automatic_valley_charge_allowed,
+                "automatic_planning_allowed": self.automatic_planning_allowed,
+            },
+        )
+
+
+# Compatibility name for existing Decision Engine tests and callers.
+DecisionContext = RuntimeSnapshot

--- a/custom_components/battery_smartflow_ai/decision_engine.py
+++ b/custom_components/battery_smartflow_ai/decision_engine.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta
 from typing import Any, List, Literal, Optional
 
 from .const import MANUAL_CONST_DISCHARGE
-from .forecast import ForecastSummary
+from .core.models.runtime import AiMode, DecisionContext, RuntimeSnapshot
 from .market_price import (
     MarketPrice,
     MarketPriceDirection,
@@ -17,7 +17,6 @@ from .price_math import peak_threshold
 from .power_controller import PowerController, PowerContext
 
 
-AiMode = Literal["automatic", "summer", "manual"]
 ZendureMode = Literal["input", "output"]
 ActionType = Literal["idle", "charge", "discharge", "emergency", "passthrough"]
 
@@ -185,122 +184,6 @@ def advance_pv_charge_hysteresis(
 
 
 PricePoint = MarketPricePoint
-
-
-@dataclass
-class DecisionContext:
-    now: datetime
-
-    soc: float
-    soc_min: float
-    soc_max: float
-
-    emergency_soc: float
-    emergency_charge_w: float
-
-    max_charge_w: float
-    max_discharge_w: float
-
-    grid_import_w: float
-    grid_export_w: float
-    pv_w: float
-    house_load_w: float
-
-    avg_charge_price: Optional[float]
-    expensive_threshold: float
-    very_expensive_threshold: float
-    profit_margin_pct: float
-
-    ai_mode: AiMode
-    manual_action: Optional[str]
-    season: Literal["winter", "summer"]
-
-    profile: dict
-    prev_discharge_w: float
-    prev_charge_w: float
-
-    battery_capacity_kwh: float
-    battery_discharge_w: float = 0.0
-    last_output_w: float = 0.0
-
-    additional_battery_charge_w: float = 0.0
-    additional_battery_discharge_w: float = 0.0
-    pv_charge_start_export_w: float = 80.0
-
-    peak_factor: float = 1.35
-    valley_factor: float = 0.85
-    very_cheap_price: Optional[float] = None
-    
-    # V4.2.3-Beta3:
-    # Opportunity cost of using PV for charging instead of exporting it.
-    # If no feed-in tariff is available, 0.0 is conservative: only zero/negative
-    # grid prices may override currently useful PV.
-
-    # V3.5.0 cell voltage protection
-    cell_voltage_emergency_active: bool = False
-
-    # V4.0.0 optional forecast input
-    forecast: Optional[ForecastSummary] = None
-
-    # V4.1.0 learned charge-window planning
-    # Passed in from coordinator as an object from learned_planning.py.
-    # Keep this typed as Any to avoid circular imports.
-    learned_charge_plan: Any | None = None
-    learned_planning_enabled: bool = False
-    import_market_price: MarketPrice | None = None
-    export_market_price: MarketPrice | None = None
-
-    # Runtime counters / debounce
-    pv_charge_start_counter: int = 0
-    pv_charge_stop_counter: int = 0
-    forecast_wait_block_counter: int = 0
-    pv_charge_latched: bool = False
-
-    # Protection state from coordinator
-    discharge_blocked_by_soc_min: bool = False
-    cell_voltage_discharge_blocked: bool = False
-
-    # SF800Pro PV house-load passthrough state
-    pv_houseload_passthrough_active: bool = False
-    pv_houseload_passthrough_target_w: float = 0.0
-    pv_houseload_passthrough_stop_reason: str = "none"
-    
-    # V4.2.x Off-Grid / Inselsteckdose
-    offgrid_power_w: float = 0.0
-    offgrid_mode: str = "not_configured"
-    offgrid_available: bool = False
-    offgrid_active: bool = False
-    offgrid_load_active: bool = False
-    offgrid_source_active: bool = False
-    
-    # V4.3.0-dev5.2 unified AutomaticStrategy context
-    automatic_strategy_active: bool = False
-    automatic_weighting: str = "inactive"
-    automatic_pv_weight: float = 0.0
-    automatic_price_weight: float = 0.0
-    automatic_reserve_weight: float = 0.0
-    automatic_forecast_weight: float = 0.0
-    automatic_discharge_allowed: bool = False
-    automatic_discharge_reason: str = "not_evaluated"
-    
-    # V4.3.0-dev5.3 strategic peak-reserve context
-    automatic_peak_reserve_allowed: bool = False
-    automatic_peak_reserve_reason: str = "not_evaluated"
-
-    # V4.3.0-dev5.4 optional valley-charge context
-    automatic_valley_charge_allowed: bool = False
-    automatic_valley_charge_reason: str = "not_evaluated"
-
-    # V4.3.0-dev5.5 strategic charge-planning context
-    automatic_planning_allowed: bool = False
-    automatic_planning_reason: str = "not_evaluated"
-
-    # V4.3.0-dev9 data-quality context.
-    grid_sensor_configured: bool = True
-    grid_sensor_valid: bool = True
-    pv_sensor_valid: bool = True
-    soc_limits_valid: bool = True
-    power_limits_valid: bool = True
 
 
 @dataclass
@@ -2608,7 +2491,7 @@ class DecisionEngine:
 
         return None
 
-    def evaluate(self, ctx: DecisionContext) -> DecisionResult:
+    def evaluate(self, ctx: RuntimeSnapshot) -> DecisionResult:
         """Evaluate every admissible rule and select the highest priority.
 
         Rule order remains the deterministic tie-breaker only. It no longer

--- a/docs/architecture/core-models-v4.7.0.md
+++ b/docs/architecture/core-models-v4.7.0.md
@@ -3,7 +3,7 @@
 - Status: Implementierungsentscheidung für Issue #267
 - Basis: `main` nach Merge von PR #293
 - Zielarchitektur: `core-ha-target-architecture-v4.7.0.md`
-- Scope: neutrale Modellgrenzen und kompatible Konsolidierung, kein RuntimeSnapshot
+- Scope: neutrale Modellgrenzen und kompatible Konsolidierung; ergänzt durch #268
 
 ## Ergebnis
 
@@ -46,9 +46,11 @@ Die Modelle enthalten keine Entity-ID, HA-State-Objekte, Registries, Services
 oder Übersetzungsschlüssel. Der spätere HA-Adapter ist dafür verantwortlich,
 Home-Assistant-Zustände in diese neutralen Kategorien zu übersetzen.
 
-Die Teilzustände werden in #267 noch nicht zu einem weiteren Sammelkontext
-zusammengesetzt. Issue #268 führt genau eine zentrale Runtime-Eingabe ein und
-ordnet dort auch Zeitstempel, Konfiguration, Forecast und Teilzustände zu.
+Die Teilzustände wurden in #267 noch nicht zu einem weiteren Sammelkontext
+zusammengesetzt. Issue #268 hat anschließend genau eine zentrale
+`RuntimeSnapshot`-Eingabe eingeführt. Sie stellt diese Teilzustände als
+typisierte Sichten bereit und bewahrt während der Migration den etablierten
+Decision-Engine-Vertrag.
 
 ### Strategie und Regelung
 
@@ -69,7 +71,7 @@ liegen kanonisch unter `core/models/`:
 Der bisherige Name `StrategyContext` bleibt als Alias für
 `AutomaticStrategyResult` erhalten. Das Modell ist das Ergebnis der
 AutomaticStrategy und keine zweite Runtime-Eingabe. Diese Einordnung verhindert
-eine Doppelung mit dem in #268 entstehenden Eingabemodell.
+eine Doppelung mit dem in #268 eingeführten Eingabemodell.
 
 `StrategyIntent` bleibt die fachliche gewünschte Wirkung. `DeviceCommand`
 bleibt der technisch freigegebene neutrale Gerätebefehl. Die vorhandenen
@@ -160,7 +162,7 @@ Strategie-, Regelungs-, Marktpreis-, Wirtschafts- und Home-Assistant-Verhalten.
 
 ## Bewusst nicht Teil von #267
 
-- kein `RuntimeSnapshot`; dieser entsteht in #268
+- kein zweiter Snapshot neben dem in #268 eingeführten `RuntimeSnapshot`
 - keine Umstellung des Coordinators auf die neuen Teilzustände
 - keine neue Command-Ausführung oder DeviceBackend-Implementierung
 - keine StateStore- oder Clock-Abstraktion

--- a/docs/architecture/runtime-snapshot-v4.7.0.md
+++ b/docs/architecture/runtime-snapshot-v4.7.0.md
@@ -1,0 +1,145 @@
+# V4.7.0: Neutraler RuntimeSnapshot
+
+- Status: Implementierungsentscheidung für Issue #268
+- Basis: `main` nach Merge von PR #295
+- Modellgrundlage: `core-models-v4.7.0.md`
+- Scope: zentrale Core-Eingabe, keine Command-, Store- oder Backend-Änderung
+
+## Entscheidung
+
+`RuntimeSnapshot` ist die einzige zentrale Laufzeiteingabe der Decision Engine.
+Der bisherige Name `DecisionContext` bleibt als Identitätsalias erhalten:
+
+```python
+DecisionContext is RuntimeSnapshot
+```
+
+Es gibt keine Konvertierung zwischen zwei Sammelmodellen und keine doppelte
+Dataclass-Definition. Bestehende Tests und Aufrufer dürfen den alten Namen
+während der V4.7-Migration weiterverwenden.
+
+## Aufbaugrenze
+
+Der Home-Assistant-Coordinator bleibt zunächst Composition Root. Er liest die
+konfigurierten HA-States, normalisiert Einheiten und Vorzeichen, klärt
+Verfügbarkeit und erzeugt anschließend einen `RuntimeSnapshot`.
+
+Die Decision Engine erhält nur diesen vorbereiteten Snapshot. Sie liest keine
+HA-States, Registries oder Services. Die Snapshot-Klasse selbst importiert kein
+Home Assistant und kann in reinen Unit Tests erzeugt werden.
+
+Ein separates `snapshot_builder.py` wird in #268 noch nicht eingeführt. Der
+Builder würde momentan lediglich die sehr große lokale Konstruktion aus dem
+Coordinator verschieben, ohne den State-Lesevorgang schon sauber abzugrenzen.
+Die physische Adapterextraktion erfolgt später entlang der in #266 festgelegten
+Migrationsroute.
+
+## Inhalt
+
+Der Snapshot führt den bestehenden, verhaltensrelevanten Decision-Engine-
+Vertrag an einem neutralen Ort zusammen:
+
+- zentraler, zeitzonenbewusster Zeitstempel
+- SoC, SoC-Grenzen und Batterieleistungen
+- Netzbezug und Einspeisung
+- PV-Leistung und abgeleitete Hauslast
+- Import- und Export-Marktpreise
+- Preisgrenzen und wirtschaftliche Parameter
+- Forecast und Lernladeplan
+- Modus, Saison und relevante Benutzerkonfiguration
+- Charge-/Discharge-Historie und Debounce-Zustände
+- Schutz- und Zellspannungszustände
+- Off-Grid- und Zusatzakku-Zustände
+- Ergebnis der AutomaticStrategy
+- Geräteprofil und daraus ableitbare DeviceCapabilities
+- explizite Datenqualitätsflags
+
+Nicht enthalten sind Entity-IDs, HA-State-Objekte, ConfigEntry, Registry-
+Objekte, Services, Entity-Klassen oder Übersetzungsschlüssel.
+
+## Typisierte Sichten
+
+Um den bestehenden Decision-Engine-Vertrag ohne Big-Bang-Rewrite zu erhalten,
+bleiben die heute verwendeten flachen Felder zunächst stabil. Derselbe Snapshot
+stellt daraus die in #267 definierten Modelle bereit:
+
+- `snapshot.battery -> BatteryState`
+- `snapshot.grid -> GridState`
+- `snapshot.pv -> PVState`
+- `snapshot.offgrid -> OffGridState`
+- `snapshot.additional_battery -> AdditionalBatteryState`
+- `snapshot.capabilities -> DeviceCapabilities`
+- `snapshot.automatic_strategy -> AutomaticStrategyResult`
+
+Diese Sichten sind keine zweite Datenhaltung. Sie werden deterministisch aus
+dem Snapshot erzeugt und können von nachfolgenden Core-Extraktionen schrittweise
+übernommen werden.
+
+## Gültigkeit
+
+Messwert und Verfügbarkeit bleiben getrennt:
+
+- ein gültiger Wert `0` bleibt ein echter Messwert
+- ein nicht konfigurierter Netzsensor wird `MISSING`
+- ein konfigurierter, aber ungültiger Netzsensor wird `INVALID`
+- ein ungültiger PV-Sensor liefert keinen erfundenen Nullwert
+- ein nicht verfügbarer Off-Grid-Pfad bleibt explizit fehlend
+
+Die bestehenden booleschen Schutzflags bleiben für die Decision Engine
+kompatibel. Die typisierten Sichten machen ihre fachliche Bedeutung zusätzlich
+für neue Core-Komponenten verfügbar.
+
+## Marktpreis, Planung und Wirtschaft
+
+Der Snapshot trägt die kanonischen `MarketPrice`-Objekte für Import und Export.
+Nullpreis, negative Preise und fehlende Preise behalten ihre V4.5/V4.6-
+Semantik.
+
+Forecast und Lernladeplan bleiben ihre vorhandenen neutralen Modelle. Es wird
+kein zweites `PlanningState` erzeugt. Wirtschaftlich relevante Eingaben wie
+durchschnittlicher Ladepreis, Preisgrenzen und Profit-Marge sind Teil desselben
+Snapshots; der persistente Economics-Lifecycle bleibt unverändert und wird erst
+in #276 weiter extrahiert.
+
+## Laufzeitintegration
+
+Der Coordinator erzeugt sowohl für die eigentliche Entscheidung als auch für
+die spätere Transparenzberechnung einen `RuntimeSnapshot`. Die Decision Engine
+typisiert ihren öffentlichen Eingang als `RuntimeSnapshot`.
+
+Alle bestehenden Regeln arbeiten während dieses Schritts weiter mit den
+kompatiblen Feldern. Dadurch ändert sich weder Regelreihenfolge noch Strategie,
+Zielleistung, Hysterese, Planning oder Schutzverhalten.
+
+## Kompatibilität und Folgeschritte
+
+- `DecisionContext` bleibt als Alias verfügbar.
+- Bestehende Test-Fixtures müssen nicht auf einmal migriert werden.
+- Feldnamen und Defaultwerte bleiben stabil.
+- Kein Store-, Config- oder Diagnoseformat ändert sich.
+- Kein Command- oder Geräte-Schreibpfad ändert sich.
+- #269 kann auf demselben Snapshot den neutralen Ausgabevertrag bearbeiten.
+- Die spätere Adapterextraktion kann die Snapshot-Konstruktion aus dem
+  Coordinator herauslösen, ohne die Core-Schnittstelle erneut zu ändern.
+
+## Nachweis
+
+Die Tests prüfen:
+
+- `DecisionContext is RuntimeSnapshot`
+- Instanziierung ohne Home-Assistant-Objekte
+- direkte Decision-Engine-Auswertung eines vorbereiteten Snapshots
+- typisierte Battery-, Grid-, PV- und Capability-Sichten
+- explizite Gültigkeit ungültiger Eingangsdaten
+- keine `homeassistant`-Imports unter `core/models/`
+- vollständige Verhaltensregression des bestehenden Systems
+
+## Nicht Teil von #268
+
+- kein zweiter StrategyContext
+- keine Änderung an StrategyIntent oder DeviceCommand
+- kein DeviceBackend
+- kein StateStore oder Clock-Port
+- keine Profilmigration
+- keine neue Strategie oder Reglerabstimmung
+- keine neue Plattform oder Geräteunterstützung

--- a/tests/test_core_models.py
+++ b/tests/test_core_models.py
@@ -18,6 +18,7 @@ from custom_components.battery_smartflow_ai.core.models import (  # noqa: E402
     BatteryState,
     DeviceCapabilities,
     DeviceCommand,
+    DecisionContext,
     GridState,
     MarketPrice,
     MarketPriceDirection,
@@ -25,6 +26,7 @@ from custom_components.battery_smartflow_ai.core.models import (  # noqa: E402
     MeasuredValue,
     OffGridState,
     PVState,
+    RuntimeSnapshot,
     StrategyContext,
     StrategyIntent,
     ValueValidity,
@@ -36,12 +38,45 @@ from custom_components.battery_smartflow_ai.regulation_models import (  # noqa: 
     DeviceCommand as LegacyDeviceCommand,
     StrategyIntent as LegacyStrategyIntent,
 )
+from custom_components.battery_smartflow_ai.decision_engine import (  # noqa: E402
+    DecisionEngine,
+)
 
 
 NOW = datetime(2026, 8, 26, 12, 0, tzinfo=timezone.utc)
 
 
 class CoreModelTests(unittest.TestCase):
+    @staticmethod
+    def runtime_snapshot(**overrides: object) -> RuntimeSnapshot:
+        values: dict[str, object] = {
+            "now": NOW,
+            "soc": 50.0,
+            "soc_min": 10.0,
+            "soc_max": 90.0,
+            "emergency_soc": 5.0,
+            "emergency_charge_w": 500.0,
+            "max_charge_w": 1000.0,
+            "max_discharge_w": 800.0,
+            "grid_import_w": 100.0,
+            "grid_export_w": 0.0,
+            "pv_w": 200.0,
+            "house_load_w": 300.0,
+            "avg_charge_price": None,
+            "expensive_threshold": 0.30,
+            "very_expensive_threshold": 0.40,
+            "profit_margin_pct": 5.0,
+            "ai_mode": "automatic",
+            "manual_action": None,
+            "season": "summer",
+            "profile": {"MAX_INPUT_W": 1000.0, "MAX_OUTPUT_W": 800.0},
+            "prev_discharge_w": 0.0,
+            "prev_charge_w": 0.0,
+            "battery_capacity_kwh": 2.0,
+        }
+        values.update(overrides)
+        return RuntimeSnapshot(**values)  # type: ignore[arg-type]
+
     def test_measurement_keeps_absence_distinct_from_zero(self) -> None:
         zero = MeasuredValue.available(0.0, observed_at=NOW)
         unavailable = MeasuredValue[float].absent(
@@ -97,6 +132,33 @@ class CoreModelTests(unittest.TestCase):
         self.assertIs(LegacyStrategyIntent, StrategyIntent)
         self.assertIs(LegacyDeviceCommand, DeviceCommand)
         self.assertIs(StrategyContext, AutomaticStrategyResult)
+
+    def test_decision_context_is_the_runtime_snapshot_not_a_second_model(self) -> None:
+        self.assertIs(DecisionContext, RuntimeSnapshot)
+
+    def test_decision_engine_evaluates_a_prepared_runtime_snapshot(self) -> None:
+        snapshot = self.runtime_snapshot(soc=4.0)
+
+        decision = DecisionEngine().evaluate(snapshot)
+
+        self.assertEqual(decision.action, "emergency")
+        self.assertEqual(decision.charge_w, 500.0)
+
+    def test_runtime_snapshot_exposes_typed_states_and_validity(self) -> None:
+        snapshot = self.runtime_snapshot(
+            grid_sensor_configured=True,
+            grid_sensor_valid=False,
+            pv_sensor_valid=True,
+        )
+
+        self.assertFalse(snapshot.grid.import_power_w.valid)
+        self.assertEqual(
+            snapshot.grid.import_power_w.validity,
+            ValueValidity.INVALID,
+        )
+        self.assertTrue(snapshot.pv.production_power_w.valid)
+        self.assertEqual(snapshot.capabilities.max_output_w, 800.0)
+        self.assertFalse(hasattr(snapshot, "entity_id"))
 
     def test_market_price_legacy_path_exports_canonical_type(self) -> None:
         price = MarketPrice(


### PR DESCRIPTION
## Zusammenfassung

- führt `RuntimeSnapshot` als einzige zentrale, Home-Assistant-unabhängige Eingabe der Decision Engine ein
- entfernt die bisherige lokale `DecisionContext`-Dataclass aus `decision_engine.py`
- erhält `DecisionContext` als Identitätsalias auf `RuntimeSnapshot`, damit bestehende Aufrufer und Tests kompatibel bleiben
- lässt den HA-Coordinator den Snapshot aus bereits normalisierten Laufzeitwerten aufbauen
- stellt Battery-, Grid-, PV-, Off-Grid-, Zusatzakku-, Capability- und AutomaticStrategy-Sichten aus den #267-Core-Modellen bereit
- modelliert fehlende beziehungsweise ungültige Eingangswerte ohne synthetische Nullwerte

## Verhalten und Grenzen

- `DecisionEngine.evaluate()` erhält unmittelbar einen `RuntimeSnapshot`
- Marktpreis-, Forecast-, Lernplanungs- und wirtschaftlich relevante Eingaben liegen im selben Snapshot
- keine Entity-ID, HA-State-, Registry-, Service- oder ConfigEntry-Pflichtfelder im Core-Kontext
- keine zweite Snapshot-/StrategyContext-Klasse und keine Konvertierung zwischen Aggregaten
- keine Änderung an Regelreihenfolge, Strategie, Leistung, Hysterese oder Schutzlogik
- keine Command-, DeviceBackend-, Store-, Clock-, Config- oder Entity-Änderung

## Validierung

- `DecisionContext is RuntimeSnapshot` verifiziert
- vorbereiteter Snapshot direkt durch die Decision Engine ausgewertet
- typisierte Zustände und Gültigkeit getestet
- keine `homeassistant`-Imports unter `core/models/`
- `git diff --check`
- Core-/Decision-Engine-Kompilierungsprüfung
- `python -m unittest discover -s tests -v`: 277 Tests bestanden

Closes #268