### PR TITLE
V4.7.0: Decision Engine und Strategiecode entschlacken

### DIFF
--- a/custom_components/battery_smartflow_ai/decision_engine.py
+++ b/custom_components/battery_smartflow_ai/decision_engine.py
@@ -2491,101 +2491,93 @@ class DecisionEngine:
 
         return None
 
-    def evaluate(self, ctx: RuntimeSnapshot) -> DecisionResult:
-        """Evaluate every admissible rule and select the highest priority.
+    def _context_error_candidate(
+        self,
+        ctx: RuntimeSnapshot,
+        reason: str,
+    ) -> dict[str, Any]:
+        """Build the sole candidate for an invalid critical context."""
 
-        Rule order remains the deterministic tie-breaker only. It no longer
-        decides which strategy wins before the V4.3 priority model is applied.
-        """
+        result = self._idle_result(ctx, reason=reason)
+        strategy = self._strategy_for_candidate(result)
+        return self._evaluated_candidate(
+            index=-1,
+            rule_name="ContextValidation",
+            result=result,
+            strategy=strategy,
+        )
 
-        context_error = self._context_validation_reason(ctx)
-        if context_error is not None:
-            result = self._idle_result(ctx, reason=context_error)
-            strategy = self._strategy_for_candidate(result)
-            state = str(getattr(strategy.state, "value", strategy.state))
-            self._last_strategy_selection = {
-                "candidate_count": 1,
-                "eligible_candidate_count": 1,
-                "selected_rule": "ContextValidation",
-                "selected_reason": context_error,
-                "selected_state": state,
-                "selected_priority": int(strategy.priority),
-                "candidates": [
-                    {
-                        "rule": "ContextValidation",
-                        "state": state,
-                        "reason": context_error,
-                        "priority": int(strategy.priority),
-                        "requested_mode": "idle",
-                        "status": "selected",
-                        "selection_reason": "critical_context_invalid",
-                    }
-                ],
-            }
-            return result
+    def _collect_rule_candidates(
+        self,
+        ctx: RuntimeSnapshot,
+    ) -> list[tuple[int, str, DecisionResult]]:
+        """Collect every admissible rule result in deterministic rule order."""
 
-        raw_candidates: list[tuple[int, str, DecisionResult]] = []
-
+        candidates: list[tuple[int, str, DecisionResult]] = []
         self._collecting_candidates = True
         try:
             for index, rule in enumerate(self._rules):
                 result = rule.evaluate(self, ctx)
                 if result is not None:
-                    raw_candidates.append(
-                        (
-                            index,
-                            rule.__class__.__name__,
-                            result,
-                        )
-                    )
+                    candidates.append((index, rule.__class__.__name__, result))
         finally:
             self._collecting_candidates = False
 
-        if not raw_candidates:
-            raw_candidates.append(
+        if not candidates:
+            candidates.append(
                 (
                     len(self._rules),
                     "SafeIdleFallback",
-                    self._idle_result(
-                        ctx,
-                        reason="idle",
+                    self._idle_result(ctx, reason="idle"),
+                )
+            )
+        return candidates
+
+    def _evaluated_candidate(
+        self,
+        *,
+        index: int,
+        rule_name: str,
+        result: DecisionResult,
+        strategy: Any,
+        rejection_reason: str | None = None,
+    ) -> dict[str, Any]:
+        """Create the normalized representation used by candidate selection."""
+
+        return {
+            "index": int(index),
+            "rule": rule_name,
+            "result": result,
+            "strategy": strategy,
+            "state": str(getattr(strategy.state, "value", strategy.state)),
+            "reason": str(result.reason or "idle"),
+            "priority": int(strategy.priority),
+            "requested_mode": str(strategy.requested_mode or "idle"),
+            "rejection_reason": rejection_reason,
+        }
+
+    def _evaluate_candidates(
+        self,
+        ctx: RuntimeSnapshot,
+        raw_candidates: list[tuple[int, str, DecisionResult]],
+    ) -> list[dict[str, Any]]:
+        """Normalize candidates and apply central strategic permissions."""
+
+        evaluated: list[dict[str, Any]] = []
+        for index, rule_name, result in raw_candidates:
+            strategy = self._strategy_for_candidate(result)
+            evaluated.append(
+                self._evaluated_candidate(
+                    index=index,
+                    rule_name=rule_name,
+                    result=result,
+                    strategy=strategy,
+                    rejection_reason=self._candidate_rejection_reason(
+                        ctx, strategy, result
                     ),
                 )
             )
 
-        evaluated: list[dict[str, Any]] = []
-
-        for index, rule_name, result in raw_candidates:
-            strategy = self._strategy_for_candidate(result)
-            rejection_reason = self._candidate_rejection_reason(
-                ctx,
-                strategy,
-                result,
-            )
-
-            evaluated.append(
-                {
-                    "index": int(index),
-                    "rule": rule_name,
-                    "result": result,
-                    "strategy": strategy,
-                    "state": str(
-                        getattr(
-                            strategy.state,
-                            "value",
-                            strategy.state,
-                        )
-                    ),
-                    "reason": str(result.reason or "idle"),
-                    "priority": int(strategy.priority),
-                    "requested_mode": str(
-                        strategy.requested_mode or "idle"
-                    ),
-                    "rejection_reason": rejection_reason,
-                }
-            )
-
-        # V4.3.1-dev3:
         # A normal learned charge window must not outrank an actually available
         # economic-discharge candidate. Deadline/latest-start reasons remain
         # eligible because those are the explicitly forced planning fallback.
@@ -2595,31 +2587,49 @@ class DecisionEngine:
             and str(candidate["result"].action or "") == "discharge"
             for candidate in evaluated
         )
-
         if economic_discharge_available:
             for candidate in evaluated:
                 if (
                     candidate["state"] == "ac_charge_learned"
-                    and candidate["reason"]
-                    in NON_FORCED_LEARNED_CHARGE_REASONS
+                    and candidate["reason"] in NON_FORCED_LEARNED_CHARGE_REASONS
                     and candidate["rejection_reason"] is None
                 ):
-                    candidate["rejection_reason"] = (
-                        "economic_discharge_window"
-                    )
+                    candidate["rejection_reason"] = "economic_discharge_window"
+        return evaluated
+
+    def _safe_idle_candidate(
+        self,
+        ctx: RuntimeSnapshot,
+        *,
+        reason: str,
+        rule_name: str,
+        index: int,
+    ) -> dict[str, Any]:
+        """Build an eligible safe-idle candidate."""
+
+        result = self._idle_result(ctx, reason=reason)
+        return self._evaluated_candidate(
+            index=index,
+            rule_name=rule_name,
+            result=result,
+            strategy=self._strategy_for_candidate(result),
+        )
+
+    def _select_candidate(
+        self,
+        ctx: RuntimeSnapshot,
+        evaluated: list[dict[str, Any]],
+    ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+        """Select by protections first, then priority and stable rule order."""
 
         eligible = [
             candidate
             for candidate in evaluated
             if candidate["rejection_reason"] is None
         ]
-
         eligible_active = [
-            candidate
-            for candidate in eligible
-            if int(candidate["priority"]) > 300
+            candidate for candidate in eligible if int(candidate["priority"]) > 300
         ]
-
         safe_idle_rejections = [
             candidate
             for candidate in evaluated
@@ -2631,111 +2641,73 @@ class DecisionEngine:
             }
         ]
 
-        grid_sensor_block = not bool(ctx.grid_sensor_valid)
-
         # A critical grid-data outage always becomes safe idle unless an
         # emergency or explicit manual action is already eligible. Directional
         # blockers become terminal only when no valid opposite strategy remains.
-        if (safe_idle_rejections or grid_sensor_block) and not eligible_active:
-            blocker_reason = (
+        if (
+            safe_idle_rejections or not bool(ctx.grid_sensor_valid)
+        ) and not eligible_active:
+            reason = (
                 "grid_sensor_invalid"
-                if grid_sensor_block
+                if not bool(ctx.grid_sensor_valid)
                 else str(safe_idle_rejections[0]["rejection_reason"])
             )
-            blocker_result = self._idle_result(
+            selected = self._safe_idle_candidate(
                 ctx,
-                reason=blocker_reason,
+                reason=reason,
+                rule_name="DirectionalBlocker",
+                index=len(self._rules) + 1,
             )
-            blocker_strategy = self._strategy_for_candidate(
-                blocker_result
-            )
-            selected = {
-                "index": len(self._rules) + 1,
-                "rule": "DirectionalBlocker",
-                "result": blocker_result,
-                "strategy": blocker_strategy,
-                "state": str(
-                    getattr(
-                        blocker_strategy.state,
-                        "value",
-                        blocker_strategy.state,
-                    )
-                ),
-                "reason": blocker_reason,
-                "priority": int(blocker_strategy.priority),
-                "requested_mode": str(
-                    blocker_strategy.requested_mode or "idle"
-                ),
-                "rejection_reason": None,
-            }
             eligible.append(selected)
             evaluated.append(selected)
         elif eligible:
-            # max() is stable for equal keys, so the earlier rule remains the
-            # deterministic tie-breaker without overriding higher priorities.
-            selected = max(
-                eligible,
-                key=lambda candidate: int(candidate["priority"]),
-            )
+            # max() is stable for equal keys, preserving the rule-order tie-break.
+            selected = max(eligible, key=lambda candidate: int(candidate["priority"]))
         else:
-            fallback_result = self._idle_result(
+            selected = self._safe_idle_candidate(
                 ctx,
                 reason="idle",
+                rule_name="SafeIdleFallback",
+                index=len(self._rules) + 2,
             )
-            fallback_strategy = self._strategy_for_candidate(
-                fallback_result
-            )
-            selected = {
-                "index": len(self._rules) + 2,
-                "rule": "SafeIdleFallback",
-                "result": fallback_result,
-                "strategy": fallback_strategy,
-                "state": str(
-                    getattr(
-                        fallback_strategy.state,
-                        "value",
-                        fallback_strategy.state,
-                    )
-                ),
-                "reason": "idle",
-                "priority": int(fallback_strategy.priority),
-                "requested_mode": "idle",
-                "rejection_reason": None,
-            }
             eligible.append(selected)
             evaluated.append(selected)
+        return selected, eligible
 
-        candidate_diagnostics: list[dict[str, Any]] = []
+    def _record_strategy_selection(
+        self,
+        evaluated: list[dict[str, Any]],
+        eligible: list[dict[str, Any]],
+        selected: dict[str, Any],
+        *,
+        selected_reason: str = "highest_priority",
+    ) -> None:
+        """Publish a stable diagnostic view without leaking internal objects."""
 
+        diagnostics: list[dict[str, Any]] = []
         for candidate in evaluated:
             if candidate is selected:
                 status = "selected"
-                selection_reason = "highest_priority"
+                reason = selected_reason
             elif candidate["rejection_reason"] is not None:
                 status = "rejected"
-                selection_reason = str(
-                    candidate["rejection_reason"]
-                )
+                reason = str(candidate["rejection_reason"])
             else:
                 status = "not_selected"
-                selection_reason = (
+                reason = (
                     "lower_priority"
-                    if int(candidate["priority"])
-                    < int(selected["priority"])
+                    if int(candidate["priority"]) < int(selected["priority"])
                     else "rule_order_tiebreak"
                 )
-
-            candidate_diagnostics.append(
+            diagnostics.append(
                 {
                     "rule": str(candidate["rule"]),
                     "state": str(candidate["state"]),
                     "reason": str(candidate["reason"]),
                     "priority": int(candidate["priority"]),
-                    "requested_mode": str(
-                        candidate["requested_mode"]
-                    ),
+                    "requested_mode": str(candidate["requested_mode"]),
                     "status": status,
-                    "selection_reason": selection_reason,
+                    "selection_reason": reason,
                 }
             )
 
@@ -2746,7 +2718,31 @@ class DecisionEngine:
             "selected_reason": str(selected["reason"]),
             "selected_state": str(selected["state"]),
             "selected_priority": int(selected["priority"]),
-            "candidates": candidate_diagnostics,
+            "candidates": diagnostics,
         }
 
+    def evaluate(self, ctx: RuntimeSnapshot) -> DecisionResult:
+        """Evaluate every admissible rule and select the highest priority.
+
+        Rule order remains the deterministic tie-breaker only. It no longer
+        decides which strategy wins before the V4.3 priority model is applied.
+        """
+
+        context_error = self._context_validation_reason(ctx)
+        if context_error is not None:
+            selected = self._context_error_candidate(ctx, context_error)
+            self._record_strategy_selection(
+                [selected],
+                [selected],
+                selected,
+                selected_reason="critical_context_invalid",
+            )
+            return selected["result"]
+
+        evaluated = self._evaluate_candidates(
+            ctx,
+            self._collect_rule_candidates(ctx),
+        )
+        selected, eligible = self._select_candidate(ctx, evaluated)
+        self._record_strategy_selection(evaluated, eligible, selected)
         return selected["result"]

--- a/docs/architecture/core-ha-target-architecture-v4.7.0.md
+++ b/docs/architecture/core-ha-target-architecture-v4.7.0.md
@@ -4,6 +4,7 @@
 - Basis: `main` bei `aeca37faea9f62d73f80ed0a93ee51e747e31dbc`
 - Release-Basis: Tag `4.6.0` bei `9b2ae4f4e04b0b0624dbbcf85dbe86664f687162`
 - Vorarbeit: `ha-dependency-inventory-v4.7.0.md`
+- Fachmodul: `decision-engine-v4.7.0.md`
 - Scope: Zielgrenzen und Migrationsroute, keine Laufzeitänderung
 
 ## Entscheidung in Kürze

--- a/docs/architecture/decision-engine-v4.7.0.md
+++ b/docs/architecture/decision-engine-v4.7.0.md
@@ -1,0 +1,49 @@
+# V4.7.0: Decision Engine und Strategie-Pipeline
+
+- Status: Umsetzung für Issue #274
+- Scope: verhaltensneutrale Gliederung der bestehenden Kandidatenauswahl
+- Eingabe: `RuntimeSnapshot`
+- Ausgabe: `DecisionResult`, anschließend bestehende Abbildung auf `StrategyIntent`
+
+## Verantwortung
+
+Die Decision Engine entscheidet weiterhin ausschließlich, **was** strategisch
+geschehen soll. `ModeArbiter` und `PowerController` bestimmen weiterhin, **wie**
+dieser Wunsch technisch und innerhalb der wirksamen Grenzen umgesetzt wird.
+Der Coordinator bleibt Composition Root und kann das ausgewählte Ergebnis vor
+der Abbildung auf `StrategyIntent` durch bereits bestehende Schutz- und
+Leistungsgrenzen anpassen.
+
+## Auswahl-Pipeline
+
+`DecisionEngine.evaluate()` ist nur noch der lesbare Orchestrator dieser Phasen:
+
+1. kritische Eingabefehler prüfen,
+2. alle zulässigen Regelkandidaten in stabiler Regelreihenfolge sammeln,
+3. Kandidaten über den bestehenden Strategie-Adapter normalisieren und zentrale
+   Richtungs-, Sensor- und Planungsfreigaben anwenden,
+4. Schutzblocker vor strategischer Priorität behandeln,
+5. nach Priorität auswählen; bei Gleichstand entscheidet unverändert die frühere
+   Regelposition,
+6. Auswahl, Ablehnungen und Nichtauswahl mit stabilen Gründen dokumentieren.
+
+Die Regelreihenfolge, Prioritäten, Gründe und Schutzentscheidungen wurden dabei
+nicht verändert. Insbesondere bleiben Charge Commit, Off-Grid-Kontext,
+Zusatzakku-Blocker sowie Sommer-, Winter- und Automatikverhalten in den
+bestehenden Fachpfaden.
+
+## Bewusste Kompatibilitätsgrenze
+
+Die Engine liefert weiterhin `DecisionResult`. Ein direktes Erzeugen von
+`StrategyIntent` in `evaluate()` wäre nicht verhaltensneutral: Zwischen Auswahl
+und Adapterabbildung greifen im Coordinator bestehende Sicherheits-, Bindungs-
+und Leistungsbegrenzungen. Erst das dadurch finalisierte Ergebnis wird wie
+bisher über `decision_to_strategy_intent()` in den klaren strategischen Vertrag
+für `ModeArbiter` und `PowerController` übersetzt.
+
+## Nachweis
+
+Die neue Struktur wird durch eigene Verträge für den schlanken Orchestrator,
+Prioritätsauswahl, stabilen Gleichstandsentscheid und verständliche
+Auswahldiagnose abgesichert. Die vollständige bestehende Testsuite bleibt der
+Verhaltensnachweis über alle unterstützten Szenarien und Profile.

--- a/tests/test_decision_engine_structure.py
+++ b/tests/test_decision_engine_structure.py
@@ -1,0 +1,140 @@
+"""Issue #274 contracts for the behavior-neutral decision pipeline."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+import unittest
+
+from support import PACKAGE_ROOT, bootstrap
+
+
+bootstrap()
+
+from custom_components.battery_smartflow_ai.decision_engine import (  # noqa: E402
+    DecisionEngine,
+)
+
+
+class DecisionEngineStructureTests(unittest.TestCase):
+    def test_strategy_modules_have_no_direct_home_assistant_dependency(self) -> None:
+        for module_name in (
+            "decision_engine.py",
+            "automatic_strategy.py",
+            "strategy_adapter.py",
+        ):
+            source = (PACKAGE_ROOT / module_name).read_text(encoding="utf-8")
+            imports = [
+                node
+                for node in ast.walk(ast.parse(source))
+                if isinstance(node, (ast.Import, ast.ImportFrom))
+            ]
+            imported_modules = {
+                alias.name
+                for node in imports
+                for alias in (
+                    node.names
+                    if isinstance(node, ast.Import)
+                    else [SimpleNamespace(name=node.module or "")]
+                )
+            }
+            self.assertFalse(
+                any(
+                    name == "homeassistant" or name.startswith("homeassistant.")
+                    for name in imported_modules
+                ),
+                module_name,
+            )
+
+    def test_evaluate_is_only_the_pipeline_orchestrator(self) -> None:
+        source = (PACKAGE_ROOT / "decision_engine.py").read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        engine = next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.ClassDef) and node.name == "DecisionEngine"
+        )
+        evaluate = next(
+            node
+            for node in engine.body
+            if isinstance(node, ast.FunctionDef) and node.name == "evaluate"
+        )
+
+        called_helpers = {
+            node.func.attr
+            for node in ast.walk(evaluate)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+        }
+        self.assertLessEqual(evaluate.end_lineno - evaluate.lineno + 1, 40)
+        self.assertTrue(
+            {
+                "_context_validation_reason",
+                "_collect_rule_candidates",
+                "_evaluate_candidates",
+                "_select_candidate",
+                "_record_strategy_selection",
+            }.issubset(called_helpers)
+        )
+
+    def test_priority_selection_preserves_rule_order_for_ties(self) -> None:
+        engine = DecisionEngine()
+        first = self._candidate("first", 400)
+        second = self._candidate("second", 400)
+        lower = self._candidate("lower", 350)
+
+        selected, eligible = engine._select_candidate(
+            SimpleNamespace(grid_sensor_valid=True),
+            [first, second, lower],
+        )
+
+        self.assertIs(selected, first)
+        self.assertEqual(eligible, [first, second, lower])
+
+    def test_diagnostics_explain_priority_and_rule_order(self) -> None:
+        engine = DecisionEngine()
+        selected = self._candidate("selected", 400)
+        tied = self._candidate("tied", 400)
+        lower = self._candidate("lower", 350)
+        rejected = self._candidate("rejected", 500, "grid_sensor_invalid")
+        evaluated = [selected, tied, lower, rejected]
+
+        engine._record_strategy_selection(
+            evaluated,
+            [selected, tied, lower],
+            selected,
+        )
+
+        diagnostics = engine.last_strategy_selection
+        self.assertEqual(diagnostics["selected_rule"], "selected")
+        by_rule = {item["rule"]: item for item in diagnostics["candidates"]}
+        self.assertEqual(by_rule["selected"]["status"], "selected")
+        self.assertEqual(by_rule["tied"]["selection_reason"], "rule_order_tiebreak")
+        self.assertEqual(by_rule["lower"]["selection_reason"], "lower_priority")
+        self.assertEqual(by_rule["rejected"]["status"], "rejected")
+        self.assertEqual(
+            by_rule["rejected"]["selection_reason"],
+            "grid_sensor_invalid",
+        )
+
+    @staticmethod
+    def _candidate(
+        rule: str,
+        priority: int,
+        rejection_reason: str | None = None,
+    ) -> dict[str, object]:
+        return {
+            "index": 0,
+            "rule": rule,
+            "result": SimpleNamespace(action="idle"),
+            "strategy": SimpleNamespace(),
+            "state": "idle_ready",
+            "reason": "idle",
+            "priority": priority,
+            "requested_mode": "idle",
+            "rejection_reason": rejection_reason,
+        }
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Zusammenfassung

- zerlegt die bisher 259-zeilige `DecisionEngine.evaluate()` in klar benannte Phasen für Validierung, Sammlung, Normalisierung/Freigabe, Auswahl und Diagnose
- zentralisiert Richtungs-, Sensor-, Zusatzakku- und Planungsblocker in der bestehenden Kandidatenprüfung und bewahrt Prioritäten sowie den stabilen Regelreihenfolge-Gleichstand
- trennt interne Kandidatenobjekte von der veröffentlichten Auswahldiagnose und dokumentiert die bestehende `RuntimeSnapshot -> Decision Engine/Strategy -> StrategyIntent -> ModeArbiter -> PowerController -> DeviceCommand`-Grenze
- hält die bewusste Kompatibilitätsgrenze ein: Der Coordinator wendet bestehende Schutz- und Leistungsgrenzen auf `DecisionResult` an, bevor der klare finale `StrategyIntent` erzeugt wird
- ergänzt Strukturverträge für schlanken Orchestrator, Priorität/Gleichstand, verständliche Reasons und fehlende direkte Home-Assistant-Abhängigkeiten im Strategy-Code

## Verhalten

Keine beabsichtigte Verhaltensänderung. Charge Commit, Off-Grid, Zusatzakku-Blocker, Schutzlogik sowie Sommer-/Winter-/Automatikpfade bleiben in ihren bestehenden Fachpfaden. Technische Regelung verbleibt bei `ModeArbiter` und `PowerController`.

## Validierung

- `python -m compileall -q custom_components tests`
- vollständige Suite: `372 passed, 337 subtests passed`
- `git diff --check`

Closes #274