### PR TITLE
V4.7.0: DeviceProfiles und Capabilities konsolidieren

### DIFF
--- a/custom_components/battery_smartflow_ai/automatic_strategy.py
+++ b/custom_components/battery_smartflow_ai/automatic_strategy.py
@@ -55,7 +55,7 @@ def maintain_active_economic_discharge(
 ) -> bool:
     """Keep self-reducing grid import from cancelling active discharge.
 
-    An SF800Pro can report net battery charging while simultaneously supplying
+    A DC-PV passthrough-capable device can report net battery charging while supplying
     AC output from its DC bus. Therefore the commanded output, rather than the
     signed battery-power sensor alone, identifies an active discharge cycle.
     The hold is only inherited from a real discharge state; PV passthrough must

--- a/custom_components/battery_smartflow_ai/config_flow.py
+++ b/custom_components/battery_smartflow_ai/config_flow.py
@@ -58,7 +58,7 @@ from .const import (
     DEFAULT_LEARNED_PLANNING_ENABLED,
 )
 
-from .device_profiles import DEVICE_PROFILES
+from .device_profiles import DEVICE_PROFILE_MODELS
 from .price_currency import price_input_profile, resolve_price_currency
 
 EMPTY_ENTITY_VALUES = {
@@ -292,9 +292,9 @@ class ZendureSmartFlowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 options=[
                     {
                         "value": key,
-                        "label": DEVICE_PROFILES[key].get("label", key),
+                        "label": DEVICE_PROFILE_MODELS[key].label,
                     }
-                    for key in DEVICE_PROFILES
+                    for key in DEVICE_PROFILE_MODELS
                 ],
                 mode=selector.SelectSelectorMode.DROPDOWN,
             )

--- a/custom_components/battery_smartflow_ai/coordinator.py
+++ b/custom_components/battery_smartflow_ai/coordinator.py
@@ -105,7 +105,7 @@ from .const import (
     ZENDURE_MODE_INPUT,
     ZENDURE_MODE_OUTPUT,
 )
-from .device_profiles import DEVICE_PROFILES, merge_profile_with_overrides
+from .device_profiles import get_device_profile, merge_profile_with_overrides
 from .decision_engine import (
     advance_pv_charge_hysteresis,
     compute_pv_attributable_export_w,
@@ -163,7 +163,7 @@ from .strategy_adapter import decision_to_strategy_intent
 from .strategy_state import ChargeCommitState
 from .mode_arbiter import ModeArbiter, build_mode_arbiter_config
 from .regulation_models import RegulationRuntimeState
-from .core.models import CommandExecutionResult, DeviceCommand
+from .core.models import CommandExecutionResult, DeviceCapabilities, DeviceCommand
 from .core.ports import Clock
 from .regulation_power_controller import (
     RegulationPowerController,
@@ -347,10 +347,8 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             or DEFAULT_DEVICE_PROFILE
         )
 
-        self._device_profile_cfg = DEVICE_PROFILES.get(
-            self.device_profile_key,
-            DEVICE_PROFILES[DEFAULT_DEVICE_PROFILE],
-        )
+        self._device_profile = get_device_profile(self.device_profile_key)
+        self._device_profile_cfg = self._device_profile.as_legacy_mapping()
 
         self.runtime_settings: dict[str, float] = dict(entry.options)
 
@@ -406,12 +404,16 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         )
         
         self._mode_arbiter = ModeArbiter(
-            build_mode_arbiter_config(self._get_active_profile())
+            build_mode_arbiter_config(
+                self._get_active_profile(),
+                self._device_profile.capabilities,
+            )
         )
         
         self._regulation_power_controller = RegulationPowerController(
             build_regulation_power_config(
                 self._get_active_profile(),
+                capabilities=self._device_profile.capabilities,
                 price_step=price_input_profile(self.price_currency).step,
             )
         )
@@ -3113,7 +3115,8 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         forecast_remaining_today_kwh: float,
         battery_capacity_kwh: float,
     ) -> tuple[bool, float, str]:
-        enabled = bool(profile.get("PV_HOUSELOAD_PASSTHROUGH", False))
+        capabilities = DeviceCapabilities.from_profile(profile)
+        enabled = capabilities.supports_pv_house_load_passthrough
 
         active = bool(self._persist.get("pv_houseload_passthrough_active", False))
         started_ts_raw = self._persist.get("pv_houseload_passthrough_started_ts")
@@ -3208,12 +3211,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     except (TypeError, ValueError):
                         daylight_available = False
 
-            mppt_clips_without_output = bool(
-                profile.get(
-                    "MPPT_CLIPS_WITHOUT_OUTPUT",
-                    False,
-                )
-            )
+            mppt_clips_without_output = capabilities.mppt_clips_without_output
             full_soc_threshold = max(
                 float(soc_min),
                 float(soc_max) - 1.0,
@@ -3835,6 +3833,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self._persist["prev_soc"] = soc
 
             profile = self._get_active_profile()
+            device_capabilities = self._device_profile.capabilities
             
             export_market_price = self._get_export_market_price(now)
             feed_in_tariff = float(
@@ -3852,12 +3851,10 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             offgrid_mode = self._normalize_offgrid_mode(offgrid_mode_raw)
 
             supports_offgrid_socket = bool(
-                profile.get("SUPPORTS_OFFGRID_SOCKET", False)
+                device_capabilities.supports_offgrid_socket
             ) or bool(self.entities.offgrid_power)
 
-            supports_offgrid_input = bool(
-                profile.get("SUPPORTS_OFFGRID_INPUT", False)
-            )
+            supports_offgrid_input = device_capabilities.supports_offgrid_input
 
             offgrid_load_active_w = float(
                 profile.get("OFFGRID_LOAD_ACTIVE_W", 50.0) or 50.0
@@ -4117,8 +4114,8 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     additional_battery_discharge_w=float(
                         additional_battery_discharge_w or 0.0
                     ),
-                    mppt_clips_without_output=bool(
-                        profile.get("MPPT_CLIPS_WITHOUT_OUTPUT", False)
+                    mppt_clips_without_output=(
+                        device_capabilities.mppt_clips_without_output
                     ),
                 )
             )

--- a/custom_components/battery_smartflow_ai/core/models/__init__.py
+++ b/custom_components/battery_smartflow_ai/core/models/__init__.py
@@ -4,6 +4,7 @@ from .device import (
     CommandExecutionResult,
     CommandExecutionStatus,
     DeviceCapabilities,
+    DeviceProfile,
 )
 from .market import (
     MarketPrice,
@@ -50,6 +51,7 @@ __all__ = [
     "CommandExecutionResult",
     "CommandExecutionStatus",
     "DeviceCapabilities",
+    "DeviceProfile",
     "DeviceCommand",
     "DecisionContext",
     "GridHistoryState",

--- a/custom_components/battery_smartflow_ai/core/models/device.py
+++ b/custom_components/battery_smartflow_ai/core/models/device.py
@@ -4,7 +4,26 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import StrEnum
+from types import MappingProxyType
 from typing import Any, Mapping
+
+
+CAPABILITY_PROFILE_KEYS = frozenset(
+    {
+        "MAX_INPUT_W",
+        "MAX_OUTPUT_W",
+        "SUPPORTS_PASSTHROUGH",
+        "PV_HOUSELOAD_PASSTHROUGH",
+        "OUTPUT_ZERO_IS_NEUTRAL",
+        "INPUT_KEEPALIVE_SAFE",
+        "REQUIRES_STABLE_EXPORT_FOR_INPUT",
+        "SUPPORTS_FAST_MODE_SWITCH",
+        "SUPPORTS_OFFGRID_SOCKET",
+        "SUPPORTS_OFFGRID_INPUT",
+        "OFFGRID_MAX_INTERNAL_SUPPLY_W",
+        "MPPT_CLIPS_WITHOUT_OUTPUT",
+    }
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -14,10 +33,19 @@ class DeviceCapabilities:
     max_input_w: float
     max_output_w: float
     supports_passthrough: bool = False
+    supports_pv_house_load_passthrough: bool = False
     supports_fast_mode_switch: bool = False
     supports_offgrid_socket: bool = False
     supports_offgrid_input: bool = False
     offgrid_max_internal_supply_w: float = 0.0
+    output_zero_is_neutral: bool = True
+    input_keepalive_safe: bool = True
+    requires_stable_export_for_input: bool = False
+    mppt_clips_without_output: bool = False
+    supports_charge: bool = True
+    supports_discharge: bool = True
+    supports_ac_charge: bool = True
+    supports_power_limits: bool = True
 
     @classmethod
     def from_profile(cls, profile: Mapping[str, Any]) -> DeviceCapabilities:
@@ -27,6 +55,12 @@ class DeviceCapabilities:
             max_input_w=float(profile.get("MAX_INPUT_W", 0.0) or 0.0),
             max_output_w=float(profile.get("MAX_OUTPUT_W", 0.0) or 0.0),
             supports_passthrough=bool(profile.get("SUPPORTS_PASSTHROUGH", False)),
+            supports_pv_house_load_passthrough=bool(
+                profile.get(
+                    "PV_HOUSELOAD_PASSTHROUGH",
+                    profile.get("SUPPORTS_PASSTHROUGH", False),
+                )
+            ),
             supports_fast_mode_switch=bool(
                 profile.get("SUPPORTS_FAST_MODE_SWITCH", False)
             ),
@@ -39,7 +73,88 @@ class DeviceCapabilities:
             offgrid_max_internal_supply_w=float(
                 profile.get("OFFGRID_MAX_INTERNAL_SUPPLY_W", 0.0) or 0.0
             ),
+            output_zero_is_neutral=bool(
+                profile.get("OUTPUT_ZERO_IS_NEUTRAL", True)
+            ),
+            input_keepalive_safe=bool(
+                profile.get("INPUT_KEEPALIVE_SAFE", True)
+            ),
+            requires_stable_export_for_input=bool(
+                profile.get("REQUIRES_STABLE_EXPORT_FOR_INPUT", False)
+            ),
+            mppt_clips_without_output=bool(
+                profile.get("MPPT_CLIPS_WITHOUT_OUTPUT", False)
+            ),
         )
+
+    def as_legacy_mapping(self) -> dict[str, Any]:
+        """Return the unchanged V4.6 capability-key representation."""
+
+        return {
+            "MAX_INPUT_W": self.max_input_w,
+            "MAX_OUTPUT_W": self.max_output_w,
+            "SUPPORTS_PASSTHROUGH": self.supports_passthrough,
+            "PV_HOUSELOAD_PASSTHROUGH": (
+                self.supports_pv_house_load_passthrough
+            ),
+            "SUPPORTS_FAST_MODE_SWITCH": self.supports_fast_mode_switch,
+            "SUPPORTS_OFFGRID_SOCKET": self.supports_offgrid_socket,
+            "SUPPORTS_OFFGRID_INPUT": self.supports_offgrid_input,
+            "OFFGRID_MAX_INTERNAL_SUPPLY_W": self.offgrid_max_internal_supply_w,
+            "OUTPUT_ZERO_IS_NEUTRAL": self.output_zero_is_neutral,
+            "INPUT_KEEPALIVE_SAFE": self.input_keepalive_safe,
+            "REQUIRES_STABLE_EXPORT_FOR_INPUT": (
+                self.requires_stable_export_for_input
+            ),
+            "MPPT_CLIPS_WITHOUT_OUTPUT": self.mppt_clips_without_output,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class DeviceProfile:
+    """Manufacturer-neutral capabilities plus behavior-preserving tuning.
+
+    ``settings`` deliberately retains the established uppercase tuning keys.
+    Those keys remain the options/migration contract while capabilities and
+    hardware limits have one typed owner for core consumers.
+    """
+
+    key: str
+    label: str
+    capabilities: DeviceCapabilities
+    settings: Mapping[str, Any]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "settings", MappingProxyType(dict(self.settings)))
+
+    @classmethod
+    def from_legacy_mapping(
+        cls,
+        key: str,
+        profile: Mapping[str, Any],
+    ) -> DeviceProfile:
+        """Split the compatible V4.6 mapping without changing any value."""
+
+        settings = {
+            setting_key: value
+            for setting_key, value in profile.items()
+            if setting_key != "label" and setting_key not in CAPABILITY_PROFILE_KEYS
+        }
+        return cls(
+            key=str(key),
+            label=str(profile.get("label", key)),
+            capabilities=DeviceCapabilities.from_profile(profile),
+            settings=settings,
+        )
+
+    def as_legacy_mapping(self) -> dict[str, Any]:
+        """Rebuild the exact dictionary shape used by existing integrations."""
+
+        return {
+            "label": self.label,
+            **dict(self.settings),
+            **self.capabilities.as_legacy_mapping(),
+        }
 
 
 class CommandExecutionStatus(StrEnum):

--- a/custom_components/battery_smartflow_ai/decision_engine.py
+++ b/custom_components/battery_smartflow_ai/decision_engine.py
@@ -17,7 +17,7 @@ from .price_math import peak_threshold
 from .power_controller import PowerController, PowerContext
 
 
-ZendureMode = Literal["input", "output"]
+DeviceACMode = Literal["input", "output"]
 ActionType = Literal["idle", "charge", "discharge", "emergency", "passthrough"]
 
 # V4.3.0-dev5.8.2:
@@ -189,7 +189,7 @@ PricePoint = MarketPricePoint
 @dataclass
 class DecisionResult:
     action: ActionType
-    ac_mode: ZendureMode
+    ac_mode: DeviceACMode
     charge_w: float
     discharge_w: float
     reason: str
@@ -852,7 +852,7 @@ class PvRule(BaseRule):
         charge_w = engine._delta_charge(ctx)
 
         if protection_active and engine._low_soc_pv_charge_requires_export(ctx):
-            # SF800Pro / Low-SoC-Schutz:
+            # Capability-driven DC-PV / low-SoC protection:
             # In der Entlade-Sperrzone darf PV nur dann in den Akku,
             # wenn wirklich stabiler Export vorhanden ist.
             # Kein Soft-Start, kein Akku-Vorrang, kein Laden bei Netzbezug.
@@ -871,7 +871,7 @@ class PvRule(BaseRule):
         # nicht der ganze Ladezustand verloren gehen.
         if keepalive_charge:
             if sf800_passthrough_enabled:
-                # Beim SF800Pro darf INPUT nicht künstlich über 80 W gehalten werden,
+                # Devices without safe INPUT keepalive must not be held above 80 W,
                 # wenn kein echter stabiler Export vorhanden ist.
                 if not has_direct_surplus:
                     return None
@@ -1242,7 +1242,7 @@ class DecisionEngine:
         return self._profile_flag(ctx, "LOW_SOC_DISCHARGE_REQUIRES_CELL_RESUME", False)
 
     def _pv_houseload_passthrough_enabled(self, ctx: DecisionContext) -> bool:
-        return self._profile_flag(ctx, "PV_HOUSELOAD_PASSTHROUGH", False)
+        return ctx.capabilities.supports_pv_house_load_passthrough
         
     def _automatic_valley_charge_context_allows(
         self,

--- a/custom_components/battery_smartflow_ai/device_profiles.py
+++ b/custom_components/battery_smartflow_ai/device_profiles.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from .core.models import DeviceProfile
+
 
 # V4.2.0:
 # Normal user-editable profile fields.
@@ -807,8 +809,25 @@ DEVICE_PROFILES = {
 }
 
 
+# Canonical V4.7 view. ``DEVICE_PROFILES`` remains the stable V4.6 mapping
+# facade for config/options, diagnostics and third-party imports.
+DEVICE_PROFILE_MODELS: dict[str, DeviceProfile] = {
+    key: DeviceProfile.from_legacy_mapping(key, profile)
+    for key, profile in DEVICE_PROFILES.items()
+}
+
+
+def get_device_profile(profile_key: str) -> DeviceProfile:
+    """Return a typed profile with the established SF2400AC fallback."""
+
+    return DEVICE_PROFILE_MODELS.get(
+        profile_key,
+        DEVICE_PROFILE_MODELS["SF2400AC"],
+    )
+
+
 def get_profile_config(profile_key: str) -> dict:
-    return DEVICE_PROFILES.get(profile_key, DEVICE_PROFILES["SF2400AC"])
+    return get_device_profile(profile_key).as_legacy_mapping()
 
 
 def get_profile_defaults(profile_key: str) -> dict:

--- a/custom_components/battery_smartflow_ai/mode_arbiter.py
+++ b/custom_components/battery_smartflow_ai/mode_arbiter.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
+from .core.models import DeviceCapabilities
+
 from homeassistant.util import dt as dt_util
 
 from .regulation_models import (
@@ -113,7 +115,10 @@ def _profile_bool(profile: dict[str, Any], key: str, default: bool) -> bool:
         return bool(default)
 
 
-def build_mode_arbiter_config(profile: dict[str, Any]) -> ModeArbiterConfig:
+def build_mode_arbiter_config(
+    profile: dict[str, Any],
+    capabilities: DeviceCapabilities | None = None,
+) -> ModeArbiterConfig:
     """Build ModeArbiterConfig from device profile/capabilities."""
 
     return ModeArbiterConfig(
@@ -195,40 +200,48 @@ def build_mode_arbiter_config(profile: dict[str, Any]) -> ModeArbiterConfig:
             "EXTERNAL_BATTERY_DISCHARGE_BLOCK_W",
             DEFAULT_EXTERNAL_BATTERY_DISCHARGE_BLOCK_W,
         ),
-        supports_passthrough=_profile_bool(
-            profile,
-            "SUPPORTS_PASSTHROUGH",
-            _profile_bool(profile, "PV_HOUSELOAD_PASSTHROUGH", False),
+        supports_passthrough=(
+            capabilities.supports_passthrough
+            if capabilities is not None
+            else _profile_bool(
+                profile,
+                "SUPPORTS_PASSTHROUGH",
+                _profile_bool(profile, "PV_HOUSELOAD_PASSTHROUGH", False),
+            )
         ),
-        input_keepalive_safe=_profile_bool(
-            profile,
-            "INPUT_KEEPALIVE_SAFE",
-            True,
+        input_keepalive_safe=(
+            capabilities.input_keepalive_safe
+            if capabilities is not None
+            else _profile_bool(profile, "INPUT_KEEPALIVE_SAFE", True)
         ),
-        requires_stable_export_for_input=_profile_bool(
-            profile,
-            "REQUIRES_STABLE_EXPORT_FOR_INPUT",
-            False,
+        requires_stable_export_for_input=(
+            capabilities.requires_stable_export_for_input
+            if capabilities is not None
+            else _profile_bool(
+                profile,
+                "REQUIRES_STABLE_EXPORT_FOR_INPUT",
+                False,
+            )
         ),
-        supports_fast_mode_switch=_profile_bool(
-            profile,
-            "SUPPORTS_FAST_MODE_SWITCH",
-            True,
+        supports_fast_mode_switch=(
+            capabilities.supports_fast_mode_switch
+            if capabilities is not None
+            else _profile_bool(profile, "SUPPORTS_FAST_MODE_SWITCH", True)
         ),
-        supports_offgrid_socket=_profile_bool(
-            profile,
-            "SUPPORTS_OFFGRID_SOCKET",
-            False,
+        supports_offgrid_socket=(
+            capabilities.supports_offgrid_socket
+            if capabilities is not None
+            else _profile_bool(profile, "SUPPORTS_OFFGRID_SOCKET", False)
         ),
-        supports_offgrid_input=_profile_bool(
-            profile,
-            "SUPPORTS_OFFGRID_INPUT",
-            False,
+        supports_offgrid_input=(
+            capabilities.supports_offgrid_input
+            if capabilities is not None
+            else _profile_bool(profile, "SUPPORTS_OFFGRID_INPUT", False)
         ),
-        offgrid_max_internal_supply_w=_profile_float(
-            profile,
-            "OFFGRID_MAX_INTERNAL_SUPPLY_W",
-            0.0,
+        offgrid_max_internal_supply_w=(
+            capabilities.offgrid_max_internal_supply_w
+            if capabilities is not None
+            else _profile_float(profile, "OFFGRID_MAX_INTERNAL_SUPPLY_W", 0.0)
         ),
         offgrid_load_active_w=_profile_float(
             profile,

--- a/custom_components/battery_smartflow_ai/regulation_power_controller.py
+++ b/custom_components/battery_smartflow_ai/regulation_power_controller.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from .core.models import DeviceCapabilities
+
 from .regulation_models import (
     GridHistoryState,
     ModeArbiterResult,
@@ -101,6 +103,7 @@ def _profile_int(profile: dict[str, Any], key: str, default: int) -> int:
 def build_regulation_power_config(
     profile: dict[str, Any],
     *,
+    capabilities: DeviceCapabilities | None = None,
     price_step: float = 0.0,
 ) -> RegulationPowerConfig:
     """Build technical power-controller config from device profile."""
@@ -220,8 +223,16 @@ def build_regulation_power_config(
             "CHARGE_MAX_STEP_DOWN",
             _profile_float(profile, "MAX_STEP_DOWN", DEFAULT_CHARGE_MAX_STEP_DOWN),
         ),
-        max_input_w=_profile_float(profile, "MAX_INPUT_W", 2400.0),
-        max_output_w=_profile_float(profile, "MAX_OUTPUT_W", 2400.0),
+        max_input_w=(
+            capabilities.max_input_w
+            if capabilities is not None
+            else _profile_float(profile, "MAX_INPUT_W", 2400.0)
+        ),
+        max_output_w=(
+            capabilities.max_output_w
+            if capabilities is not None
+            else _profile_float(profile, "MAX_OUTPUT_W", 2400.0)
+        ),
     )
 
 

--- a/docs/architecture/core-ha-target-architecture-v4.7.0.md
+++ b/docs/architecture/core-ha-target-architecture-v4.7.0.md
@@ -345,6 +345,9 @@ Vorläufiger Verantwortungszuschnitt:
 - DeviceCapabilities beschreiben erlaubte Fähigkeiten; sie führen keine
   Herstellerabfrage im Core aus.
 
+Die umgesetzte Profil-/Capability-Trennung und die kompatiblen Legacy-Fallbacks
+sind in [`device-profiles-v4.7.0.md`](device-profiles-v4.7.0.md) dokumentiert.
+
 Safe-Idle, Manual-Standby und Schutzstopps müssen dieselbe Grenze verwenden wie
 der Normalpfad. Das Backend darf nicht nur den glücklichen DeviceCommand-Pfad
 abdecken.

--- a/docs/architecture/device-profiles-v4.7.0.md
+++ b/docs/architecture/device-profiles-v4.7.0.md
@@ -1,0 +1,117 @@
+# DeviceProfile und DeviceCapabilities in V4.7.0
+
+Issue #272 trennt technische Fähigkeiten von Regel-Tuning, ohne den bestehenden
+Profil-, Options- oder Diagnosevertrag zu verändern.
+
+## Modell
+
+```text
+DeviceProfile
+  |-- key / label                Auswahl und Darstellung
+  |-- DeviceCapabilities        Fähigkeiten und technische Grenzen
+  `-- settings                  Regel-, Schutz- und Backend-Tuning
+
+DeviceProfile.as_legacy_mapping()
+  `-- unverändertes V4.6-Dictionary für UI, Overrides und Diagnose
+```
+
+`DeviceProfile` und `DeviceCapabilities` liegen im neutralen Core und können
+ohne Home Assistant instanziiert und getestet werden. `settings` ist eine
+unveränderliche Mapping-Sicht. Damit gibt es im laufenden Modell einen klaren
+Besitzer, während die etablierte Dictionary-Darstellung kompatibel bleibt.
+
+## Verantwortlichkeiten
+
+### DeviceCapabilities
+
+Capabilities beantworten, was ein Backend beziehungsweise Gerät technisch
+kann. Dazu gehören:
+
+- maximale Eingangs- und Ausgangsleistung
+- Laden, Entladen, AC-Laden und Leistungsgrenzen
+- Passthrough
+- DC-PV-/Hauslast-Passthrough als bestehende, engere Teilfähigkeit
+- schneller Moduswechsel
+- neutrales OUTPUT 0
+- sichere INPUT-Keepalive-Leistung
+- erforderlicher stabiler Export vor INPUT
+- Off-Grid-Socket und Off-Grid-Input
+- maximale interne Off-Grid-Versorgung
+- MPPT-Clipping ohne OUTPUT
+
+Die Modelle enthalten weder Hersteller- noch Modellnamen, Entity-IDs, Services
+oder Home-Assistant-Objekte.
+
+### DeviceProfile.settings
+
+Settings beschreiben das unveränderte Verhalten, nicht die Existenz einer
+Gerätefähigkeit:
+
+- Grid-History- und Hystereseparameter
+- ModeArbiter-Zeiten und Zyklusgrenzen
+- Charge-/Discharge-Reglerparameter
+- Ziel-Netzbezug, Export-Guard und Keepalive-Schwellen
+- Schutz- und SoC-Wiederfreigaberegeln
+- Off-Grid-Aktivitätsschwellen
+- bestehendes DC-PV-/Hauslast-Passthrough-Tuning
+
+Kein Wert wurde in #272 neu abgestimmt.
+
+## Core-Verwendung
+
+- `RuntimeSnapshot.capabilities` stellt die neutrale Capability-Sicht bereit.
+- Die DecisionEngine entscheidet Passthrough über
+  `ctx.capabilities.supports_passthrough`, nicht über einen Modellnamen.
+- Der ModeArbiter erhält Fähigkeiten typisiert; seine Zeiten und Zähler kommen
+  weiterhin aus den Settings.
+- Der RegulationPowerController erhält technische Leistungsgrenzen typisiert;
+  KP-, Deadband- und Step-Werte bleiben Settings.
+- Der Coordinator verwendet die typisierte Off-Grid- und MPPT-Sicht. Die
+  Dictionary-Fassade bleibt für Options-Overrides und bestehende Diagnosen.
+
+Strategy, MarketPrice und Economics erhalten dadurch kein neues Zendure-Wissen.
+
+## Legacy- und Übergangsfelder
+
+Die fünf Felder
+
+- `DEADBAND_W`
+- `KP_UP`
+- `KP_DOWN`
+- `MAX_STEP_UP`
+- `MAX_STEP_DOWN`
+
+sind keine kanonischen V4.7-Reglerwerte. Sie bleiben ausschließlich erhalten,
+damit alte gespeicherte Overrides und die bereits vorhandenen gerichteten
+Fallbacks weiter funktionieren. Neue Profile sollen die getrennten
+`CHARGE_*`- und `DISCHARGE_*`-Felder setzen.
+
+Die Aktivierung `PV_HOUSELOAD_PASSTHROUGH` ist als engere Capability typisiert.
+Die übrigen `PV_HOUSELOAD_PASSTHROUGH_*`-Tuning-Schlüssel und historischen `sf800_*`-
+Persistenz-/Diagnosenamen bleiben ebenfalls kompatibel, solange ihre
+zustandsbehaftete Regelung noch im Coordinator liegt. Die fachliche Freigabe
+erfolgt bereits über die neutrale Passthrough-Capability. Eine Umbenennung der
+persistierten Keys wäre eine eigene Migration und gehört nicht in #272.
+
+## Registry und Fallback
+
+`DEVICE_PROFILE_MODELS` ist die typisierte V4.7-Registry. Das bisherige
+`DEVICE_PROFILES` bleibt als stabile Mapping-Fassade verfügbar. Für unbekannte
+Profil-IDs bleibt `SF2400AC` unverändert der Default.
+
+Alle elf vorhandenen Profile werden in Tests vom typisierten Modell zurück in
+die alte Mapping-Form überführt und müssen dabei exakt denselben Schlüssel-
+und Wertebestand liefern. Auch Hardwaregrenzen und Profil-Overrides bleiben
+damit unverändert.
+
+## Erweiterung um weitere Hersteller
+
+Ein späteres Profil benötigt:
+
+1. neutrale `DeviceCapabilities`,
+2. bestätigte technische Limits,
+3. explizite Settings für tatsächlich abweichendes Regelverhalten und
+4. ein separates Backend für die technische Befehlsausführung.
+
+Core-Strategien dürfen dafür weder Hersteller- noch Modellabfragen erhalten.
+#272 führt kein weiteres Backend und keinen neuen Hersteller ein.

--- a/tests/test_device_profiles.py
+++ b/tests/test_device_profiles.py
@@ -12,8 +12,20 @@ from support import bootstrap
 bootstrap()
 
 from custom_components.battery_smartflow_ai.device_profiles import (  # noqa: E402
+    DEVICE_PROFILE_MODELS,
     DEVICE_PROFILES,
     SF2400AC_PROFILE,
+    get_device_profile,
+    merge_profile_with_overrides,
+)
+from custom_components.battery_smartflow_ai.core.models import (  # noqa: E402
+    DeviceCapabilities,
+)
+from custom_components.battery_smartflow_ai.mode_arbiter import (  # noqa: E402
+    build_mode_arbiter_config,
+)
+from custom_components.battery_smartflow_ai.regulation_power_controller import (  # noqa: E402
+    build_regulation_power_config,
 )
 
 
@@ -82,6 +94,97 @@ class MixDeviceProfileTests(unittest.TestCase):
         ):
             with self.subTest(setting=setting):
                 self.assertEqual(maximum_by_key[setting], 4000.0)
+
+
+class TypedDeviceProfileTests(unittest.TestCase):
+    def test_every_typed_profile_rebuilds_the_legacy_mapping_exactly(self) -> None:
+        self.assertEqual(set(DEVICE_PROFILE_MODELS), set(DEVICE_PROFILES))
+
+        for key, legacy in DEVICE_PROFILES.items():
+            with self.subTest(profile=key):
+                self.assertEqual(
+                    DEVICE_PROFILE_MODELS[key].as_legacy_mapping(),
+                    legacy,
+                )
+
+    def test_capabilities_and_tuning_have_distinct_owners(self) -> None:
+        profile = DEVICE_PROFILE_MODELS["SF800Pro"]
+
+        self.assertEqual(profile.capabilities.max_input_w, 1000.0)
+        self.assertEqual(profile.capabilities.max_output_w, 800.0)
+        self.assertTrue(profile.capabilities.supports_passthrough)
+        self.assertTrue(
+            profile.capabilities.supports_pv_house_load_passthrough
+        )
+        self.assertTrue(profile.capabilities.mppt_clips_without_output)
+        self.assertFalse(profile.capabilities.input_keepalive_safe)
+        self.assertNotIn("MAX_INPUT_W", profile.settings)
+        self.assertNotIn("SUPPORTS_PASSTHROUGH", profile.settings)
+        self.assertNotIn("PV_HOUSELOAD_PASSTHROUGH", profile.settings)
+        self.assertEqual(profile.settings["CHARGE_DEADBAND_W"], 35.0)
+        self.assertEqual(profile.settings["DISCHARGE_KP_DOWN"], 0.75)
+
+        with self.assertRaises(TypeError):
+            profile.settings["CHARGE_DEADBAND_W"] = 999.0  # type: ignore[index]
+
+    def test_unknown_profile_keeps_the_existing_sf2400ac_fallback(self) -> None:
+        self.assertIs(
+            get_device_profile("future-unknown-device"),
+            DEVICE_PROFILE_MODELS["SF2400AC"],
+        )
+
+    def test_legacy_override_fields_remain_compatibility_only(self) -> None:
+        merged = merge_profile_with_overrides(
+            "SF2400AC",
+            {
+                "DEADBAND_W": 77.0,
+                "CHARGE_DEADBAND_W": 44.0,
+                "MAX_INPUT_W": 9999.0,
+                "SUPPORTS_PASSTHROUGH": True,
+            },
+        )
+
+        self.assertEqual(merged["DEADBAND_W"], 77.0)
+        self.assertEqual(merged["CHARGE_DEADBAND_W"], 44.0)
+        self.assertEqual(merged["MAX_INPUT_W"], 2400.0)
+        self.assertFalse(merged["SUPPORTS_PASSTHROUGH"])
+
+    def test_core_configs_prefer_typed_capabilities_over_mapping_flags(self) -> None:
+        legacy = dict(DEVICE_PROFILES["SF2400AC"])
+        capabilities = DeviceCapabilities(
+            max_input_w=1111.0,
+            max_output_w=777.0,
+            supports_passthrough=True,
+            supports_fast_mode_switch=False,
+            supports_offgrid_socket=False,
+            supports_offgrid_input=False,
+            output_zero_is_neutral=False,
+            input_keepalive_safe=False,
+            requires_stable_export_for_input=True,
+        )
+
+        arbiter = build_mode_arbiter_config(legacy, capabilities)
+        power = build_regulation_power_config(
+            legacy,
+            capabilities=capabilities,
+        )
+
+        self.assertTrue(arbiter.supports_passthrough)
+        self.assertFalse(arbiter.supports_fast_mode_switch)
+        self.assertFalse(arbiter.input_keepalive_safe)
+        self.assertTrue(arbiter.requires_stable_export_for_input)
+        self.assertEqual(power.max_input_w, 1111.0)
+        self.assertEqual(power.max_output_w, 777.0)
+
+    def test_partial_mapping_builder_defaults_remain_unchanged(self) -> None:
+        arbiter = build_mode_arbiter_config({})
+        power = build_regulation_power_config({})
+
+        self.assertTrue(arbiter.supports_fast_mode_switch)
+        self.assertTrue(arbiter.input_keepalive_safe)
+        self.assertFalse(arbiter.supports_passthrough)
+        self.assertEqual(power.max_input_w, 2400.0)
+        self.assertEqual(power.max_output_w, 2400.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Zusammenfassung
- führt ein neutrales, unveränderliches DeviceProfile mit klar getrennten DeviceCapabilities und Tuning-Settings ein
- behält DEVICE_PROFILES und die vollständige V4.6-Dictionary-Darstellung als kompatible Fassade bei
- erweitert DeviceCapabilities um die tatsächlich verwendeten technischen Fähigkeiten und Grenzen
- führt DecisionEngine, ModeArbiter, RegulationPowerController und Coordinator über die typisierte Capability-Sicht
- erhält Legacy-Override-Felder ausschließlich als dokumentierten Migrations-/Fallbackpfad
- entfernt Hersteller-/Modellbegriffe aus zentralem Strategy-/Regulation-Code
- dokumentiert Profilverantwortung, Legacy-Felder und die spätere Backend-Erweiterung

## Kompatibilität
- alle 11 Profile rekonstruieren exakt denselben Schlüssel- und Wertebestand wie zuvor
- keine Leistungsgrenze und kein Tuningwert wurde verändert
- unbekannte Profile fallen weiterhin auf SF2400AC zurück
- partielle Mapping-Aufrufer behalten die bisherigen Builder-Defaults
- historische PV-Hauslast-Passthrough-Semantik bleibt als eigene Capability erhalten

## Validierung
- 365 Tests bestanden
- 337 Subtests bestanden
- Syntax- und Importprüfung bestanden
- git diff --check bestanden

Closes #272