### PR TITLE
V4.7.0: Core-Zeitquelle über Clock abstrahieren

### DIFF
--- a/custom_components/battery_smartflow_ai/adapters/home_assistant/clock.py
+++ b/custom_components/battery_smartflow_ai/adapters/home_assistant/clock.py
@@ -1,0 +1,14 @@
+"""Home Assistant configuration of the neutral system Clock."""
+
+from __future__ import annotations
+
+from homeassistant.util import dt as dt_util
+
+from ...core.clock import SystemClock
+
+
+class HomeAssistantClock(SystemClock):
+    """Use Home Assistant's configured timezone for local calendar logic."""
+
+    def __init__(self) -> None:
+        super().__init__(local_timezone=dt_util.get_default_time_zone())

--- a/custom_components/battery_smartflow_ai/coordinator.py
+++ b/custom_components/battery_smartflow_ai/coordinator.py
@@ -164,6 +164,7 @@ from .strategy_state import ChargeCommitState
 from .mode_arbiter import ModeArbiter, build_mode_arbiter_config
 from .regulation_models import RegulationRuntimeState
 from .core.models import CommandExecutionResult, DeviceCommand
+from .core.ports import Clock
 from .regulation_power_controller import (
     RegulationPowerController,
     build_regulation_power_config,
@@ -173,6 +174,7 @@ from .adapters.home_assistant.device_command_executor import (
     DeviceCommandExecutionError,
     HomeAssistantEntityCommandExecutor,
 )
+from .adapters.home_assistant.clock import HomeAssistantClock
 from .adapters.home_assistant.state_store import HomeAssistantStateStore
 from .command_effectiveness import (
     CommandEffectivenessConfig,
@@ -316,7 +318,13 @@ class SelectedEntities:
 
 
 class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
-    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+        *,
+        clock: Clock | None = None,
+    ) -> None:
         self.hass = hass
         self.entry = entry
         self.price_currency: PriceCurrency = resolve_price_currency(
@@ -415,6 +423,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             set_output_limit=self._set_output_limit,
         )
         self._command_effectiveness_config = CommandEffectivenessConfig()
+        self._clock = clock or HomeAssistantClock()
 
         self._state_store = HomeAssistantStateStore(
             hass,
@@ -1777,7 +1786,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         self._debug_recorder.start(
             duration_minutes=duration_minutes,
-            now=dt_util.utcnow(),
+            now=self._clock.utc_now(),
             device_profile=self.device_profile_key,
             ai_mode=str(self.runtime_mode.get("ai_mode") or AI_MODE_AUTOMATIC),
             season_mode=str(self._persist.get("season_mode", "winter")),
@@ -1798,7 +1807,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     async def async_stop_debug_recording(self) -> None:
         """Stop the active debug recording and write its JSON package."""
 
-        package = self._debug_recorder.stop(now=dt_util.utcnow())
+        package = self._debug_recorder.stop(now=self._clock.utc_now())
         if package is not None:
             await self._async_export_debug_package(package)
         await self.async_request_refresh()
@@ -3443,7 +3452,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self,
         global_lowest_cell_voltage: float | None,
     ) -> bool:
-        now_utc = dt_util.utcnow()
+        now_utc = self._clock.utc_now()
         previously_active = bool(
             self._persist.get("cell_voltage_emergency_active", False)
         )
@@ -3572,7 +3581,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         )
         
         try:
-            local_now = dt_util.as_local(now or dt_util.utcnow())
+            local_now = dt_util.as_local(now or self._clock.utc_now())
             season_eval_hour = local_now.hour + (local_now.minute / 60.0)
         except Exception:
             season_eval_hour = 12.0
@@ -3702,7 +3711,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     ) -> dict[str, Any]:
         """Stop the active command and expose a deterministic safe-idle state."""
 
-        package = self._debug_recorder.tick(now=dt_util.utcnow())
+        package = self._debug_recorder.tick(now=self._clock.utc_now())
         if package is not None:
             await self._async_export_debug_package(package)
 
@@ -3756,7 +3765,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._persist["regulation_last_resolved_mode"] = "idle"
         self._persist["regulation_skipped_write_reason"] = reason
         self._persist["debug"] = reason.upper()
-        self._persist["last_ts"] = dt_util.utcnow().isoformat()
+        self._persist["last_ts"] = self._clock.utc_now().isoformat()
         await self._save()
 
         details = {
@@ -3794,9 +3803,9 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         try:
             if self._persist.get("last_ts") is None:
                 await self._load()
-                self._persist["last_ts"] = dt_util.utcnow().isoformat()
+                self._persist["last_ts"] = self._clock.utc_now().isoformat()
 
-            now = dt_util.utcnow()
+            now = self._clock.utc_now()
 
             soc = _to_float(self._state(self.entities.soc), None)
             pv = _to_float(self._state(self.entities.pv), None)
@@ -4009,6 +4018,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 tomorrow_entity_id=self.entities.pv_forecast_tomorrow,
                 installed_pv_wp=self._get_installed_pv_wp(),
                 forecast_base_load_w=float(forecast_base_load_w),
+                clock=self._clock,
             )
 
             additional_battery_charge_w = _to_float(

--- a/custom_components/battery_smartflow_ai/core/clock.py
+++ b/custom_components/battery_smartflow_ai/core/clock.py
@@ -1,0 +1,66 @@
+"""Platform-independent production and deterministic Clock implementations."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta, tzinfo
+import time
+
+
+class SystemClock:
+    """Read calendar and monotonic time from the host system."""
+
+    def __init__(self, *, local_timezone: tzinfo = UTC) -> None:
+        self._local_timezone = local_timezone
+
+    def utc_now(self) -> datetime:
+        return datetime.now(UTC)
+
+    def local_now(self) -> datetime:
+        return datetime.now(self._local_timezone)
+
+    def monotonic(self) -> float:
+        return time.monotonic()
+
+
+class TestClock:
+    """Controllable Clock for deterministic domain tests without waiting."""
+
+    __test__ = False
+
+    def __init__(
+        self,
+        now: datetime,
+        *,
+        local_timezone: tzinfo | None = None,
+        monotonic_seconds: float = 0.0,
+    ) -> None:
+        if now.tzinfo is None or now.utcoffset() is None:
+            raise ValueError("now must be timezone-aware")
+        self._utc_now = now.astimezone(UTC)
+        self._local_timezone = local_timezone or now.tzinfo
+        self._monotonic = float(monotonic_seconds)
+
+    def utc_now(self) -> datetime:
+        return self._utc_now
+
+    def local_now(self) -> datetime:
+        return self._utc_now.astimezone(self._local_timezone)
+
+    def monotonic(self) -> float:
+        return self._monotonic
+
+    def set(self, now: datetime) -> None:
+        """Set calendar time without changing the monotonic reading."""
+
+        if now.tzinfo is None or now.utcoffset() is None:
+            raise ValueError("now must be timezone-aware")
+        self._utc_now = now.astimezone(UTC)
+
+    def advance(self, delta: timedelta) -> None:
+        """Advance calendar and monotonic time together."""
+
+        seconds = delta.total_seconds()
+        if seconds < 0:
+            raise ValueError("TestClock cannot advance by a negative duration")
+        self._utc_now += delta
+        self._monotonic += seconds

--- a/custom_components/battery_smartflow_ai/core/ports/__init__.py
+++ b/custom_components/battery_smartflow_ai/core/ports/__init__.py
@@ -1,5 +1,6 @@
 """Platform-independent side-effect boundaries for the BSFAI core."""
 
+from .clock import Clock
 from .state_store import (
     StateLoadResult,
     StateSaveResult,
@@ -8,6 +9,7 @@ from .state_store import (
 )
 
 __all__ = [
+    "Clock",
     "StateLoadResult",
     "StateSaveResult",
     "StateStore",

--- a/custom_components/battery_smartflow_ai/core/ports/clock.py
+++ b/custom_components/battery_smartflow_ai/core/ports/clock.py
@@ -1,0 +1,19 @@
+"""Neutral time source for calendar and process-runtime semantics."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Protocol
+
+
+class Clock(Protocol):
+    """Provide explicit calendar time and monotonic process time."""
+
+    def utc_now(self) -> datetime:
+        """Return an aware UTC timestamp for restart-safe domain time."""
+
+    def local_now(self) -> datetime:
+        """Return an aware local timestamp for calendar-based planning."""
+
+    def monotonic(self) -> float:
+        """Return process-local seconds for non-persisted intervals."""

--- a/custom_components/battery_smartflow_ai/debug_exporter.py
+++ b/custom_components/battery_smartflow_ai/debug_exporter.py
@@ -11,6 +11,7 @@ import tempfile
 import re
 
 from .debug_package import DebugPackage, redact_secrets
+from .core.clock import SystemClock
 
 
 DEBUG_DIRECTORY = Path("bsfai") / "debug"
@@ -173,7 +174,7 @@ def export_debug_package(
         directory.mkdir(parents=True, exist_ok=True)
         destination = _available_destination(
             directory,
-            _filename(package.created_at or datetime.now(timezone.utc)),
+            _filename(package.created_at or SystemClock().utc_now()),
         )
         descriptor, temporary_name = tempfile.mkstemp(
             prefix=".bsfai_debug_",

--- a/custom_components/battery_smartflow_ai/debug_package.py
+++ b/custom_components/battery_smartflow_ai/debug_package.py
@@ -14,6 +14,8 @@ from enum import Enum
 import re
 from typing import Any, Mapping
 
+from .core.clock import SystemClock
+
 
 DEBUG_SCHEMA_NAME = "battery_smartflow_ai.debug"
 DEBUG_SCHEMA_VERSION = 1
@@ -179,7 +181,7 @@ class DebugPackage:
     def as_dict(self) -> dict[str, Any]:
         """Build a complete, JSON-safe and secret-filtered package."""
 
-        created_at = self.created_at or datetime.now(timezone.utc)
+        created_at = self.created_at or SystemClock().utc_now()
         if self.recording_end is not None and self.recording_end < self.recording_start:
             raise ValueError("recording_end must not be before recording_start")
 

--- a/custom_components/battery_smartflow_ai/debug_recorder.py
+++ b/custom_components/battery_smartflow_ai/debug_recorder.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections import deque
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from typing import Any, Mapping
 
 from .debug_package import DebugPackage, DebugSample, redact_secrets
@@ -158,7 +158,7 @@ class DebugRecorder:
             integration_version=self._integration_version,
             recording_start=self._recording_start,
             recording_end=now,
-            created_at=datetime.now(timezone.utc),
+            created_at=now,
             device_profile=self._device_profile,
             ai_mode=self._ai_mode,
             season_mode=self._season_mode,

--- a/custom_components/battery_smartflow_ai/forecast.py
+++ b/custom_components/battery_smartflow_ai/forecast.py
@@ -16,6 +16,8 @@ from .const import (
     PV_OUTLOOK_POOR,
     PV_OUTLOOK_UNKNOWN,
 )
+from .core.clock import SystemClock
+from .core.ports import Clock
 
 
 @dataclass
@@ -233,6 +235,7 @@ def _compute_peak_kw_for_date(
 def _compute_peaks_for_sensor(
     hass: HomeAssistant,
     entity_id: str | None,
+    now_local: datetime,
 ) -> tuple[float, float]:
     """
     Returns:
@@ -242,7 +245,6 @@ def _compute_peaks_for_sensor(
     if not found:
         return 0.0, 0.0
 
-    now_local = dt_util.as_local(dt_util.utcnow())
     today = now_local.date()
     tomorrow = (now_local + timedelta(days=1)).date()
 
@@ -320,6 +322,7 @@ def _compute_subday_metrics(
     today_entity_id: str | None,
     tomorrow_entity_id: str | None,
     forecast_base_load_w: float,
+    now_local: datetime,
 ) -> tuple[float, float, float, float]:
     """
     Returns:
@@ -330,10 +333,10 @@ def _compute_subday_metrics(
     """
     attrs, found = _read_sensor_attrs(hass, today_entity_id)
     if not found:
-        _, peak_tomorrow_w = _compute_peaks_for_sensor(hass, tomorrow_entity_id)
+        _, peak_tomorrow_w = _compute_peaks_for_sensor(
+            hass, tomorrow_entity_id, now_local
+        )
         return 0.0, 0.0, 0.0, peak_tomorrow_w
-
-    now_local = dt_util.as_local(dt_util.utcnow())
 
     hourly = _iter_hourly_intervals(attrs)
     if hourly:
@@ -351,8 +354,12 @@ def _compute_subday_metrics(
             slot_minutes=60,
             forecast_base_load_w=forecast_base_load_w,
         )
-        peak_today_w, _ = _compute_peaks_for_sensor(hass, today_entity_id)
-        _, peak_tomorrow_w = _compute_peaks_for_sensor(hass, tomorrow_entity_id)
+        peak_today_w, _ = _compute_peaks_for_sensor(
+            hass, today_entity_id, now_local
+        )
+        _, peak_tomorrow_w = _compute_peaks_for_sensor(
+            hass, tomorrow_entity_id, now_local
+        )
         return next_3h_kwh, next_6h_kwh, peak_today_w, peak_tomorrow_w
 
     halfhour = _iter_halfhour_intervals(attrs)
@@ -371,11 +378,17 @@ def _compute_subday_metrics(
             slot_minutes=30,
             forecast_base_load_w=forecast_base_load_w,
         )
-        peak_today_w, _ = _compute_peaks_for_sensor(hass, today_entity_id)
-        _, peak_tomorrow_w = _compute_peaks_for_sensor(hass, tomorrow_entity_id)
+        peak_today_w, _ = _compute_peaks_for_sensor(
+            hass, today_entity_id, now_local
+        )
+        _, peak_tomorrow_w = _compute_peaks_for_sensor(
+            hass, tomorrow_entity_id, now_local
+        )
         return next_3h_kwh, next_6h_kwh, peak_today_w, peak_tomorrow_w
 
-    _, peak_tomorrow_w = _compute_peaks_for_sensor(hass, tomorrow_entity_id)
+    _, peak_tomorrow_w = _compute_peaks_for_sensor(
+        hass, tomorrow_entity_id, now_local
+    )
     return 0.0, 0.0, 0.0, peak_tomorrow_w
 
 
@@ -385,6 +398,8 @@ def build_forecast_summary(
     tomorrow_entity_id: str | None,
     installed_pv_wp: float = 0.0,
     forecast_base_load_w: float = 300.0,
+    *,
+    clock: Clock | None = None,
 ) -> ForecastSummary:
     """
     Build a normalized optional forecast summary from two daily forecast sensors.
@@ -415,7 +430,7 @@ def build_forecast_summary(
             pv_outlook=PV_OUTLOOK_UNKNOWN,
         )
 
-    now_local = dt_util.as_local(dt_util.utcnow())
+    now_local = (clock or SystemClock()).local_now()
     today = now_local.date()
     tomorrow = (now_local + timedelta(days=1)).date()
 
@@ -440,6 +455,7 @@ def build_forecast_summary(
         today_entity_id=today_entity_id,
         tomorrow_entity_id=tomorrow_entity_id,
         forecast_base_load_w=forecast_base_load_w,
+        now_local=now_local,
     )
 
     pv_outlook = _classify_pv_outlook(

--- a/docs/architecture/clock-v4.7.0.md
+++ b/docs/architecture/clock-v4.7.0.md
@@ -1,0 +1,76 @@
+# Clock-Grenze in V4.7.0
+
+Issue #271 zentralisiert die Zeitbeschaffung für Core-Logik, ohne die Semantik
+bereits persistierter Zeitstempel zu verändern.
+
+## Laufzeitpfad
+
+```text
+Coordinator
+    |
+    v
+core.ports.Clock
+    |-- utc_now()    -> restart-feste Fach- und Persistenzzeit
+    |-- local_now()  -> lokale Kalender-, Preis- und Lernplanung
+    `-- monotonic()  -> ausschließlich prozesslokale Laufzeitabstände
+    |
+    v
+HomeAssistantClock / SystemClock / TestClock
+```
+
+`HomeAssistantClock` übernimmt die in Home Assistant konfigurierte Zeitzone.
+`SystemClock` ist die plattformunabhängige Produktionsimplementierung.
+`TestClock` kann UTC-Zeit, lokale Zeit und monotone Laufzeit ohne reales Warten
+deterministisch fortschreiben.
+
+## Inventar und Zeitsemantik
+
+| Bereich | Quelle im Core | Semantik | Begründung |
+| --- | --- | --- | --- |
+| DecisionEngine und RuntimeSnapshot | übergebenes `now` | aware UTC/Kalenderzeit | Preise, Forecasts und Deadlines benötigen absolute Vergleichbarkeit |
+| ChargeCommit | `started_at`, `latest_start`, `deadline`, `valid_until` | UTC/Kalenderzeit, persistiert | Bindungen müssen nach einem Neustart korrekt weiterlaufen oder ablaufen |
+| Lern- und Ladeplanung | aus `now` abgeleitete lokale Zeit | lokale Kalenderzeit | Wochentag, Tageszeit, Morgenlast und Preisfenster sind zeitzonenabhängig |
+| Forecast | `Clock.local_now()` | lokale Kalenderzeit | Heute/Morgen und 3h-/6h-Fenster folgen der HA-Zeitzone |
+| Economics und Energieakkumulator | übergebenes `sampled_at` | aware Kalenderzeit | Tageswechsel und anteilige Zuordnung über Mitternacht müssen deterministisch bleiben |
+| ModeArbiter und Regulation | persistierte UTC-Zeitstempel | UTC/Kalenderzeit | Cooldowns, Latches und Holds werden heute gespeichert und müssen Neustarts überleben |
+| CommandEffectiveness | persistiertes `last_retry_at` | UTC/Kalenderzeit | Wiederholschutz darf nach einem Neustart nicht sofort umgangen werden |
+| Debug-Aufzeichnung | vom Coordinator übergebenes UTC-`now` | UTC/Kalenderzeit | Exportzeitfenster müssen als reale Zeitstempel verständlich bleiben |
+| künftige rein prozesslokale Intervalle | `Clock.monotonic()` | monoton | unempfindlich gegen Systemzeitkorrekturen; niemals persistieren |
+
+## Bewusste Entscheidung zu Cooldowns und Holds
+
+Monotone Zeit wäre für einen ausschließlich im Prozess lebenden Cooldown ideal.
+Die vorhandenen ModeArbiter-, Regulation- und CommandEffectiveness-Zeitpunkte
+liegen jedoch im StateStore. Ein Wechsel auf monotone Sekunden würde ihre
+Bedeutung bei einem Neustart zerstören, weil der monotone Zähler dann neu
+beginnt. #271 erhält deshalb für diese vorhandenen Zustände bewusst die
+UTC-Kalenderzeit.
+
+`Clock.monotonic()` ist für neue oder später explizit als nicht persistent
+klassifizierte Laufzeitintervalle verfügbar. Eine spätere Umstellung eines
+bestehenden Zustands erfordert zuerst eine eigene Persistenz- und
+Restart-Entscheidung.
+
+## Deterministische Tests
+
+Mit `TestClock` können Tests gezielt:
+
+- Preis- und Forecast-Slots wechseln,
+- einen lokalen Tageswechsel auslösen,
+- Commit-Deadlines und Latest-Start erreichen,
+- Holds und Cooldowns vor und nach Ablauf prüfen,
+- Economics-Zeit über Mitternacht fortschreiben,
+- monotone Laufzeit unabhängig von einer Kalenderzeitkorrektur prüfen.
+
+Die fachlichen Komponenten behalten ihre bereits vorhandenen expliziten
+`now`-/`sampled_at`-Parameter. Der Coordinator beschafft den Zeitpunkt einmal
+über die Clock und reicht ihn weiter. Dadurch bleiben die Modelle frei von
+Home-Assistant- und globalen Systemzeitfunktionen.
+
+## Abgrenzung
+
+#271 ändert keine Zeitdauer, keinen Deadline-Algorithmus und kein gespeichertes
+Zeitformat. Direkte Zeit-Fallbacks in reinem Debug-Exportcode sind keine
+Core-Entscheidungsquelle; der produktive Debugpfad erhält seine Zeit ebenfalls
+vom Coordinator. Eine künftige vollständige Adapterzerlegung kann diese
+Darstellungs-Fallbacks separat verschieben.

--- a/docs/architecture/core-ha-target-architecture-v4.7.0.md
+++ b/docs/architecture/core-ha-target-architecture-v4.7.0.md
@@ -328,6 +328,9 @@ Eine Clock-Abstraktion darf persistierte Holds/Cooldowns nicht blind auf
 monotone Zeit umstellen. Issue #271 legt je Zustand fest, ob Kalender- oder
 Laufzeitsemantik gilt.
 
+Die umgesetzte Clock-Grenze und das vollständige Zeitsemantik-Inventar sind in
+[`clock-v4.7.0.md`](clock-v4.7.0.md) dokumentiert.
+
 ### DeviceBackend
 
 Der Core definiert langfristig eine kleine Ausführungsgrenze für

--- a/tests/test_clock.py
+++ b/tests/test_clock.py
@@ -1,0 +1,118 @@
+"""Contracts for the platform-independent V4.7 Clock boundary."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+import unittest
+from zoneinfo import ZoneInfo
+
+from support import bootstrap
+
+
+bootstrap()
+
+from custom_components.battery_smartflow_ai.core.clock import (  # noqa: E402
+    SystemClock,
+    TestClock,
+)
+
+
+BERLIN = ZoneInfo("Europe/Berlin")
+
+
+class ClockTests(unittest.TestCase):
+    def test_test_clock_exposes_utc_local_and_monotonic_time(self) -> None:
+        clock = TestClock(
+            datetime(2026, 8, 27, 12, 0, tzinfo=UTC),
+            local_timezone=BERLIN,
+            monotonic_seconds=40.0,
+        )
+
+        self.assertEqual(
+            clock.utc_now(),
+            datetime(2026, 8, 27, 12, 0, tzinfo=UTC),
+        )
+        self.assertEqual(clock.local_now().hour, 14)
+        self.assertEqual(clock.local_now().utcoffset(), timedelta(hours=2))
+        self.assertEqual(clock.monotonic(), 40.0)
+
+    def test_advance_moves_deadlines_and_runtime_together(self) -> None:
+        clock = TestClock(
+            datetime(2026, 8, 27, 23, 45, tzinfo=BERLIN),
+            local_timezone=BERLIN,
+            monotonic_seconds=10.0,
+        )
+
+        clock.advance(timedelta(minutes=30))
+
+        self.assertEqual(clock.local_now().date().isoformat(), "2026-08-28")
+        self.assertEqual(clock.local_now().strftime("%H:%M"), "00:15")
+        self.assertEqual(clock.monotonic(), 1810.0)
+
+    def test_calendar_set_does_not_fake_process_elapsed_time(self) -> None:
+        clock = TestClock(
+            datetime(2026, 8, 27, 12, 0, tzinfo=UTC),
+            monotonic_seconds=25.0,
+        )
+
+        clock.set(datetime(2026, 8, 28, 12, 0, tzinfo=UTC))
+
+        self.assertEqual(clock.utc_now().day, 28)
+        self.assertEqual(clock.monotonic(), 25.0)
+
+    def test_naive_time_and_negative_advance_are_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            TestClock(datetime(2026, 8, 27, 12, 0))
+
+        clock = TestClock(datetime(2026, 8, 27, 12, 0, tzinfo=UTC))
+        with self.assertRaises(ValueError):
+            clock.advance(timedelta(seconds=-1))
+
+    def test_system_clock_returns_aware_values(self) -> None:
+        clock = SystemClock(local_timezone=BERLIN)
+
+        self.assertIsNotNone(clock.utc_now().utcoffset())
+        self.assertIsNotNone(clock.local_now().utcoffset())
+        self.assertGreater(clock.monotonic(), 0.0)
+
+    def test_core_clock_has_no_home_assistant_dependency(self) -> None:
+        root = Path(__file__).resolve().parents[1]
+        port = (
+            root
+            / "custom_components"
+            / "battery_smartflow_ai"
+            / "core"
+            / "ports"
+            / "clock.py"
+        ).read_text(encoding="utf-8")
+        implementation = (
+            root
+            / "custom_components"
+            / "battery_smartflow_ai"
+            / "core"
+            / "clock.py"
+        ).read_text(encoding="utf-8")
+        coordinator = (
+            root
+            / "custom_components"
+            / "battery_smartflow_ai"
+            / "coordinator.py"
+        ).read_text(encoding="utf-8")
+        forecast = (
+            root
+            / "custom_components"
+            / "battery_smartflow_ai"
+            / "forecast.py"
+        ).read_text(encoding="utf-8")
+
+        self.assertNotIn("homeassistant", port)
+        self.assertNotIn("homeassistant", implementation)
+        self.assertNotIn("dt_util.utcnow()", coordinator)
+        self.assertNotIn("dt_util.utcnow()", forecast)
+        self.assertIn("clock: Clock | None = None", coordinator)
+        self.assertIn("clock=self._clock", coordinator)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Zusammenfassung
- führt einen neutralen Clock-Port mit UTC-, lokaler und monotoner Zeit ein
- ergänzt SystemClock, HomeAssistantClock und eine deterministisch steuerbare TestClock
- injiziert die Clock in Coordinator und Forecast, sodass Core-Zeit nicht mehr direkt aus globalen HA-/Systemfunktionen stammt
- führt auch Debug-Aufnahme und Debug-Fallbacks über die zentrale Zeitgrenze
- erhält persistierte UTC-Deadlines, Holds und Cooldowns bewusst restart-kompatibel
- dokumentiert die Zeitsemantik für Planung, Forecast, Economics, ChargeCommit, Regulation und Diagnose

## Validierung
- 359 passed, 326 subtests passed
- 38 fokussierte Debugtests bestanden
- 6 neue Clock-Vertragstests bestanden
- direkte Systemzeitaufrufe existieren nur noch in SystemClock
- python -m compileall -q custom_components/battery_smartflow_ai tests
- git diff --check

Closes #271