### PR TITLE
V4.7.0: MarketPrice und Economics als Core festigen (Main)

### DIFF
--- a/custom_components/battery_smartflow_ai/economics.py
+++ b/custom_components/battery_smartflow_ai/economics.py
@@ -228,7 +228,7 @@ class EnergyAccumulator:
         return EnergyAccumulatorSnapshot(day=day, daily=self._daily, total=self._total)
 
     def to_state(self) -> dict[str, Any]:
-        """Serialize totals for the Home Assistant Store."""
+        """Serialize totals as plain state for any StateStore adapter."""
 
         return {
             "version": self.STATE_VERSION,

--- a/custom_components/battery_smartflow_ai/market_price/sources.py
+++ b/custom_components/battery_smartflow_ai/market_price/sources.py
@@ -40,7 +40,7 @@ class PriceSource(Protocol):
 
 
 class StateLike(Protocol):
-    """Minimal Home Assistant state shape used by the generic source."""
+    """Minimal platform-state shape accepted by the boundary adapter."""
 
     state: object
     attributes: Mapping[str, Any]
@@ -52,7 +52,7 @@ StateGetter = Callable[[str], StateLike | None]
 
 @dataclass(frozen=True, slots=True)
 class GenericStatePriceSource:
-    """Read a price from the state of any configured Home Assistant sensor."""
+    """Adapt a configured platform state to a raw price-source reading."""
 
     entity_id: str
     state_getter: StateGetter

--- a/docs/architecture/core-ha-target-architecture-v4.7.0.md
+++ b/docs/architecture/core-ha-target-architecture-v4.7.0.md
@@ -6,6 +6,7 @@
 - Vorarbeit: `ha-dependency-inventory-v4.7.0.md`
 - Fachmodul: `decision-engine-v4.7.0.md`
 - Regelung: `technical-regulation-v4.7.0.md`
+- Markt und Wirtschaft: `market-economics-core-v4.7.0.md`
 - Scope: Zielgrenzen und Migrationsroute, keine Laufzeitänderung
 
 ## Entscheidung in Kürze

--- a/docs/architecture/market-economics-core-v4.7.0.md
+++ b/docs/architecture/market-economics-core-v4.7.0.md
@@ -1,0 +1,56 @@
+# V4.7.0: MarketPrice und Economics im Core
+
+- Status: Prüfung und Bereinigung für Issue #276
+- Scope: Plattformgrenzen und bestehende Fachsemantik, keine neue Berechnung
+
+## Ergebnis der Prüfung
+
+Die mit V4.6 eingeführten Bereiche besitzen bereits die vorgesehene gerichtete
+Struktur:
+
+`Plattformzustand / Konfiguration → PriceSource → Normalizer → MarketPrice → EconomicsEngine`
+
+Die kanonischen `MarketPrice`-, Forecast- und Gültigkeitsmodelle liegen in
+`core.models.market`. `market_price.models` ist nur eine identitätserhaltende
+Kompatibilitätsausgabe derselben Klassen und erzeugt kein zweites Modell.
+
+## Plattformgrenze
+
+- `GenericStatePriceSource` ist ein Boundary-Adapter. Er erhält lediglich einen
+  aufrufbaren State-Getter und eine minimale strukturelle State-Sicht.
+- Providerattribute werden ausschließlich von `ForecastAdapter`-
+  Implementierungen normalisiert.
+- `PriceNormalizer`, Core-Modelle, Planung und `EconomicsEngine` kennen keine
+  Entities, Registries, Services oder Provider.
+- Die statische Einspeisevergütung durchläuft dieselbe Normalisierung wie ein
+  dynamischer Wert; ein gültiger dynamischer Preis hat weiterhin Vorrang.
+
+## Preisvertrag
+
+Alle Core-Preise verwenden die aktive Währung pro kWh. Es findet keine
+FX-Umrechnung statt. Dabei gelten ausdrücklich:
+
+- `0` ist ein gültiger Preis,
+- negative Preise sind gültig,
+- missing, unknown, unavailable, stale und invalid bleiben von `0` getrennt,
+- abweichende Währungen sind ungültig,
+- MWh- und Cent-Einheiten werden ausschließlich am Adapter normalisiert.
+
+## Economics-Lifecycle
+
+`EnergyAccumulator` erhält einen expliziten aware Zeitstempel. Dadurch ist die
+Zeitabhängigkeit deterministisch und direkt mit der neutralen `Clock` testbar,
+ohne dass die Engine selbst Systemzeit liest. Neustarts stellen nur abgeschlossene
+Summen wieder her; das gespeicherte letzte Sample wird bewusst nicht weiter
+integriert, damit während eines Ausfalls keine Energie erfunden wird.
+
+`EnergyAccumulator.to_state()` und `EconomicsEngine.to_state()` liefern nur
+versionierte Python-Daten. Diese können innerhalb des vorhandenen
+StateStore-Dokuments gespeichert werden; die Core-Module kennen weder das
+Home-Assistant-Store-Objekt noch Pfad, Entry-ID oder Backend-Ausnahmen.
+
+## Bestehende Wirtschaftsregeln
+
+Netzladekosten, PV-Opportunitätskosten, Einspeiseertrag, vermiedene
+Netzbezugskosten und Batterienutzen bleiben getrennte Größen. Normale
+PV-Einspeisung wird weiterhin nicht als Batterienutzen doppelt gezählt.

--- a/tests/test_market_economics_core_contract.py
+++ b/tests/test_market_economics_core_contract.py
@@ -1,0 +1,102 @@
+"""Issue #276 contracts for platform-neutral market and economics code."""
+
+from __future__ import annotations
+
+import ast
+from datetime import datetime, timezone
+from types import SimpleNamespace
+import unittest
+
+from support import PACKAGE_ROOT, bootstrap
+
+
+bootstrap()
+
+from custom_components.battery_smartflow_ai.core.clock import TestClock  # noqa: E402
+from custom_components.battery_smartflow_ai.core.models import (  # noqa: E402
+    MarketPrice as CoreMarketPrice,
+)
+from custom_components.battery_smartflow_ai.economics import (  # noqa: E402
+    EconomicPowerFlows,
+    EnergyAccumulator,
+)
+from custom_components.battery_smartflow_ai.market_price import (  # noqa: E402
+    MarketPrice as PublicMarketPrice,
+    MarketPriceDirection,
+    MarketPriceSourceAdapter,
+    MarketPriceValidity,
+    NumericPriceNormalizer,
+)
+from custom_components.battery_smartflow_ai.market_price.sources import (  # noqa: E402
+    GenericStatePriceSource,
+)
+
+
+class MarketEconomicsCoreContractTests(unittest.TestCase):
+    def test_market_and_economics_core_have_no_platform_imports(self) -> None:
+        paths = [PACKAGE_ROOT / "economics.py"]
+        paths.extend((PACKAGE_ROOT / "market_price").glob("*.py"))
+        for path in paths:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            modules = {
+                node.module or ""
+                for node in ast.walk(tree)
+                if isinstance(node, ast.ImportFrom)
+            }
+            modules.update(
+                alias.name
+                for node in ast.walk(tree)
+                if isinstance(node, ast.Import)
+                for alias in node.names
+            )
+            self.assertFalse(
+                any(
+                    module == "homeassistant"
+                    or module.startswith("homeassistant.")
+                    for module in modules
+                ),
+                str(path),
+            )
+
+    def test_public_market_model_is_the_canonical_core_model(self) -> None:
+        self.assertIs(PublicMarketPrice, CoreMarketPrice)
+
+    def test_boundary_preserves_zero_negative_and_unavailable(self) -> None:
+        now = datetime(2026, 8, 28, 13, 0, tzinfo=timezone.utc)
+
+        def adapt(value: object) -> CoreMarketPrice:
+            state = SimpleNamespace(
+                state=value,
+                attributes={"unit_of_measurement": "EUR/kWh"},
+                last_updated=now,
+            )
+            return MarketPriceSourceAdapter(
+                source=GenericStatePriceSource("sensor.price", lambda _: state),
+                normalizer=NumericPriceNormalizer(now=now),
+                direction=MarketPriceDirection.IMPORT,
+                active_currency="EUR",
+            ).read()
+
+        self.assertEqual(adapt(0).current_price, 0.0)
+        self.assertEqual(adapt(-0.05).current_price, -0.05)
+        unavailable = adapt("unavailable")
+        self.assertIsNone(unavailable.current_price)
+        self.assertIs(unavailable.validity, MarketPriceValidity.UNAVAILABLE)
+
+    def test_energy_time_is_supplied_by_clock_and_state_is_plain_data(self) -> None:
+        clock = TestClock(datetime(2026, 8, 28, 13, 0, tzinfo=timezone.utc))
+        accumulator = EnergyAccumulator()
+        accumulator.add_sample(
+            sampled_at=clock.utc_now(),
+            power=EconomicPowerFlows(grid_to_battery_w=1000.0),
+        )
+        state = accumulator.to_state()
+
+        self.assertIsInstance(state, dict)
+        self.assertEqual(state["version"], EnergyAccumulator.STATE_VERSION)
+        self.assertNotIn("entity_id", state)
+        self.assertNotIn("store_path", state)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Korrigierte Main-Auslieferung für Issue #276

PR #307 wurde in einem gestapelten Workflow versehentlich in den bereits gemergten #275-Feature-Branch statt in `main` gemergt. Dieser PR liefert denselben geprüften #276-Commit nun auf der tatsächlichen aktuellen Main-Basis aus.

## Inhalt

- neutraler Vertrag `PriceSource → Normalizer → MarketPrice → EconomicsEngine`
- Plattform-Boundary für State-Preisquellen
- Core-Verträge für kanonisches Modell, Null-/Negativpreise, unavailable, Clock und plain-State-Persistenz
- keine neue Preis- oder Wirtschaftlichkeitslogik

## Validierung

- vollständige gestapelte Suite: `379 passed, 337 subtests passed`
- HACS/Hassfest werden auf der korrigierten Main-Basis erneut ausgeführt

Closes #276