### PR TITLE
V4.7.0: Sensor-, Übersetzungs- und Diagnose-Struktur bereinigen

### DIFF
--- a/custom_components/battery_smartflow_ai/diagnostic_values.py
+++ b/custom_components/battery_smartflow_ai/diagnostic_values.py
@@ -1,0 +1,20 @@
+"""Privacy-safe presentation values for permanent HA diagnostics."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .debug_package import redact_secrets
+
+
+def safe_diagnostic_sensor_value(key: str, value: object) -> object:
+    """Minimize permanent diagnostic values without changing entity identity."""
+
+    if key == "debug_last_package":
+        # The full owned path remains internal for diagnostics download. A
+        # Recorder-facing entity only needs the non-sensitive package name.
+        return Path(str(value)).name
+    if key == "debug_last_error":
+        # Free error text may contain credentials from an upstream exception.
+        return redact_secrets(str(value))
+    return value

--- a/custom_components/battery_smartflow_ai/sensor.py
+++ b/custom_components/battery_smartflow_ai/sensor.py
@@ -46,6 +46,7 @@ from .const import (
     AUTOMATIC_WEIGHTING_ENUMS,
 )
 from .device_profiles import DEVICE_PROFILES
+from .diagnostic_values import safe_diagnostic_sensor_value
 from .price_currency import price_input_profile
 
 _LOGGER = logging.getLogger(__name__)
@@ -1335,6 +1336,9 @@ class ZendureSmartFlowSensor(CoordinatorEntity, SensorEntity):
 
         if val is None:
             return None
+
+        if key in {"debug_last_package", "debug_last_error"}:
+            return safe_diagnostic_sensor_value(key, val)
 
         if key == "learned_planning_data_coverage":
             try:

--- a/custom_components/battery_smartflow_ai/translations/de.json
+++ b/custom_components/battery_smartflow_ai/translations/de.json
@@ -629,7 +629,7 @@
         "state": {"no": "Nein", "yes": "Ja"}
       },
       "debug_recording_ends_at": {"name": "Debug-Aufzeichnung endet um"},
-      "debug_sample_count": {"name": "Erfasste Debug-Samples"},
+      "debug_sample_count": {"name": "Erfasste Debug-Datensätze"},
       "debug_last_package": {"name": "Letztes Debug-Paket"},
       "debug_last_error": {"name": "Letzter Debug-Fehler"},
       "fault_level_status": {

--- a/docs/architecture/core-ha-target-architecture-v4.7.0.md
+++ b/docs/architecture/core-ha-target-architecture-v4.7.0.md
@@ -8,6 +8,7 @@
 - Regelung: `technical-regulation-v4.7.0.md`
 - Markt und Wirtschaft: `market-economics-core-v4.7.0.md`
 - Legacy-Cleanup: `legacy-cleanup-v4.7.0.md`
+- Sensoren und Diagnose: `sensor-diagnostics-v4.7.0.md`
 - Scope: Zielgrenzen und Migrationsroute, keine Laufzeitänderung
 
 ## Entscheidung in Kürze

--- a/docs/architecture/sensor-diagnostics-v4.7.0.md
+++ b/docs/architecture/sensor-diagnostics-v4.7.0.md
@@ -1,0 +1,61 @@
+# V4.7.0: Sensor-, Übersetzungs- und Diagnose-Struktur
+
+- Status: Konsolidierung für Issue #278
+- Scope: Home-Assistant-Oberfläche, keine Core- oder Strategieänderung
+
+## Sensoroberfläche
+
+Die Sensoren folgen sechs fachlichen Bereichen:
+
+1. Geräte- und Batteriezustand,
+2. Strategie und technische Regelung,
+3. Planung und Forecast,
+4. Marktpreise und Wirtschaft,
+5. zeitbegrenztes Debug und Diagnose,
+6. Konfiguration und Profilstatus.
+
+Wirtschafts-, Energie- und Preissensoren verwenden weiterhin das virtuelle Gerät
+`Wirtschaft & Preise`. Die übrigen nutzerrelevanten Zustände verbleiben am
+BSFAI-Hauptgerät. Keys und Unique IDs werden nicht umbenannt; bestehende
+Dashboards, Registry-Einträge und Automationen behalten damit ihre Identität.
+
+## Dauerdiagnose und Debug-Paket
+
+Umfangreiche Strategie-, Regelungs-, Planungs- und Rohwertdiagnosen gehören in
+das begrenzte JSON-Debug-Paket. Von dieser Diagnoseoberfläche bleiben nur fünf
+schlanke Statussensoren dauerhaft Recorder-sichtbar:
+
+- Debug-Aufzeichnung aktiv,
+- Ende der Aufzeichnung,
+- Anzahl erfasster Datensätze,
+- Name des letzten Pakets,
+- letzter Fehler.
+
+Der Paketsensor veröffentlicht ausschließlich den Dateinamen. Der vollständige
+lokale Pfad bleibt intern beim Coordinator und wird nur zum kontrollierten
+Diagnostics-Download verwendet. Freier Fehlertext wird vor der Veröffentlichung
+mit demselben Secret-Filter wie das JSON-Paket bereinigt.
+
+## Datenschutz
+
+Debug-Paket und permanente Diagnosewerte filtern unter anderem Tokens,
+Authorization-Header, Passwörter, API-Schlüssel, Client-Secrets und freie
+Credential-Zuweisungen. Die Diagnostics-Funktion akzeptiert ausschließlich eine
+Datei unmittelbar im integrationsspezifischen Debug-Verzeichnis. Persönliche
+Pfade werden nicht als Sensorzustand gespeichert.
+
+## Übersetzungen und Einheiten
+
+`strings.json` bleibt die vollständige englische Quelle; Deutsch, Englisch,
+Französisch und Niederländisch besitzen dieselben Schlüssel und Enum-Zustände.
+Deutsche Begriffe verwenden weiterhin nutzernahe Bezeichnungen wie Netz,
+Ladebindung und Regelungsgrund. Geld- und Preissensoren beziehen ihre Einheit
+dynamisch aus der aktiven Home-Assistant-Währung; die bestehende Entity-ID
+`profit_eur` bleibt nur aus Kompatibilitätsgründen erhalten und zeigt keine fest
+verdrahtete EUR-Einheit an.
+
+## Core-Grenze
+
+Sensorbeschreibungen, Translation Keys, Device Classes, State Classes,
+Entity Categories und Gerätezuordnungen verbleiben ausschließlich in der
+Home-Assistant-Plattform. Die Core-Module kennen diese Oberfläche nicht.

--- a/tests/test_sensor_diagnostics_v470.py
+++ b/tests/test_sensor_diagnostics_v470.py
@@ -1,0 +1,85 @@
+"""Issue #278 contracts for safe, compatible HA diagnostics."""
+
+from __future__ import annotations
+
+import ast
+import unittest
+
+from support import PACKAGE_ROOT, bootstrap
+
+
+bootstrap()
+
+from custom_components.battery_smartflow_ai.diagnostic_values import (  # noqa: E402
+    safe_diagnostic_sensor_value,
+)
+
+
+class SensorDiagnosticsV470Tests(unittest.TestCase):
+    def test_debug_status_surface_stays_bounded(self) -> None:
+        tree = ast.parse(
+            (PACKAGE_ROOT / "sensor.py").read_text(encoding="utf-8")
+        )
+        debug_keys = next(
+            ast.literal_eval(node.value.args[0])
+            for node in tree.body
+            if isinstance(node, ast.Assign)
+            and any(
+                isinstance(target, ast.Name)
+                and target.id == "DEBUG_STATUS_SENSOR_KEYS"
+                for target in node.targets
+            )
+            and isinstance(node.value, ast.Call)
+        )
+        self.assertEqual(
+            debug_keys,
+            {
+                "debug_recording_active",
+                "debug_recording_ends_at",
+                "debug_sample_count",
+                "debug_last_package",
+                "debug_last_error",
+            },
+        )
+        source = ast.unparse(tree)
+        self.assertIn("description.key not in DEBUG_STATUS_SENSOR_KEYS", source)
+
+    def test_package_sensor_never_exposes_local_path(self) -> None:
+        path = r"C:\private\home-assistant\battery_smartflow_ai_debug\report.json"
+        self.assertEqual(
+            safe_diagnostic_sensor_value("debug_last_package", path),
+            "report.json",
+        )
+
+    def test_error_sensor_uses_debug_secret_redaction(self) -> None:
+        result = safe_diagnostic_sensor_value(
+            "debug_last_error",
+            "request failed authorization=Bearer abc123 password=hunter2",
+        )
+        self.assertNotIn("abc123", str(result))
+        self.assertNotIn("hunter2", str(result))
+        self.assertIn("[REDACTED]", str(result))
+
+    def test_sensor_unique_id_formula_is_unchanged(self) -> None:
+        source = (PACKAGE_ROOT / "sensor.py").read_text(encoding="utf-8")
+        self.assertIn(
+            'f"{DOMAIN}_{entry.entry_id}_{description.key}"',
+            source,
+        )
+
+    def test_core_models_have_no_ha_sensor_surface(self) -> None:
+        forbidden = {
+            "SensorEntityDescription",
+            "SensorDeviceClass",
+            "SensorStateClass",
+            "EntityCategory",
+            "translation_key",
+            "entity_id",
+        }
+        for path in (PACKAGE_ROOT / "core").rglob("*.py"):
+            source = path.read_text(encoding="utf-8")
+            self.assertTrue(forbidden.isdisjoint(source.split()), str(path))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Zusammenfassung

- veröffentlicht beim permanenten Sensor für das letzte Debug-Paket nur noch den Dateinamen statt des vollständigen lokalen Pfads
- filtert freien Text im permanenten Debug-Fehlersensor mit derselben Secret-Redaktion wie das JSON-Debug-Paket
- kapselt die reine Diagnosewert-Normalisierung in einem HA-unabhängig testbaren Plattform-Hilfsmodul
- dokumentiert die Sensorbereiche, Gerätezuordnung, begrenzte Dauerdiagnose, Datenschutz- und Core-Grenze
- ersetzt die deutsche Mischbezeichnung „Debug-Samples“ durch „Debug-Datensätze“

## Kompatibilität

- keine Änderungen an Sensor-Keys, Unique IDs oder bestehenden Entity IDs
- keine geänderte Gerätezuordnung
- keine neue permanente Debug-Entität
- `profit_eur` bleibt als kompatible Entity-ID erhalten, nutzt aber weiterhin die aktive HA-Währung
- der vollständige Paketpfad bleibt intern für den kontrollierten Diagnostics-Download verfügbar

## Validierung

- `python -m compileall -q custom_components tests`
- vollständige Suite: `387 passed, 348 subtests passed`
- Übersetzungsparität und Enum-Oberfläche eingeschlossen
- `git diff --check`

Closes #278