### PR TITLE
V4.7.0: Technische Regelung klarer kapseln

### DIFF
--- a/custom_components/battery_smartflow_ai/core/clock.py
+++ b/custom_components/battery_smartflow_ai/core/clock.py
@@ -6,6 +6,14 @@ from datetime import UTC, datetime, timedelta, tzinfo
 import time
 
 
+def as_utc(value: datetime) -> datetime:
+    """Normalize an aware domain timestamp without a platform dependency."""
+
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError("value must be timezone-aware")
+    return value.astimezone(UTC)
+
+
 class SystemClock:
     """Read calendar and monotonic time from the host system."""
 

--- a/custom_components/battery_smartflow_ai/mode_arbiter.py
+++ b/custom_components/battery_smartflow_ai/mode_arbiter.py
@@ -4,9 +4,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
+from .core.clock import as_utc
 from .core.models import DeviceCapabilities
-
-from homeassistant.util import dt as dt_util
 
 from .regulation_models import (
     GridHistoryState,
@@ -286,7 +285,7 @@ class ModeArbiter:
         offgrid_load_active: bool = False,
         offgrid_source_active: bool = False,
     ) -> ModeArbiterResult:
-        now_utc = dt_util.as_utc(now)
+        now_utc = as_utc(now)
         requested_mode = intent.requested_mode
 
         metadata: dict[str, Any] = {
@@ -913,7 +912,7 @@ class ModeArbiter:
             return 0.0
 
         try:
-            until_utc = dt_util.as_utc(until_ts)
+            until_utc = as_utc(until_ts)
             return max(0.0, (until_utc - now_utc).total_seconds())
         except Exception:
             return 0.0
@@ -929,7 +928,7 @@ class ModeArbiter:
             return 0.0
 
         try:
-            started_utc = dt_util.as_utc(started_ts)
+            started_utc = as_utc(started_ts)
             elapsed_s = (now_utc - started_utc).total_seconds()
             return max(0.0, float(hold_s) - elapsed_s)
         except Exception:
@@ -1304,7 +1303,7 @@ class ModeArbiter:
         if runtime.last_mode_change_ts is None:
             return 0.0
 
-        last_change = dt_util.as_utc(runtime.last_mode_change_ts)
+        last_change = as_utc(runtime.last_mode_change_ts)
         elapsed_s = (now_utc - last_change).total_seconds()
 
         if previous_mode == "output" and requested_mode == "input":

--- a/docs/architecture/core-ha-target-architecture-v4.7.0.md
+++ b/docs/architecture/core-ha-target-architecture-v4.7.0.md
@@ -5,6 +5,7 @@
 - Release-Basis: Tag `4.6.0` bei `9b2ae4f4e04b0b0624dbbcf85dbe86664f687162`
 - Vorarbeit: `ha-dependency-inventory-v4.7.0.md`
 - Fachmodul: `decision-engine-v4.7.0.md`
+- Regelung: `technical-regulation-v4.7.0.md`
 - Scope: Zielgrenzen und Migrationsroute, keine Laufzeitänderung
 
 ## Entscheidung in Kürze

--- a/docs/architecture/technical-regulation-v4.7.0.md
+++ b/docs/architecture/technical-regulation-v4.7.0.md
@@ -1,0 +1,45 @@
+# V4.7.0: Technische Regelung
+
+- Status: Umsetzung für Issue #275
+- Scope: klare Core-Grenzen ohne Regler-Tuning
+- Eingang: `StrategyIntent`
+- Ausgang: `DeviceCommand`
+
+## Eindeutige Verarbeitung
+
+Die technische Regelung besteht aus einer gerichteten Kette:
+
+`StrategyIntent → ModeArbiter → RegulationPowerController → DeviceCommandBuilder`
+
+| Baustein | Verantwortung | Nicht verantwortlich für |
+| --- | --- | --- |
+| `ModeArbiter` | Modusfreigabe, Latches, Holds, Cooldowns, Übergänge und Ramp-down-Modi | Preise, Wirtschaftlichkeit oder Auswahl einer Strategie |
+| `RegulationPowerController` | Leistung, Near-Zero-Regelung, Grid-Ziel, Deadbands, Schritte und wirksame Gerätegrenzen | Moduswechsel oder strategische Lade-/Entladeauswahl |
+| `DeviceCommandBuilder` | finalen neutralen `DeviceCommand` und nötige Schreibabsicht erzeugen | HA-Serviceaufrufe oder erneute Fach-/Regelentscheidung |
+
+`GridHistoryState` ist die einzige zusammengefasste Sicht auf aktuellen Netzwert,
+kurze und mittlere Durchschnitte, Änderungen sowie stabile Import-/Exportzyklen.
+
+## Plattformgrenze
+
+ModeArbiter, RegulationPowerController, GridHistory und DeviceCommandBuilder
+benötigen keine Home-Assistant-States, Services oder Zeit-Hilfsfunktionen. Aware
+Zeitstempel werden über die neutrale Core-Zeitfunktion nach UTC normalisiert.
+Der Coordinator erzeugt Eingaben, verdrahtet die Stufen und übergibt den fertigen
+`DeviceCommand` an das konfigurierte `DeviceBackend`.
+
+## Profile und Fähigkeiten
+
+Profil-Dictionaries werden ausschließlich in den bestehenden Buildern in
+`ModeArbiterConfig`, `RegulationPowerConfig` und `GridHistoryConfig` übersetzt.
+Die Regler selbst verwenden diese typisierten Konfigurationen. Hardwaregrenzen
+und technische Freigaben werden bevorzugt aus `DeviceCapabilities` übernommen;
+es gibt keine Modellnamen-Abfragen in der Regelung.
+
+## Verhaltensgarantie
+
+Die vorhandenen Parameter und Zustandsübergänge bleiben unverändert. Das gilt
+insbesondere für INPUT-nach-OUTPUT-Sperren, Flapping-Schutz, stabile Import- und
+Exportzyklen, PV-/Entlade-/Passthrough-Latches, Post-Load-Drop- und
+Post-Output-Overshoot-Holds, Ramp-down, Near-Zero-Regelung und profilabhängige
+Grenzen.

--- a/tests/test_technical_regulation_core.py
+++ b/tests/test_technical_regulation_core.py
@@ -1,0 +1,67 @@
+"""Issue #275 contracts for the platform-neutral regulation chain."""
+
+from __future__ import annotations
+
+import ast
+from datetime import UTC, datetime, timedelta, timezone
+from pathlib import Path
+import unittest
+
+from support import PACKAGE_ROOT, bootstrap
+
+
+bootstrap()
+
+from custom_components.battery_smartflow_ai.core.clock import as_utc  # noqa: E402
+
+
+class TechnicalRegulationCoreTests(unittest.TestCase):
+    def test_regulation_modules_have_no_home_assistant_imports(self) -> None:
+        for name in (
+            "mode_arbiter.py",
+            "regulation_power_controller.py",
+            "grid_history.py",
+            "device_command.py",
+        ):
+            tree = ast.parse((PACKAGE_ROOT / name).read_text(encoding="utf-8"))
+            modules = {
+                alias.name
+                for node in ast.walk(tree)
+                if isinstance(node, ast.Import)
+                for alias in node.names
+            }
+            modules.update(
+                node.module or ""
+                for node in ast.walk(tree)
+                if isinstance(node, ast.ImportFrom)
+            )
+            self.assertFalse(
+                any(
+                    module == "homeassistant"
+                    or module.startswith("homeassistant.")
+                    for module in modules
+                ),
+                name,
+            )
+
+    def test_domain_utc_normalization_is_platform_neutral(self) -> None:
+        local = datetime(
+            2026,
+            8,
+            28,
+            15,
+            0,
+            tzinfo=timezone(timedelta(hours=2)),
+        )
+        self.assertEqual(
+            as_utc(local),
+            datetime(2026, 8, 28, 13, 0, tzinfo=UTC),
+        )
+
+    def test_naive_domain_timestamp_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "timezone-aware"):
+            as_utc(datetime(2026, 8, 28, 13, 0))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Zusammenfassung

- entfernt die letzte direkte Home-Assistant-Abhängigkeit aus dem `ModeArbiter` und normalisiert aware Zeitstempel über die neutrale Core-Zeitgrenze
- dokumentiert die eindeutige Verantwortung von `ModeArbiter`, `RegulationPowerController`, `DeviceCommandBuilder` und `GridHistoryState`
- bestätigt per Architekturtest, dass die vollständige technische Regelkette keine Home-Assistant-Imports besitzt
- bewahrt alle Reglerparameter, Latches, Holds, Cooldowns, Übergänge, Near-Zero- und Ramp-down-Pfade unverändert

## Architektur

`StrategyIntent → ModeArbiter → RegulationPowerController → DeviceCommandBuilder → DeviceCommand`

Profil-Dictionaries werden weiterhin nur in den bestehenden Config-Buildern normalisiert; Arbiter und Controller arbeiten mit typisierten Konfigurationen und `DeviceCapabilities`.

## Validierung

- vollständige Suite: `375 passed, 337 subtests passed`
- `git diff --check`

Closes #275