### PR TITLE
V4.7.0: Persistenz über StateStore abstrahieren

### DIFF
--- a/custom_components/battery_smartflow_ai/adapters/home_assistant/state_store.py
+++ b/custom_components/battery_smartflow_ai/adapters/home_assistant/state_store.py
@@ -1,0 +1,58 @@
+"""Home Assistant implementation of the neutral BSFAI StateStore port."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.storage import Store
+
+from ...core.ports import (
+    StateLoadResult,
+    StateSaveResult,
+    StateStoreStatus,
+)
+
+
+class HomeAssistantStateStore:
+    """Keep the established HA Store key and flat payload fully compatible."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        *,
+        version: int,
+        key: str,
+    ) -> None:
+        self._store: Store[dict[str, Any]] = Store(hass, version, key)
+
+    async def load(self) -> StateLoadResult:
+        try:
+            data = await self._store.async_load()
+        except Exception as err:
+            return StateLoadResult(
+                status=StateStoreStatus.FAILED,
+                error=f"{type(err).__name__}: {err}",
+            )
+
+        if data is None:
+            return StateLoadResult(status=StateStoreStatus.EMPTY)
+        if not isinstance(data, dict):
+            return StateLoadResult(
+                status=StateStoreStatus.INVALID,
+                error=f"expected dict, got {type(data).__name__}",
+            )
+        return StateLoadResult(
+            status=StateStoreStatus.LOADED,
+            data=dict(data),
+        )
+
+    async def save(self, data: dict[str, Any]) -> StateSaveResult:
+        try:
+            await self._store.async_save(dict(data))
+        except Exception as err:
+            return StateSaveResult(
+                status=StateStoreStatus.FAILED,
+                error=f"{type(err).__name__}: {err}",
+            )
+        return StateSaveResult(status=StateStoreStatus.SAVED)

--- a/custom_components/battery_smartflow_ai/coordinator.py
+++ b/custom_components/battery_smartflow_ai/coordinator.py
@@ -8,7 +8,6 @@ from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
 
@@ -174,6 +173,7 @@ from .adapters.home_assistant.device_command_executor import (
     DeviceCommandExecutionError,
     HomeAssistantEntityCommandExecutor,
 )
+from .adapters.home_assistant.state_store import HomeAssistantStateStore
 from .command_effectiveness import (
     CommandEffectivenessConfig,
     CommandEffectivenessState,
@@ -416,7 +416,11 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         )
         self._command_effectiveness_config = CommandEffectivenessConfig()
 
-        self._store = Store(hass, STORE_VERSION, f"{DOMAIN}.{entry.entry_id}")
+        self._state_store = HomeAssistantStateStore(
+            hass,
+            version=STORE_VERSION,
+            key=f"{DOMAIN}.{entry.entry_id}",
+        )
         self._persist: dict[str, Any] = {
             "runtime_mode": dict(self.runtime_mode),
 
@@ -563,9 +567,9 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         )
 
     async def _load(self) -> None:
-        data = await self._store.async_load()
-        if isinstance(data, dict):
-            loaded_data = dict(data)
+        load_result = await self._state_store.load()
+        if load_result.usable:
+            loaded_data = dict(load_result.data)
             migrate_legacy_price_fields(loaded_data)
             self._persist.update(loaded_data)
 
@@ -604,10 +608,22 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 self._persist.get("economics_money_state"),
                 currency=self.price_currency.code,
             )
+        elif load_result.error:
+            _LOGGER.warning(
+                "Persistent state load skipped (%s): %s",
+                load_result.status,
+                load_result.error,
+            )
 
     async def _save(self) -> None:
         self._persist["runtime_mode"] = dict(self.runtime_mode)
-        await self._store.async_save(self._persist)
+        save_result = await self._state_store.save(self._persist)
+        if not save_result.saved:
+            _LOGGER.warning(
+                "Persistent state save failed (%s): %s",
+                save_result.status,
+                save_result.error or "unknown error",
+            )
         
     def _charge_pricing_reason(self, decision_reason: str | None) -> str:
         """Return the reason that should be used for charge price attribution.

--- a/custom_components/battery_smartflow_ai/core/ports/__init__.py
+++ b/custom_components/battery_smartflow_ai/core/ports/__init__.py
@@ -1,0 +1,15 @@
+"""Platform-independent side-effect boundaries for the BSFAI core."""
+
+from .state_store import (
+    StateLoadResult,
+    StateSaveResult,
+    StateStore,
+    StateStoreStatus,
+)
+
+__all__ = [
+    "StateLoadResult",
+    "StateSaveResult",
+    "StateStore",
+    "StateStoreStatus",
+]

--- a/custom_components/battery_smartflow_ai/core/ports/state_store.py
+++ b/custom_components/battery_smartflow_ai/core/ports/state_store.py
@@ -1,0 +1,59 @@
+"""Neutral persistence contract for restart-safe BSFAI core state."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any, Protocol
+
+
+class StateStoreStatus(StrEnum):
+    """Outcome of a persistence operation without platform exceptions."""
+
+    LOADED = "loaded"
+    EMPTY = "empty"
+    SAVED = "saved"
+    INVALID = "invalid"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True, slots=True)
+class StateLoadResult:
+    """Neutral load result containing only plain Python state."""
+
+    status: StateStoreStatus
+    data: dict[str, Any] = field(default_factory=dict)
+    error: str | None = None
+
+    @property
+    def usable(self) -> bool:
+        """Return whether state can safely be merged with defaults."""
+
+        return self.status is StateStoreStatus.LOADED
+
+
+@dataclass(frozen=True, slots=True)
+class StateSaveResult:
+    """Neutral save result."""
+
+    status: StateStoreStatus
+    error: str | None = None
+
+    @property
+    def saved(self) -> bool:
+        return self.status is StateStoreStatus.SAVED
+
+
+class StateStore(Protocol):
+    """Small backend-independent boundary for one versioned state document.
+
+    The document stays flat for compatibility with existing installations.
+    Component-owned serializers can be introduced behind this boundary without
+    exposing Home Assistant Store objects, entry IDs or paths to the core.
+    """
+
+    async def load(self) -> StateLoadResult:
+        """Load the persisted document or return a neutral fallback result."""
+
+    async def save(self, data: dict[str, Any]) -> StateSaveResult:
+        """Persist a plain Python document without leaking backend errors."""

--- a/docs/architecture/core-ha-target-architecture-v4.7.0.md
+++ b/docs/architecture/core-ha-target-architecture-v4.7.0.md
@@ -311,6 +311,9 @@ HA-Implementierung:
 Das heutige flache `_persist`-Dictionary wird nicht auf einmal ersetzt. Issue
 #270 ordnet zuerst Besitz und Serialisierung der Teilzustände zu.
 
+Die umgesetzte Grenze und die kompatible Zuordnung sind in
+[`state-store-v4.7.0.md`](state-store-v4.7.0.md) dokumentiert.
+
 ### Clock
 
 Zeit wird semantisch getrennt:

--- a/docs/architecture/state-store-v4.7.0.md
+++ b/docs/architecture/state-store-v4.7.0.md
@@ -1,0 +1,67 @@
+# StateStore-Grenze in V4.7.0
+
+Issue #270 trennt die persistente Zustandsablage von Home Assistant, ohne das
+vorhandene Speicherformat bestehender Installationen zu verändern.
+
+## Laufzeitpfad
+
+```text
+Coordinator und Core-Komponenten
+        |
+        | neutrale dict-Daten und neutrale Ergebnisse
+        v
+core.ports.StateStore
+        |
+        v
+adapters.home_assistant.HomeAssistantStateStore
+        |
+        v
+homeassistant.helpers.storage.Store
+```
+
+Der Core-Port kennt weder `HomeAssistant`, Config Entries, Store-Schlüssel noch
+Dateipfade. Der HA-Adapter verwendet weiterhin Version `1` und den bisherigen
+Schlüssel `battery_smartflow_ai.<entry_id>`. Auch der gespeicherte Payload bleibt
+ein flaches Dictionary. Dadurch können vorhandene Daten ohne Formatmigration
+weiter geladen werden.
+
+## Zustandsbesitz
+
+Das bestehende Dictionary wird in #270 bewusst nicht als große Migration
+umgebaut. Die fachliche Verantwortung der bereits vorhandenen Teilzustände ist:
+
+| Besitzer | Restart-relevante Beispiele | Serialisierung/Wiederherstellung |
+| --- | --- | --- |
+| Economics | `economics_energy_state`, `economics_money_state`, Tagesgrenze | `EnergyAccumulator.to_state/from_state`, `EconomicsEngine.to_state/from_state` |
+| Strategische Planung | `charge_commit_*`, Lernslots und Leistungsproben | bestehende neutrale Zahlen, Strings, Listen und Dictionaries |
+| Regulation und Schutz | Latches, Holds, Schutzsperren und letzte bestätigte Sollwerte | bestehendes flaches, JSON-kompatibles Schema |
+| Coordinator-Laufzeit | `runtime_mode`, Saison und restart-relevante Anzeigezustände | Defaults plus kompatibles Überschreiben geladener Werte |
+| Diagnose | wenige für die Laufzeit benötigte Diagnosewerte | keine zusätzlichen Debug-Pakete oder Rohdaten |
+
+Kurzlebige Messwerte, vollständige Snapshots und HA-Objekte werden nicht neu
+persistiert. Neue Core-Komponenten sollen ihren eigenen neutralen Teilzustand
+serialisieren; der Coordinator führt diese Teile bis zu einer späteren,
+expliziten Schemamigration verlustfrei im kompatiblen Dokument zusammen.
+
+## Fehler- und Migrationsverhalten
+
+- Fehlender Store ergibt einen leeren, sicheren Start mit den bisherigen
+  Defaults.
+- Ein nicht-dictionaryförmiger oder nicht lesbarer Store wird nicht in den
+  Runtime-Zustand übernommen.
+- Backend-Ausnahmen werden als neutrale Resultate zurückgegeben. Der
+  Coordinator protokolliert sie in der HA-Plattformschicht und arbeitet mit
+  Defaults beziehungsweise dem aktuellen In-Memory-Zustand weiter.
+- Bestehende fachliche Migrationen und Normalisierungen bleiben erhalten:
+  Preisfeldmigration, Begrenzung des Saison-Zählers, Entfernen obsoleter Keys
+  sowie Wiederherstellung von Economics- und Runtime-Zuständen.
+- Ein Speicherfehler unterbricht weder den Regelzyklus noch einen Safe-Idle-
+  Schutzpfad. Der aktuelle Zustand bleibt im Speicher und der nächste Zyklus
+  kann erneut speichern.
+
+## Bewusste Grenze
+
+Issue #270 führt keinen Datei- oder SQLite-Store ein und zieht keine
+Zeitabstraktion aus #271 vor. Die kleine Schnittstelle bildet genau den heute
+benötigten versionierten Zustandsdatensatz ab; weitere Backends können später
+denselben neutralen Vertrag implementieren.

--- a/tests/test_state_store.py
+++ b/tests/test_state_store.py
@@ -1,0 +1,151 @@
+"""Contracts for the neutral StateStore and its HA adapter."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from types import ModuleType
+import unittest
+
+from support import bootstrap
+
+
+bootstrap()
+
+
+class FakeHAStore:
+    """Small controllable replacement for homeassistant.helpers.storage.Store."""
+
+    loaded: object = None
+    load_error: Exception | None = None
+    save_error: Exception | None = None
+    saved: dict[str, object] | None = None
+    init_args: tuple[object, int, str] | None = None
+
+    def __class_getitem__(cls, item: object) -> type[FakeHAStore]:
+        return cls
+
+    def __init__(self, hass: object, version: int, key: str) -> None:
+        type(self).init_args = (hass, version, key)
+
+    async def async_load(self) -> object:
+        if type(self).load_error is not None:
+            raise type(self).load_error
+        return type(self).loaded
+
+    async def async_save(self, data: dict[str, object]) -> None:
+        if type(self).save_error is not None:
+            raise type(self).save_error
+        type(self).saved = data
+
+
+helpers = ModuleType("homeassistant.helpers")
+helpers.__path__ = []
+storage = ModuleType("homeassistant.helpers.storage")
+storage.Store = FakeHAStore
+sys.modules["homeassistant.helpers"] = helpers
+sys.modules["homeassistant.helpers.storage"] = storage
+
+from custom_components.battery_smartflow_ai.adapters.home_assistant.state_store import (  # noqa: E402
+    HomeAssistantStateStore,
+)
+from custom_components.battery_smartflow_ai.core.ports import (  # noqa: E402
+    StateStoreStatus,
+)
+
+
+class StateStoreTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        FakeHAStore.loaded = None
+        FakeHAStore.load_error = None
+        FakeHAStore.save_error = None
+        FakeHAStore.saved = None
+        FakeHAStore.init_args = None
+        self.hass = object()
+        self.store = HomeAssistantStateStore(
+            self.hass,
+            version=1,
+            key="battery_smartflow_ai.entry-id",
+        )
+
+    async def test_existing_store_identity_and_flat_payload_are_preserved(self) -> None:
+        payload = {
+            "economics_energy_state": {"charged_kwh": 1.5},
+            "charge_commit_active": True,
+            "learned_load_slots": {"12": 230.0},
+        }
+        FakeHAStore.loaded = payload
+
+        result = await self.store.load()
+
+        self.assertEqual(
+            FakeHAStore.init_args,
+            (self.hass, 1, "battery_smartflow_ai.entry-id"),
+        )
+        self.assertEqual(result.status, StateStoreStatus.LOADED)
+        self.assertEqual(result.data, payload)
+        self.assertIsNot(result.data, payload)
+
+    async def test_empty_and_invalid_documents_are_safe_fallbacks(self) -> None:
+        empty = await self.store.load()
+        self.assertEqual(empty.status, StateStoreStatus.EMPTY)
+        self.assertEqual(empty.data, {})
+
+        FakeHAStore.loaded = ["not", "a", "mapping"]
+        invalid = await self.store.load()
+        self.assertEqual(invalid.status, StateStoreStatus.INVALID)
+        self.assertFalse(invalid.usable)
+        self.assertIn("expected dict", invalid.error or "")
+
+    async def test_load_failure_becomes_neutral_result(self) -> None:
+        FakeHAStore.load_error = OSError("storage unavailable")
+
+        result = await self.store.load()
+
+        self.assertEqual(result.status, StateStoreStatus.FAILED)
+        self.assertFalse(result.usable)
+        self.assertEqual(result.data, {})
+        self.assertIn("storage unavailable", result.error or "")
+
+    async def test_save_copies_payload_and_reports_success(self) -> None:
+        payload = {"runtime_mode": {"ai_mode": "automatic"}}
+
+        result = await self.store.save(payload)
+
+        self.assertEqual(result.status, StateStoreStatus.SAVED)
+        self.assertTrue(result.saved)
+        self.assertEqual(FakeHAStore.saved, payload)
+        self.assertIsNot(FakeHAStore.saved, payload)
+
+    async def test_save_failure_becomes_neutral_result(self) -> None:
+        FakeHAStore.save_error = OSError("disk full")
+
+        result = await self.store.save({"profit": 1.0})
+
+        self.assertEqual(result.status, StateStoreStatus.FAILED)
+        self.assertFalse(result.saved)
+        self.assertIn("disk full", result.error or "")
+
+    def test_core_port_has_no_home_assistant_dependency(self) -> None:
+        port = (
+            Path(__file__).resolve().parents[1]
+            / "custom_components"
+            / "battery_smartflow_ai"
+            / "core"
+            / "ports"
+            / "state_store.py"
+        ).read_text(encoding="utf-8")
+        coordinator = (
+            Path(__file__).resolve().parents[1]
+            / "custom_components"
+            / "battery_smartflow_ai"
+            / "coordinator.py"
+        ).read_text(encoding="utf-8")
+
+        self.assertNotIn("homeassistant", port)
+        self.assertNotIn("homeassistant.helpers.storage", coordinator)
+        self.assertIn("HomeAssistantStateStore", coordinator)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Zusammenfassung
- führt einen kleinen, Home-Assistant-unabhängigen StateStore-Port mit neutralen Lade-/Speicherresultaten ein
- kapselt den bestehenden HA-Store in HomeAssistantStateStore, ohne Store-Key, Version oder flaches Bestandsformat zu verändern
- lässt den Coordinator bei leeren, ungültigen oder fehlerhaften Persistenzzugriffen kontrolliert mit Defaults/In-Memory-Zustand weiterarbeiten
- dokumentiert Zustandsbesitz, bestehende Migrationen und die bewusste Abgrenzung zu #271
- ergänzt Vertragstests für Kompatibilität, defensive Kopien und Fehlerfälle

## Validierung
- 353 passed, 326 subtests passed`n- python -m compileall -q custom_components/battery_smartflow_ai tests`n- git diff --check`n
Closes #270