### PR TITLE
V4.7.0: DeviceCommand-Ausgabe vom HA-Schreibpfad entkoppeln

### DIFF
--- a/custom_components/battery_smartflow_ai/adapters/__init__.py
+++ b/custom_components/battery_smartflow_ai/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""Platform adapters for Battery SmartFlow AI."""

--- a/custom_components/battery_smartflow_ai/adapters/home_assistant/__init__.py
+++ b/custom_components/battery_smartflow_ai/adapters/home_assistant/__init__.py
@@ -1,0 +1,1 @@
+"""Home Assistant adapter implementations."""

--- a/custom_components/battery_smartflow_ai/adapters/home_assistant/device_command_executor.py
+++ b/custom_components/battery_smartflow_ai/adapters/home_assistant/device_command_executor.py
@@ -1,0 +1,110 @@
+"""Execute neutral core commands through the existing HA entity write path."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+from ...core.models.device import (
+    CommandExecutionResult,
+    CommandExecutionStatus,
+)
+from ...core.models.regulation import DeviceCommand
+
+
+ModeWriter = Callable[[str], Awaitable[None]]
+PowerWriter = Callable[..., Awaitable[None]]
+
+
+class DeviceCommandExecutionError(RuntimeError):
+    """Preserve the platform exception while exposing neutral failure feedback."""
+
+    def __init__(self, result: CommandExecutionResult) -> None:
+        super().__init__(result.error or result.reason)
+        self.result = result
+
+
+class HomeAssistantEntityCommandExecutor:
+    """Map a neutral DeviceCommand to the current Select/Number writers.
+
+    Entity IDs, services, availability checks, clamping and cache updates stay
+    in the supplied Home Assistant writer callbacks. The core command contains
+    no knowledge of those platform details.
+    """
+
+    def __init__(
+        self,
+        *,
+        set_ac_mode: ModeWriter,
+        set_input_limit: PowerWriter,
+        set_output_limit: PowerWriter,
+    ) -> None:
+        self._set_ac_mode = set_ac_mode
+        self._set_input_limit = set_input_limit
+        self._set_output_limit = set_output_limit
+
+    async def execute(
+        self,
+        command: DeviceCommand,
+        *,
+        force_power: bool = True,
+        power_before_mode: bool = False,
+    ) -> CommandExecutionResult:
+        """Execute requested writes in the established order."""
+
+        if command.skipped or not (
+            command.should_write_mode
+            or command.should_write_input
+            or command.should_write_output
+        ):
+            return CommandExecutionResult(
+                status=CommandExecutionStatus.SKIPPED,
+                reason=command.skip_reason or command.reason,
+            )
+
+        mode_written = False
+        input_written = False
+        output_written = False
+
+        async def write_power() -> None:
+            nonlocal input_written, output_written
+            if command.should_write_input:
+                await self._set_input_limit(
+                    command.input_limit_w,
+                    force=force_power,
+                )
+                input_written = True
+            if command.should_write_output:
+                await self._set_output_limit(
+                    command.output_limit_w,
+                    force=force_power,
+                )
+                output_written = True
+
+        try:
+            if power_before_mode:
+                await write_power()
+
+            if command.should_write_mode:
+                await self._set_ac_mode(command.ac_mode)
+                mode_written = True
+
+            if not power_before_mode:
+                await write_power()
+        except Exception as err:
+            result = CommandExecutionResult(
+                status=CommandExecutionStatus.FAILED,
+                reason=command.reason,
+                mode_written=mode_written,
+                input_written=input_written,
+                output_written=output_written,
+                error=f"{type(err).__name__}: {err}",
+            )
+            raise DeviceCommandExecutionError(result) from err
+
+        return CommandExecutionResult(
+            status=CommandExecutionStatus.APPLIED,
+            reason=command.reason,
+            mode_written=mode_written,
+            input_written=input_written,
+            output_written=output_written,
+        )

--- a/custom_components/battery_smartflow_ai/coordinator.py
+++ b/custom_components/battery_smartflow_ai/coordinator.py
@@ -164,11 +164,16 @@ from .strategy_adapter import decision_to_strategy_intent
 from .strategy_state import ChargeCommitState
 from .mode_arbiter import ModeArbiter, build_mode_arbiter_config
 from .regulation_models import RegulationRuntimeState
+from .core.models import CommandExecutionResult, DeviceCommand
 from .regulation_power_controller import (
     RegulationPowerController,
     build_regulation_power_config,
 )
 from .device_command import DeviceCommandBuilder, clamp_number_power_request
+from .adapters.home_assistant.device_command_executor import (
+    DeviceCommandExecutionError,
+    HomeAssistantEntityCommandExecutor,
+)
 from .command_effectiveness import (
     CommandEffectivenessConfig,
     CommandEffectivenessState,
@@ -404,6 +409,11 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         )
         
         self._device_command_builder = DeviceCommandBuilder()
+        self._device_command_executor = HomeAssistantEntityCommandExecutor(
+            set_ac_mode=self._set_ac_mode,
+            set_input_limit=self._set_input_limit,
+            set_output_limit=self._set_output_limit,
+        )
         self._command_effectiveness_config = CommandEffectivenessConfig()
 
         self._store = Store(hass, STORE_VERSION, f"{DOMAIN}.{entry.entry_id}")
@@ -2016,6 +2026,47 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         ] = effective_int != requested_int
 
         return effective_int
+
+    def _store_command_execution_result(
+        self,
+        result: CommandExecutionResult,
+    ) -> None:
+        """Expose neutral backend feedback without leaking HA details to core."""
+
+        self._persist["command_execution_status"] = str(result.status)
+        self._persist["command_execution_reason"] = str(result.reason)
+        self._persist["command_execution_mode_written"] = bool(
+            result.mode_written
+        )
+        self._persist["command_execution_input_written"] = bool(
+            result.input_written
+        )
+        self._persist["command_execution_output_written"] = bool(
+            result.output_written
+        )
+        self._persist["command_execution_error"] = result.error
+
+    async def _execute_device_command(
+        self,
+        command: DeviceCommand,
+        *,
+        force_power: bool = True,
+        power_before_mode: bool = False,
+    ) -> CommandExecutionResult:
+        """Execute one neutral command through the HA entity adapter."""
+
+        try:
+            result = await self._device_command_executor.execute(
+                command,
+                force_power=force_power,
+                power_before_mode=power_before_mode,
+            )
+        except DeviceCommandExecutionError as err:
+            self._store_command_execution_result(err.result)
+            raise
+
+        self._store_command_execution_result(result)
+        return result
 
     async def _set_ac_mode(self, mode: str) -> None:
         """Write the AC mode reliably.
@@ -3651,10 +3702,32 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self._persist.get("last_set_output_w", 0.0) or 0.0
         )
 
-        if current_mode == ZENDURE_MODE_INPUT or last_input_w > 0.0:
-            await self._set_input_limit(0.0, force=True)
-        elif current_mode == ZENDURE_MODE_OUTPUT or last_output_w > 0.0:
-            await self._set_output_limit(0.0, force=True)
+        stop_input = bool(
+            current_mode == ZENDURE_MODE_INPUT or last_input_w > 0.0
+        )
+        stop_output = bool(
+            not stop_input
+            and (
+                current_mode == ZENDURE_MODE_OUTPUT
+                or last_output_w > 0.0
+            )
+        )
+        safe_idle_command = DeviceCommand(
+            ac_mode=("input" if stop_input else "output"),
+            input_limit_w=0.0,
+            output_limit_w=0.0,
+            reason=reason,
+            should_write_mode=False,
+            should_write_input=stop_input,
+            should_write_output=stop_output,
+            skipped=not (stop_input or stop_output),
+            skip_reason=("none" if stop_input or stop_output else "unchanged"),
+            metadata={"command_path": "safe_idle"},
+        )
+        await self._execute_device_command(
+            safe_idle_command,
+            force_power=True,
+        )
 
         self._persist["last_set_input_w"] = 0
         self._persist["last_set_output_w"] = 0
@@ -5707,11 +5780,29 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         measured_discharge_w=battery_discharge_w,
                     )
 
-                    if standby_direction == "input":
-                        await self._set_input_limit(0.0, force=True)
-                        await self._set_ac_mode(ZENDURE_MODE_OUTPUT)
-                    elif standby_direction == "output":
-                        await self._set_output_limit(0.0, force=True)
+                    standby_command = DeviceCommand(
+                        ac_mode=ZENDURE_MODE_OUTPUT,
+                        input_limit_w=0.0,
+                        output_limit_w=0.0,
+                        reason="manual_standby",
+                        should_write_mode=standby_direction == "input",
+                        should_write_input=standby_direction == "input",
+                        should_write_output=standby_direction == "output",
+                        skipped=standby_direction is None,
+                        skip_reason=(
+                            "none"
+                            if standby_direction is not None
+                            else "unchanged"
+                        ),
+                        metadata={"command_path": "manual_standby"},
+                    )
+                    await self._execute_device_command(
+                        standby_command,
+                        force_power=True,
+                        # Preserve the established INPUT-stop then OUTPUT-mode
+                        # sequence used when entering passive manual standby.
+                        power_before_mode=standby_direction == "input",
+                    )
 
                     self._persist["last_set_input_w"] = 0
                     self._persist["last_set_output_w"] = 0
@@ -5730,28 +5821,31 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
             else:
                 self._persist["manual_standby_stop_applied"] = False
-                if regulation_device_command.should_write_mode:
-                    await self._set_ac_mode(ac_mode)
+                # DeviceCommandBuilder already applied the write tolerance.
+                # Force the selected active-side command so a direction change
+                # cannot be skipped merely because the Number entity still
+                # displays the same watt value as an earlier cycle.
+                execution_result = await self._execute_device_command(
+                    regulation_device_command,
+                    force_power=True,
+                )
 
-                if regulation_device_command.should_write_input:
-                    # DeviceCommandBuilder already applied the write tolerance.
-                    # Force the selected active-side command so a direction
-                    # change cannot be skipped merely because the Number entity
-                    # still displays the same watt value as an earlier cycle.
-                    await self._set_input_limit(in_w, force=True)
-                    if effectiveness_retry_direction == "input":
-                        self._record_command_effectiveness_retry(
-                            now=now,
-                            direction="input",
-                        )
-
-                if regulation_device_command.should_write_output:
-                    await self._set_output_limit(out_w, force=True)
-                    if effectiveness_retry_direction == "output":
-                        self._record_command_effectiveness_retry(
-                            now=now,
-                            direction="output",
-                        )
+                if (
+                    effectiveness_retry_direction == "input"
+                    and execution_result.input_written
+                ):
+                    self._record_command_effectiveness_retry(
+                        now=now,
+                        direction="input",
+                    )
+                elif (
+                    effectiveness_retry_direction == "output"
+                    and execution_result.output_written
+                ):
+                    self._record_command_effectiveness_retry(
+                        now=now,
+                        direction="output",
+                    )
 
             is_charging = ac_mode == ZENDURE_MODE_INPUT and in_w > 0.0
 

--- a/custom_components/battery_smartflow_ai/core/models/__init__.py
+++ b/custom_components/battery_smartflow_ai/core/models/__init__.py
@@ -1,6 +1,10 @@
 """Canonical platform-independent models shared across the BSFAI core."""
 
-from .device import DeviceCapabilities
+from .device import (
+    CommandExecutionResult,
+    CommandExecutionStatus,
+    DeviceCapabilities,
+)
 from .market import (
     MarketPrice,
     MarketPriceDirection,
@@ -43,6 +47,8 @@ __all__ = [
     "BatteryState",
     "ChargeCommitState",
     "ChargeSourceAllocation",
+    "CommandExecutionResult",
+    "CommandExecutionStatus",
     "DeviceCapabilities",
     "DeviceCommand",
     "DecisionContext",

--- a/custom_components/battery_smartflow_ai/core/models/device.py
+++ b/custom_components/battery_smartflow_ai/core/models/device.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import StrEnum
 from typing import Any, Mapping
 
 
@@ -39,3 +40,23 @@ class DeviceCapabilities:
                 profile.get("OFFGRID_MAX_INTERNAL_SUPPLY_W", 0.0) or 0.0
             ),
         )
+
+
+class CommandExecutionStatus(StrEnum):
+    """Platform-neutral result status of one backend execution attempt."""
+
+    APPLIED = "applied"
+    SKIPPED = "skipped"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True, slots=True)
+class CommandExecutionResult:
+    """Neutral feedback from a platform adapter after command execution."""
+
+    status: CommandExecutionStatus
+    reason: str
+    mode_written: bool = False
+    input_written: bool = False
+    output_written: bool = False
+    error: str | None = None

--- a/docs/architecture/device-command-output-v4.7.0.md
+++ b/docs/architecture/device-command-output-v4.7.0.md
@@ -1,0 +1,156 @@
+# V4.7.0: Neutraler DeviceCommand-Ausgabepfad
+
+- Status: Implementierungsentscheidung für Issue #269
+- Basis: `main` nach Merge von PR #296
+- Eingabegrenze: `runtime-snapshot-v4.7.0.md`
+- Scope: neutrale Core-Ausgabe und HA-Ausführung, kein neuer Gerätepfad
+
+## Entscheidung
+
+Der fachliche und technische Core erzeugt ausschließlich einen neutralen
+`DeviceCommand`. Die Ausführung erfolgt über den Home-Assistant-Adapter
+`HomeAssistantEntityCommandExecutor`:
+
+```text
+RuntimeSnapshot
+  -> DecisionEngine
+  -> StrategyIntent
+  -> ModeArbiter
+  -> RegulationPowerController
+  -> DeviceCommand
+  -> HomeAssistantEntityCommandExecutor
+  -> bestehende Select-/Number-Writer
+```
+
+Der Command kennt keine Entity-ID, HA-Domain, Services, Registry-Objekte,
+MQTT-Topics, Modbus-Register oder Hersteller-API.
+
+## DeviceCommand
+
+Der bestehende Command bleibt der kanonische neutrale Vertrag. Er enthält:
+
+- gewünschte technische AC-Richtung
+- Input- und Output-Limit
+- stabilen Reason
+- Schreibentscheidungen für Modus und beide Leistungsrichtungen
+- Skip-Status und Skip-Reason
+- plattformneutrale Diagnosemetadaten
+
+Die vorhandenen `should_write_*`-Felder bleiben in #269 erhalten. Sie tragen
+heute die bereits getestete Schreibschwellen-, Live-Wert- und
+Richtungswechseloptimierung. Eine Entfernung oder grundlegende Neuverteilung
+würde unnötig das Geräteverhalten verändern.
+
+Die Felder sind keine HA-Entity-Information. Der Adapter entscheidet weiterhin,
+welche konkrete Select-/Number-Entity und welcher Service den Wunsch umsetzt.
+
+## Home-Assistant-Adapter
+
+`adapters/home_assistant/device_command_executor.py` besitzt die technische
+Ausführungsgrenze. Er erhält drei HA-seitige Writer-Callbacks:
+
+- Modus setzen
+- Input-Limit setzen
+- Output-Limit setzen
+
+Entity-Verfügbarkeit, dynamische Number-Grenzen, Cache-/Istwert-Abgleich,
+Serviceaufruf und Cache-Update bleiben in diesen bestehenden Coordinator-
+Writern. Der Adapter und der Core benötigen keine Entity-ID.
+
+## Einheitliche Command-Pfade
+
+Folgende Produktpfade verwenden dieselbe Ausführungsgrenze:
+
+1. normaler Strategy-/Regulation-Command
+2. Safe-Idle bei ungültigen Pflichtdaten
+3. einmaliger Stop beim Eintritt in Manual-Standby
+
+Es existieren außerhalb des Executors keine direkten produktiven Aufrufe der
+drei Writer mehr.
+
+### Normalbetrieb
+
+Die bestehende Reihenfolge bleibt Modus vor aktiver Leistung. Die vom
+`DeviceCommandBuilder` bestimmten Write-Flags und Toleranzen bleiben erhalten.
+Effectiveness-Retries werden nur dann verbucht, wenn der Adapter den
+entsprechenden Richtungswrite tatsächlich ausgeführt hat.
+
+### Safe-Idle
+
+Safe-Idle erzeugt einen neutralen Nullleistungs-Command für die aktive oder
+zuletzt aktive Richtung. Das bisherige Verhalten bleibt erhalten:
+
+- aktive INPUT-Seite wird über Input `0` gestoppt
+- andernfalls wird aktive OUTPUT-Seite über Output `0` gestoppt
+- ohne aktive oder bekannte Richtung wird kein Gerätewrite erfunden
+
+### Manual-Standby
+
+Manual-Standby bleibt passiv, nachdem der beim Eintritt notwendige Stop genau
+einmal ausgeführt wurde. Bei vorherigem INPUT bleibt die etablierte Reihenfolge
+erhalten:
+
+1. Input-Leistung auf `0`
+2. Modus auf OUTPUT
+
+Bei vorherigem OUTPUT wird nur Output `0` geschrieben. Das bestehende
+`manual_standby_stop_applied`-Latch bleibt unverändert.
+
+## Neutrales Ausführungsfeedback
+
+`CommandExecutionResult` meldet plattformneutral:
+
+- `APPLIED`
+- `SKIPPED`
+- `FAILED`
+- welche der drei technischen Operationen ausgeführt wurden
+- neutralen Reason
+- optional eine Fehlerbeschreibung
+
+Der Coordinator speichert dieses Feedback für Diagnosezwecke. Ein HA-Fehler
+wird nicht verschluckt: `DeviceCommandExecutionError` trägt das neutrale
+Ergebnis und wirft den Fehler weiter in den bestehenden Coordinator-
+Fehlerpfad. Dadurch ändert sich das Laufzeit-Fehlerverhalten nicht.
+
+## Schreibschutz und Optimierung
+
+Unverändert bleiben:
+
+- minimale Leistungsänderung für einen Write
+- Vergleich mit internem Cache und realem Entity-Wert
+- dynamische Number-Min-/Max-Grenzen
+- Null als besonderer Stop-Befehl trotz positiver Entity-Mindestleistung
+- nur ein aktiver Richtungswrite
+- kein zusätzlicher gegenüberliegender Nullwrite
+- Force-Verhalten bei Richtungswechseln und Effectiveness-Retry
+- Cache-Update erst nach erfolgreichem HA-Serviceaufruf
+
+## Erweiterbarkeit
+
+Der neutrale Command und das neutrale Feedback können später von weiteren
+Backends verwendet werden. #269 implementiert ausdrücklich nur den vorhandenen
+HA-Entity-Pfad. Es entstehen kein Zendure-Direct-, MQTT-, Modbus- oder weiteres
+Hersteller-Backend.
+
+Issue #273 kann die formale DeviceBackend-Port-Signatur aus dem nun realen
+Ausführungsvertrag ableiten, ohne den Core-Command erneut zu ändern.
+
+## Nachweis
+
+Die Tests prüfen:
+
+- Modus-vor-Leistung im Normalpfad
+- Leistung-vor-Modus beim INPUT-Stop für Manual-Standby
+- keine Plattformwrites für übersprungene Commands
+- neutrales Fehlerfeedback bei fehlgeschlagenem Plattformwrite
+- alle produktiven Coordinator-Writes laufen über den Executor
+- vollständige Strategie-, Regelungs-, Safety- und Geräteverhaltensregression
+
+## Nicht Teil von #269
+
+- kein neues Hardware- oder Herstellerbackend
+- keine neue HA-Entity
+- keine Änderung an StrategyIntent oder Leistungsberechnung
+- kein StateStore- oder Clock-Port
+- keine Persistenzschema- oder Config-Migration
+- keine Reglerabstimmung

--- a/tests/test_device_command_executor.py
+++ b/tests/test_device_command_executor.py
@@ -1,0 +1,147 @@
+"""Contracts for the Home Assistant DeviceCommand execution boundary."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from support import bootstrap
+
+
+bootstrap()
+
+from custom_components.battery_smartflow_ai.adapters.home_assistant.device_command_executor import (  # noqa: E402
+    DeviceCommandExecutionError,
+    HomeAssistantEntityCommandExecutor,
+)
+from custom_components.battery_smartflow_ai.core.models import (  # noqa: E402
+    CommandExecutionStatus,
+    DeviceCommand,
+)
+
+
+class DeviceCommandExecutorTests(unittest.IsolatedAsyncioTestCase):
+    def executor(
+        self,
+        calls: list[tuple[str, object]],
+        *,
+        fail_output: bool = False,
+    ) -> HomeAssistantEntityCommandExecutor:
+        async def set_mode(mode: str) -> None:
+            calls.append(("mode", mode))
+
+        async def set_input(watts: float, *, force: bool = False) -> None:
+            calls.append(("input", (watts, force)))
+
+        async def set_output(watts: float, *, force: bool = False) -> None:
+            calls.append(("output", (watts, force)))
+            if fail_output:
+                raise RuntimeError("entity unavailable")
+
+        return HomeAssistantEntityCommandExecutor(
+            set_ac_mode=set_mode,
+            set_input_limit=set_input,
+            set_output_limit=set_output,
+        )
+
+    async def test_normal_command_preserves_mode_then_power_order(self) -> None:
+        calls: list[tuple[str, object]] = []
+        command = DeviceCommand(
+            ac_mode="input",
+            input_limit_w=600.0,
+            reason="planned_charge",
+            should_write_mode=True,
+            should_write_input=True,
+            should_write_output=False,
+        )
+
+        result = await self.executor(calls).execute(command, force_power=True)
+
+        self.assertEqual(
+            calls,
+            [("mode", "input"), ("input", (600.0, True))],
+        )
+        self.assertEqual(result.status, CommandExecutionStatus.APPLIED)
+        self.assertTrue(result.mode_written)
+        self.assertTrue(result.input_written)
+        self.assertFalse(result.output_written)
+
+    async def test_manual_standby_can_stop_power_before_mode(self) -> None:
+        calls: list[tuple[str, object]] = []
+        command = DeviceCommand(
+            ac_mode="output",
+            input_limit_w=0.0,
+            reason="manual_standby",
+            should_write_mode=True,
+            should_write_input=True,
+            should_write_output=False,
+        )
+
+        result = await self.executor(calls).execute(
+            command,
+            power_before_mode=True,
+        )
+
+        self.assertEqual(
+            calls,
+            [("input", (0.0, True)), ("mode", "output")],
+        )
+        self.assertEqual(result.status, CommandExecutionStatus.APPLIED)
+
+    async def test_skipped_command_performs_no_platform_write(self) -> None:
+        calls: list[tuple[str, object]] = []
+        command = DeviceCommand(
+            ac_mode="output",
+            reason="idle",
+            should_write_mode=False,
+            should_write_input=False,
+            should_write_output=False,
+            skipped=True,
+            skip_reason="unchanged",
+        )
+
+        result = await self.executor(calls).execute(command)
+
+        self.assertEqual(calls, [])
+        self.assertEqual(result.status, CommandExecutionStatus.SKIPPED)
+        self.assertEqual(result.reason, "unchanged")
+
+    async def test_platform_failure_is_raised_with_neutral_feedback(self) -> None:
+        calls: list[tuple[str, object]] = []
+        command = DeviceCommand(
+            ac_mode="output",
+            output_limit_w=500.0,
+            reason="cover_deficit",
+            should_write_mode=False,
+            should_write_input=False,
+            should_write_output=True,
+        )
+
+        with self.assertRaises(DeviceCommandExecutionError) as raised:
+            await self.executor(calls, fail_output=True).execute(command)
+
+        result = raised.exception.result
+        self.assertEqual(result.status, CommandExecutionStatus.FAILED)
+        self.assertEqual(result.reason, "cover_deficit")
+        self.assertIn("entity unavailable", result.error or "")
+        self.assertFalse(result.output_written)
+
+    def test_coordinator_routes_all_product_writes_through_executor(self) -> None:
+        coordinator = (
+            Path(__file__).resolve().parents[1]
+            / "custom_components"
+            / "battery_smartflow_ai"
+            / "coordinator.py"
+        ).read_text(encoding="utf-8")
+
+        self.assertNotIn("await self._set_ac_mode(", coordinator)
+        self.assertNotIn("await self._set_input_limit(", coordinator)
+        self.assertNotIn("await self._set_output_limit(", coordinator)
+        self.assertGreaterEqual(
+            coordinator.count("await self._execute_device_command("),
+            3,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Zusammenfassung

- führt `HomeAssistantEntityCommandExecutor` als zentrale technische Ausführungsgrenze für neutrale `DeviceCommand`s ein
- routet Normalbetrieb, Safe-Idle und den einmaligen Manual-Standby-Stop über dieselbe Adaptergrenze
- hält konkrete Entity-IDs, HA-Services, dynamische Number-Grenzen und Cache-/Istwert-Abgleich in den bestehenden HA-Writern
- ergänzt plattformneutrales Ausführungsfeedback mit `APPLIED`, `SKIPPED` und `FAILED`
- wirft HA-Schreibfehler weiterhin in den bestehenden Coordinator-Fehlerpfad weiter

## Verhaltensschutz

- bestehende Modus-vor-Leistung-Reihenfolge im Normalbetrieb bleibt erhalten
- bestehende Input-0-vor-Output-Modus-Reihenfolge beim Manual-Standby bleibt erhalten
- Safe-Idle stoppt weiterhin genau die aktive beziehungsweise zuletzt aktive Richtung
- Write-Toleranzen, Live-Wert-Abgleich, dynamische Min-/Max-Grenzen und Null-Stop-Semantik bleiben unverändert
- Effectiveness-Retry wird nur nach tatsächlich ausgeführtem Richtungswrite verbucht
- keine direkten produktiven Aufrufe der drei HA-Writer außerhalb des Executors

## Grenzen

- keine Änderung an StrategyIntent, ModeArbiter, PowerController oder Leistungsberechnung
- keine Entity-, Config-, Store- oder Persistenzmigration
- kein Zendure-Direct-, MQTT-, Modbus- oder Herstellerbackend
- formaler DeviceBackend-Port bleibt dem vorgesehenen Issue #273 vorbehalten

## Validierung

- Adaptertests für normale Reihenfolge, Manual-Standby-Reihenfolge, Skip und Fehlerfeedback
- Source-Contract für vollständiges Routing aller produktiven Coordinator-Writes
- `git diff --check`
- Core-/Adapter-Kompilierungsprüfung
- vollständige Suite: 347 Tests und 326 Subtests bestanden

Closes #269