### PR TITLE
V4.7.0: DeviceBackend-Schnittstelle formalisieren

### DIFF
--- a/custom_components/battery_smartflow_ai/adapters/home_assistant/device_backend.py
+++ b/custom_components/battery_smartflow_ai/adapters/home_assistant/device_backend.py
@@ -1,0 +1,102 @@
+"""Execute neutral core commands through the HA entity backend."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+from ...core.models.device import (
+    CommandExecutionResult,
+    CommandExecutionStatus,
+    DeviceCapabilities,
+)
+from ...core.models.regulation import DeviceCommand
+from ...core.ports.device_backend import DeviceBackendExecutionError
+
+ModeWriter = Callable[[str], Awaitable[None]]
+PowerWriter = Callable[..., Awaitable[None]]
+
+
+class HomeAssistantEntityBackend:
+    """Map a neutral DeviceCommand to the current Select/Number writers."""
+
+    def __init__(
+        self,
+        *,
+        capabilities: DeviceCapabilities | None = None,
+        set_ac_mode: ModeWriter,
+        set_input_limit: PowerWriter,
+        set_output_limit: PowerWriter,
+    ) -> None:
+        self._capabilities = capabilities or DeviceCapabilities(0.0, 0.0)
+        self._set_ac_mode = set_ac_mode
+        self._set_input_limit = set_input_limit
+        self._set_output_limit = set_output_limit
+
+    @property
+    def capabilities(self) -> DeviceCapabilities:
+        return self._capabilities
+
+    async def execute(
+        self,
+        command: DeviceCommand,
+        *,
+        force_power: bool = True,
+        power_before_mode: bool = False,
+    ) -> CommandExecutionResult:
+        """Execute requested writes in the established order."""
+
+        if command.skipped or not (
+            command.should_write_mode
+            or command.should_write_input
+            or command.should_write_output
+        ):
+            return CommandExecutionResult(
+                status=CommandExecutionStatus.SKIPPED,
+                reason=command.skip_reason or command.reason,
+            )
+
+        mode_written = False
+        input_written = False
+        output_written = False
+
+        async def write_power() -> None:
+            nonlocal input_written, output_written
+            if command.should_write_input:
+                await self._set_input_limit(
+                    command.input_limit_w,
+                    force=force_power,
+                )
+                input_written = True
+            if command.should_write_output:
+                await self._set_output_limit(
+                    command.output_limit_w,
+                    force=force_power,
+                )
+                output_written = True
+
+        try:
+            if power_before_mode:
+                await write_power()
+            if command.should_write_mode:
+                await self._set_ac_mode(command.ac_mode)
+                mode_written = True
+            if not power_before_mode:
+                await write_power()
+        except Exception as err:
+            result = CommandExecutionResult(
+                status=CommandExecutionStatus.FAILED,
+                reason=command.reason,
+                mode_written=mode_written,
+                input_written=input_written,
+                output_written=output_written,
+                error=f"{type(err).__name__}: {err}",
+            )
+            raise DeviceBackendExecutionError(result) from err
+
+        return CommandExecutionResult(
+            status=CommandExecutionStatus.APPLIED,
+            reason=command.reason,
+            mode_written=mode_written,
+            input_written=input_written,
+            output_written=output_written,
+        )

--- a/custom_components/battery_smartflow_ai/adapters/home_assistant/device_command_executor.py
+++ b/custom_components/battery_smartflow_ai/adapters/home_assistant/device_command_executor.py
@@ -1,110 +1,12 @@
-"""Execute neutral core commands through the existing HA entity write path."""
+"""Compatibility facade for the Issue #269 command-executor names."""
 
-from __future__ import annotations
+from ...core.ports.device_backend import DeviceBackendExecutionError
+from .device_backend import HomeAssistantEntityBackend
 
-from collections.abc import Awaitable, Callable
+HomeAssistantEntityCommandExecutor = HomeAssistantEntityBackend
+DeviceCommandExecutionError = DeviceBackendExecutionError
 
-from ...core.models.device import (
-    CommandExecutionResult,
-    CommandExecutionStatus,
-)
-from ...core.models.regulation import DeviceCommand
-
-
-ModeWriter = Callable[[str], Awaitable[None]]
-PowerWriter = Callable[..., Awaitable[None]]
-
-
-class DeviceCommandExecutionError(RuntimeError):
-    """Preserve the platform exception while exposing neutral failure feedback."""
-
-    def __init__(self, result: CommandExecutionResult) -> None:
-        super().__init__(result.error or result.reason)
-        self.result = result
-
-
-class HomeAssistantEntityCommandExecutor:
-    """Map a neutral DeviceCommand to the current Select/Number writers.
-
-    Entity IDs, services, availability checks, clamping and cache updates stay
-    in the supplied Home Assistant writer callbacks. The core command contains
-    no knowledge of those platform details.
-    """
-
-    def __init__(
-        self,
-        *,
-        set_ac_mode: ModeWriter,
-        set_input_limit: PowerWriter,
-        set_output_limit: PowerWriter,
-    ) -> None:
-        self._set_ac_mode = set_ac_mode
-        self._set_input_limit = set_input_limit
-        self._set_output_limit = set_output_limit
-
-    async def execute(
-        self,
-        command: DeviceCommand,
-        *,
-        force_power: bool = True,
-        power_before_mode: bool = False,
-    ) -> CommandExecutionResult:
-        """Execute requested writes in the established order."""
-
-        if command.skipped or not (
-            command.should_write_mode
-            or command.should_write_input
-            or command.should_write_output
-        ):
-            return CommandExecutionResult(
-                status=CommandExecutionStatus.SKIPPED,
-                reason=command.skip_reason or command.reason,
-            )
-
-        mode_written = False
-        input_written = False
-        output_written = False
-
-        async def write_power() -> None:
-            nonlocal input_written, output_written
-            if command.should_write_input:
-                await self._set_input_limit(
-                    command.input_limit_w,
-                    force=force_power,
-                )
-                input_written = True
-            if command.should_write_output:
-                await self._set_output_limit(
-                    command.output_limit_w,
-                    force=force_power,
-                )
-                output_written = True
-
-        try:
-            if power_before_mode:
-                await write_power()
-
-            if command.should_write_mode:
-                await self._set_ac_mode(command.ac_mode)
-                mode_written = True
-
-            if not power_before_mode:
-                await write_power()
-        except Exception as err:
-            result = CommandExecutionResult(
-                status=CommandExecutionStatus.FAILED,
-                reason=command.reason,
-                mode_written=mode_written,
-                input_written=input_written,
-                output_written=output_written,
-                error=f"{type(err).__name__}: {err}",
-            )
-            raise DeviceCommandExecutionError(result) from err
-
-        return CommandExecutionResult(
-            status=CommandExecutionStatus.APPLIED,
-            reason=command.reason,
-            mode_written=mode_written,
-            input_written=input_written,
-            output_written=output_written,
-        )
+__all__ = [
+    "DeviceCommandExecutionError",
+    "HomeAssistantEntityCommandExecutor",
+]

--- a/custom_components/battery_smartflow_ai/coordinator.py
+++ b/custom_components/battery_smartflow_ai/coordinator.py
@@ -164,15 +164,14 @@ from .strategy_state import ChargeCommitState
 from .mode_arbiter import ModeArbiter, build_mode_arbiter_config
 from .regulation_models import RegulationRuntimeState
 from .core.models import CommandExecutionResult, DeviceCapabilities, DeviceCommand
-from .core.ports import Clock
+from .core.ports import Clock, DeviceBackend, DeviceBackendExecutionError
 from .regulation_power_controller import (
     RegulationPowerController,
     build_regulation_power_config,
 )
 from .device_command import DeviceCommandBuilder, clamp_number_power_request
-from .adapters.home_assistant.device_command_executor import (
-    DeviceCommandExecutionError,
-    HomeAssistantEntityCommandExecutor,
+from .adapters.home_assistant.device_backend import (
+    HomeAssistantEntityBackend,
 )
 from .adapters.home_assistant.clock import HomeAssistantClock
 from .adapters.home_assistant.state_store import HomeAssistantStateStore
@@ -419,7 +418,8 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         )
         
         self._device_command_builder = DeviceCommandBuilder()
-        self._device_command_executor = HomeAssistantEntityCommandExecutor(
+        self._device_backend: DeviceBackend = HomeAssistantEntityBackend(
+            capabilities=self._device_profile.capabilities,
             set_ac_mode=self._set_ac_mode,
             set_input_limit=self._set_input_limit,
             set_output_limit=self._set_output_limit,
@@ -2080,15 +2080,15 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         force_power: bool = True,
         power_before_mode: bool = False,
     ) -> CommandExecutionResult:
-        """Execute one neutral command through the HA entity adapter."""
+        """Execute one neutral command through the configured backend."""
 
         try:
-            result = await self._device_command_executor.execute(
+            result = await self._device_backend.execute(
                 command,
                 force_power=force_power,
                 power_before_mode=power_before_mode,
             )
-        except DeviceCommandExecutionError as err:
+        except DeviceBackendExecutionError as err:
             self._store_command_execution_result(err.result)
             raise
 

--- a/custom_components/battery_smartflow_ai/core/ports/__init__.py
+++ b/custom_components/battery_smartflow_ai/core/ports/__init__.py
@@ -1,6 +1,7 @@
 """Platform-independent side-effect boundaries for the BSFAI core."""
 
 from .clock import Clock
+from .device_backend import DeviceBackend, DeviceBackendExecutionError
 from .state_store import (
     StateLoadResult,
     StateSaveResult,
@@ -10,6 +11,8 @@ from .state_store import (
 
 __all__ = [
     "Clock",
+    "DeviceBackend",
+    "DeviceBackendExecutionError",
     "StateLoadResult",
     "StateSaveResult",
     "StateStore",

--- a/custom_components/battery_smartflow_ai/core/ports/device_backend.py
+++ b/custom_components/battery_smartflow_ai/core/ports/device_backend.py
@@ -1,0 +1,33 @@
+"""Neutral command-execution boundary for device backends."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from ..models.device import CommandExecutionResult, DeviceCapabilities
+from ..models.regulation import DeviceCommand
+
+
+class DeviceBackendExecutionError(RuntimeError):
+    """Expose neutral failure feedback without leaking a platform exception."""
+
+    def __init__(self, result: CommandExecutionResult) -> None:
+        super().__init__(result.error or result.reason)
+        self.result = result
+
+
+class DeviceBackend(Protocol):
+    """Small backend contract shared by HA and future hardware adapters."""
+
+    @property
+    def capabilities(self) -> DeviceCapabilities:
+        """Return the immutable capabilities of the attached device."""
+
+    async def execute(
+        self,
+        command: DeviceCommand,
+        *,
+        force_power: bool = True,
+        power_before_mode: bool = False,
+    ) -> CommandExecutionResult:
+        """Execute one neutral command and return neutral feedback."""

--- a/docs/architecture/core-ha-target-architecture-v4.7.0.md
+++ b/docs/architecture/core-ha-target-architecture-v4.7.0.md
@@ -352,6 +352,9 @@ Safe-Idle, Manual-Standby und Schutzstopps müssen dieselbe Grenze verwenden wie
 der Normalpfad. Das Backend darf nicht nur den glücklichen DeviceCommand-Pfad
 abdecken.
 
+Der formale Port, die HA-Erstimplementierung und das Availability-/Fehlerverhalten
+sind in [`device-backend-v4.7.0.md`](device-backend-v4.7.0.md) dokumentiert.
+
 Issue #273 führt ausschließlich diese Grenze und den vorhandenen
 Home-Assistant-Entity-Adapter ein. Es entstehen weder ein Zendure-Direct-
 Backend noch eine zweite Hardwareanbindung.

--- a/docs/architecture/device-backend-v4.7.0.md
+++ b/docs/architecture/device-backend-v4.7.0.md
@@ -1,0 +1,137 @@
+# DeviceBackend-Grenze in V4.7.0
+
+Issue #273 formalisiert den in #269 eingeführten Geräte-Ausgabepfad als
+neutralen Backend-Port. Es entsteht kein zweiter Schreibpfad und keine neue
+Hardwarekommunikation.
+
+## Laufzeitpfad
+
+```text
+RuntimeSnapshot + DeviceCapabilities
+        |
+        v
+DecisionEngine / Regulation
+        |
+        v
+DeviceCommand
+        |
+        v
+core.ports.DeviceBackend
+        |
+        v
+HomeAssistantEntityBackend
+        |
+        v
+bestehende Select-/Number-Writer und HA-Services
+```
+
+Der Coordinator bleibt Composition Root. Er verbindet das gewählte
+`DeviceProfile`, dessen `DeviceCapabilities` und die konkrete Backend-
+Implementierung.
+
+## Neutraler Port
+
+`DeviceBackend` besitzt bewusst nur:
+
+- die unveränderlichen `DeviceCapabilities` des angebundenen Geräts und
+- `execute(DeviceCommand) -> CommandExecutionResult`.
+
+Die zwei bestehenden Ausführungsoptionen bleiben neutral und
+verhaltensrelevant:
+
+- `force_power` erzwingt einen technisch nötigen Leistungswrite, etwa bei
+  Richtungswechsel oder Effectiveness-Retry.
+- `power_before_mode` erhält die sichere Reihenfolge beim einmaligen INPUT-Stop
+  für Manual-Standby.
+
+Sie enthalten keine Entity-, Service-, Hersteller- oder Protokollinformation.
+
+## Verantwortlichkeit des Core
+
+Der Core erzeugt ausschließlich `DeviceCommand` mit:
+
+- gewünschtem AC-Modus,
+- Input-/Output-Leistung,
+- Write-/Skip-Entscheidung,
+- neutralem Grund und
+- neutralen Diagnosemetadaten.
+
+DecisionEngine, Strategy, Planning, Economics, MarketPrice, ModeArbiter und
+PowerController kennen weder HA-Entities noch MQTT-Topics, Modbus-Register oder
+Hersteller-APIs.
+
+## Verantwortlichkeit des HA-Backends
+
+`HomeAssistantEntityBackend` bildet einen Command auf die drei bereits
+vorhandenen Writer ab:
+
+- AC-Modus setzen,
+- Input-Limit setzen,
+- Output-Limit setzen.
+
+Die Writer kapseln weiterhin:
+
+- operation-spezifische Entity-Verfügbarkeit,
+- HA-Serviceaufrufe,
+- dynamische Number-Min-/Max-Grenzen,
+- Istwert-/Cache-Abgleich,
+- Null als Stop trotz positiver Entity-Mindestleistung und
+- Cache-Update erst nach erfolgreichem Schreiben.
+
+Availability ist damit nicht eine ungenaue globale Backend-Flagge: Sie wird für
+die tatsächlich angeforderte Operation geprüft. Ein nicht verfügbares Entity
+oder ein Servicefehler wird außerhalb der Strategie in ein neutrales
+`CommandExecutionResult(FAILED)` übersetzt.
+
+## Ergebnis und Fehler
+
+`CommandExecutionResult` bleibt der gemeinsame neutrale Rückgabevertrag:
+
+- `APPLIED`, `SKIPPED` oder `FAILED`,
+- ausgeführter Modus-, Input- und Output-Write,
+- neutraler Command-Grund und
+- optionale bereinigte Fehlerbeschreibung.
+
+`DeviceBackendExecutionError` transportiert dieses Ergebnis in den bestehenden
+Coordinator-Fehlerpfad. Die Plattformursache wird nicht in Strategy oder
+Planung gereicht und ein Teilwrite wird korrekt im Ergebnis festgehalten.
+
+## Einheitliche Produktpfade
+
+Alle produktiven Geräteoperationen laufen über `_device_backend.execute()`:
+
+1. normaler Strategy-/Regulation-Command,
+2. Safe-Idle bei ungültigen Pflichtdaten und
+3. einmaliger Stop beim Eintritt in Manual-Standby.
+
+Außerhalb des HA-Backends existiert kein direkter produktiver Aufruf der drei
+Writer. Reihenfolge, Write-Schwellen, Latches und Retry-Verhalten bleiben
+unverändert.
+
+## Kompatibilität
+
+Die #269-Namen bleiben als reine Re-Export-Fassade erhalten:
+
+- `HomeAssistantEntityCommandExecutor` verweist auf
+  `HomeAssistantEntityBackend`.
+- `DeviceCommandExecutionError` verweist auf
+  `DeviceBackendExecutionError`.
+
+Vorhandene Imports erzeugen damit keine zweite Klasse und keinen alternativen
+Pfad.
+
+## Spätere Erweiterung
+
+Ein künftiges MQTT-, Modbus- oder Direct-Backend kann denselben Port
+implementieren und seine eigenen Capabilities bereitstellen. Eine spätere
+Multi-Battery-Komposition kann mehrere Backend-Instanzen adressieren, ohne den
+fachlichen `DeviceCommand` neu zu definieren.
+
+#273 implementiert ausdrücklich nicht:
+
+- kein Zendure-Direct-Backend,
+- kein MQTT- oder Modbus-Backend,
+- keinen weiteren Hersteller,
+- keine Geräteerkennung,
+- keine Multi-Battery-Orchestrierung und
+- keine Änderung an Leistung, Strategie oder Regel-Tuning.

--- a/docs/architecture/device-command-output-v4.7.0.md
+++ b/docs/architecture/device-command-output-v4.7.0.md
@@ -135,6 +135,10 @@ Hersteller-Backend.
 Issue #273 kann die formale DeviceBackend-Port-Signatur aus dem nun realen
 Ausführungsvertrag ableiten, ohne den Core-Command erneut zu ändern.
 
+Dies ist mit [`device-backend-v4.7.0.md`](device-backend-v4.7.0.md) umgesetzt.
+Der frühere Executor-Name bleibt als kompatibler Alias der kanonischen
+`HomeAssistantEntityBackend`-Implementierung erhalten.
+
 ## Nachweis
 
 Die Tests prüfen:

--- a/tests/test_device_command_executor.py
+++ b/tests/test_device_command_executor.py
@@ -14,9 +14,16 @@ from custom_components.battery_smartflow_ai.adapters.home_assistant.device_comma
     DeviceCommandExecutionError,
     HomeAssistantEntityCommandExecutor,
 )
+from custom_components.battery_smartflow_ai.adapters.home_assistant.device_backend import (  # noqa: E402
+    HomeAssistantEntityBackend,
+)
 from custom_components.battery_smartflow_ai.core.models import (  # noqa: E402
     CommandExecutionStatus,
+    DeviceCapabilities,
     DeviceCommand,
+)
+from custom_components.battery_smartflow_ai.core.ports import (  # noqa: E402
+    DeviceBackendExecutionError,
 )
 
 
@@ -26,7 +33,7 @@ class DeviceCommandExecutorTests(unittest.IsolatedAsyncioTestCase):
         calls: list[tuple[str, object]],
         *,
         fail_output: bool = False,
-    ) -> HomeAssistantEntityCommandExecutor:
+    ) -> HomeAssistantEntityBackend:
         async def set_mode(mode: str) -> None:
             calls.append(("mode", mode))
 
@@ -38,7 +45,12 @@ class DeviceCommandExecutorTests(unittest.IsolatedAsyncioTestCase):
             if fail_output:
                 raise RuntimeError("entity unavailable")
 
-        return HomeAssistantEntityCommandExecutor(
+        return HomeAssistantEntityBackend(
+            capabilities=DeviceCapabilities(
+                max_input_w=2400.0,
+                max_output_w=800.0,
+                supports_passthrough=True,
+            ),
             set_ac_mode=set_mode,
             set_input_limit=set_input,
             set_output_limit=set_output,
@@ -65,6 +77,13 @@ class DeviceCommandExecutorTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(result.mode_written)
         self.assertTrue(result.input_written)
         self.assertFalse(result.output_written)
+
+    async def test_backend_exposes_profile_owned_capabilities(self) -> None:
+        backend = self.executor([])
+
+        self.assertEqual(backend.capabilities.max_input_w, 2400.0)
+        self.assertEqual(backend.capabilities.max_output_w, 800.0)
+        self.assertTrue(backend.capabilities.supports_passthrough)
 
     async def test_manual_standby_can_stop_power_before_mode(self) -> None:
         calls: list[tuple[str, object]] = []
@@ -126,7 +145,29 @@ class DeviceCommandExecutorTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("entity unavailable", result.error or "")
         self.assertFalse(result.output_written)
 
-    def test_coordinator_routes_all_product_writes_through_executor(self) -> None:
+    def test_issue_269_names_remain_compatibility_aliases(self) -> None:
+        self.assertIs(
+            HomeAssistantEntityCommandExecutor,
+            HomeAssistantEntityBackend,
+        )
+        self.assertIs(DeviceCommandExecutionError, DeviceBackendExecutionError)
+
+    def test_backend_port_is_platform_independent(self) -> None:
+        port = (
+            Path(__file__).resolve().parents[1]
+            / "custom_components"
+            / "battery_smartflow_ai"
+            / "core"
+            / "ports"
+            / "device_backend.py"
+        ).read_text(encoding="utf-8")
+
+        self.assertNotIn("homeassistant", port)
+        self.assertIn("class DeviceBackend(Protocol)", port)
+        self.assertIn("def capabilities(self) -> DeviceCapabilities", port)
+        self.assertIn("async def execute(", port)
+
+    def test_coordinator_routes_all_product_writes_through_backend(self) -> None:
         coordinator = (
             Path(__file__).resolve().parents[1]
             / "custom_components"
@@ -137,6 +178,9 @@ class DeviceCommandExecutorTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("await self._set_ac_mode(", coordinator)
         self.assertNotIn("await self._set_input_limit(", coordinator)
         self.assertNotIn("await self._set_output_limit(", coordinator)
+        self.assertIn("self._device_backend: DeviceBackend", coordinator)
+        self.assertIn("await self._device_backend.execute(", coordinator)
+        self.assertNotIn("self._device_command_executor", coordinator)
         self.assertGreaterEqual(
             coordinator.count("await self._execute_device_command("),
             3,


### PR DESCRIPTION
## Zusammenfassung
- definiert einen Home-Assistant-unabhängigen DeviceBackend-Port mit Capabilities und neutraler Command-Ausführung
- ordnet den bestehenden HA-Entity-Schreibpfad als HomeAssistantEntityBackend ein
- verbindet DeviceProfile/DeviceCapabilities am Coordinator-Composition-Root mit dem konkreten Backend
- führt normale Commands, Safe-Idle und Manual-Standby weiterhin über genau dieselbe Backend-Grenze
- verschiebt den neutralen DeviceBackendExecutionError in den Core-Port
- erhält die #269-Executor-Namen als identische Re-Export-Aliase
- dokumentiert Availability-, Fehler-, Capability- und Erweiterungsverantwortung

## Kompatibilität
- keine Änderung an DeviceCommand, Write-Reihenfolge, Schwellen, Latches oder Retry-Verhalten
- Entity-Verfügbarkeit, dynamische Limits, Services und Cache bleiben in den bestehenden HA-Writern
- keine zweite Ausführungsklasse und kein alternativer Schreibpfad
- kein Direct-, MQTT-, Modbus-, Multi-Battery- oder weiterer Hersteller-Backend

## Validierung
- 368 Tests bestanden
- 337 Subtests bestanden
- 8 fokussierte Backend-Vertragstests bestanden
- Syntax- und Importprüfung bestanden
- git diff --check bestanden

Closes #273