### PR TITLE
V4.7.0: Test core without Home Assistant

### DIFF
--- a/custom_components/battery_smartflow_ai/__init__.py
+++ b/custom_components/battery_smartflow_ai/__init__.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import logging
 
+from .const import DOMAIN, PLATFORMS
+
 try:
     import homeassistant.helpers.config_validation as cv
     from homeassistant.config_entries import ConfigEntry
@@ -13,14 +15,15 @@ except ModuleNotFoundError as err:
     # Importing a neutral submodule first executes this package module.  Keep
     # that import path usable for standalone core tests without pretending
     # that Home Assistant is installed.
-    CONFIG_SCHEMA = None
+    cv = None
 else:
     import voluptuous as vol
 
-    from .const import DOMAIN, PLATFORMS
     from .coordinator import ZendureSmartFlowCoordinator
 
-    CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+CONFIG_SCHEMA = (
+    cv.config_entry_only_config_schema(DOMAIN) if cv is not None else None
+)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/battery_smartflow_ai/__init__.py
+++ b/custom_components/battery_smartflow_ai/__init__.py
@@ -1,16 +1,26 @@
 from __future__ import annotations
 
 import logging
-import voluptuous as vol
 
-import homeassistant.helpers.config_validation as cv
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, ServiceCall
+try:
+    import homeassistant.helpers.config_validation as cv
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant, ServiceCall
+except ModuleNotFoundError as err:
+    if err.name is None or not err.name.startswith("homeassistant"):
+        raise
 
-from .const import DOMAIN, PLATFORMS
-from .coordinator import ZendureSmartFlowCoordinator
+    # Importing a neutral submodule first executes this package module.  Keep
+    # that import path usable for standalone core tests without pretending
+    # that Home Assistant is installed.
+    CONFIG_SCHEMA = None
+else:
+    import voluptuous as vol
 
-CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+    from .const import DOMAIN, PLATFORMS
+    from .coordinator import ZendureSmartFlowCoordinator
+
+    CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -1,6 +1,19 @@
 from __future__ import annotations
 
-from homeassistant.const import Platform
+try:
+    from homeassistant.const import Platform
+except ModuleNotFoundError as err:
+    if err.name is None or not err.name.startswith("homeassistant"):
+        raise
+
+    from enum import StrEnum
+
+    class Platform(StrEnum):
+        """Minimal platform names for standalone core imports."""
+
+        SENSOR = "sensor"
+        NUMBER = "number"
+        SELECT = "select"
 
 # ==================================================
 # Integration meta

--- a/custom_components/battery_smartflow_ai/core/testing.py
+++ b/custom_components/battery_smartflow_ai/core/testing.py
@@ -1,0 +1,59 @@
+"""Small deterministic test doubles for the platform-independent core."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass, field
+from typing import Any
+
+from .models.device import (
+    CommandExecutionResult,
+    CommandExecutionStatus,
+    DeviceCapabilities,
+)
+from .models.regulation import DeviceCommand
+from .ports.state_store import (
+    StateLoadResult,
+    StateSaveResult,
+    StateStoreStatus,
+)
+
+
+class MemoryStateStore:
+    """Keep one detached state document in memory for domain tests."""
+
+    def __init__(self, initial: dict[str, Any] | None = None) -> None:
+        self._data = deepcopy(initial)
+
+    async def load(self) -> StateLoadResult:
+        if self._data is None:
+            return StateLoadResult(StateStoreStatus.EMPTY)
+        return StateLoadResult(StateStoreStatus.LOADED, deepcopy(self._data))
+
+    async def save(self, data: dict[str, Any]) -> StateSaveResult:
+        self._data = deepcopy(data)
+        return StateSaveResult(StateStoreStatus.SAVED)
+
+
+@dataclass
+class FakeDeviceBackend:
+    """Record neutral device commands and report deterministic success."""
+
+    capabilities: DeviceCapabilities
+    commands: list[DeviceCommand] = field(default_factory=list)
+
+    async def execute(
+        self,
+        command: DeviceCommand,
+        *,
+        force_power: bool = True,
+        power_before_mode: bool = False,
+    ) -> CommandExecutionResult:
+        self.commands.append(deepcopy(command))
+        return CommandExecutionResult(
+            CommandExecutionStatus.APPLIED,
+            "fake_backend_applied",
+            mode_written=command.should_write_mode,
+            input_written=command.should_write_input and force_power,
+            output_written=command.should_write_output and force_power,
+        )

--- a/docs/architecture/core-ha-target-architecture-v4.7.0.md
+++ b/docs/architecture/core-ha-target-architecture-v4.7.0.md
@@ -663,6 +663,10 @@ ist kein zusätzliches Architektur-Issue erforderlich.
 - keine stärkere Zendure-/HA-Bindung: **durch verbotene Core-Abhängigkeiten abgesichert**
 - Grundlage für Folge-Issues: **Modulabbildung, Migrationsstufen und Stopppunkte dokumentiert**
 
+Der ausführbare Nachweis der später umgesetzten Testgrenze ist in
+[Core ohne Home Assistant testen](core-without-home-assistant-v4.7.0.md)
+dokumentiert.
+
 ## Nicht Teil dieser Änderung
 
 - keine neue Python-Paketstruktur im Laufzeitcode

--- a/docs/architecture/core-without-home-assistant-v4.7.0.md
+++ b/docs/architecture/core-without-home-assistant-v4.7.0.md
@@ -1,0 +1,51 @@
+# Core ohne Home Assistant testen (V4.7.0)
+
+Issue #279 schließt die letzte technische Lücke zwischen neutralem Core und
+seinen Tests: Core-Module lassen sich über den normalen Python-Paketpfad laden,
+ohne dass Home Assistant installiert, gestartet oder durch Modul-Stubs
+nachgebildet sein muss.
+
+## Importgrenze
+
+Python führt beim Import eines Untermoduls zuerst das Paketmodul
+`custom_components.battery_smartflow_ai` aus. Dieses Paket lädt den
+Home-Assistant-Lifecycle daher nur, wenn Home Assistant verfügbar ist. Im
+realen Integrationsbetrieb bleiben `CONFIG_SCHEMA`, Coordinator, Services,
+Setup, Unload und Migration unverändert aktiv. Ein alleiniger Core-Import lädt
+dagegen weder Home Assistant noch den Coordinator.
+
+Der Core behält seine bestehenden Regeln:
+
+- keine `homeassistant`-Imports unter `core/`
+- Plattformdaten kommen normalisiert über `RuntimeSnapshot`
+- Geräte-I/O läuft über den neutralen `DeviceBackend`-Port
+- Persistenz läuft über den neutralen `StateStore`-Port
+- Zeitlogik erhält eine `Clock`
+
+## Deterministische Testhilfen
+
+`core.testing` stellt drei kleine Bausteine für eigenständige Domänentests
+bereit:
+
+- den bereits vorhandenen `TestClock` für kontrollierte Zeit
+- `MemoryStateStore` für eine kopierte, flüchtige Zustandsablage
+- `FakeDeviceBackend` für aufgezeichnete Befehle und neutrales Erfolgsfeedback
+
+Die Doubles implementieren dieselben Ports wie die Home-Assistant-Adapter,
+kennen aber weder Entities noch Services, Config Entries oder den Recorder.
+
+## Ausführbarer Nachweis
+
+`tests/test_core_without_home_assistant.py` startet einen isolierten
+Python-Prozess. Er prüft zuerst, dass `homeassistant` nicht auffindbar ist, und
+importiert danach über den regulären Paketpfad unter anderem RuntimeSnapshot,
+DecisionEngine, Marktmodelle, TestClock, MemoryStateStore und
+FakeDeviceBackend. Der Test wertet einen Snapshot aus, unterscheidet einen
+gültigen Nullpreis von nicht verfügbaren Werten und führt Persistenz sowie
+einen Gerätebefehl über die neutralen Ports aus. Abschließend wird erneut
+geprüft, dass kein Home-Assistant-Modul geladen wurde.
+
+Die breitere Szenariomatrix für Netzbezug, PV-Laden, strategisches Laden,
+Charge-Commit, Schutzgrenzen, Off-grid/Zusatzakku, Near-zero, Cooldowns,
+Haltezeiten und Tageswechsel bleibt in den jeweiligen Core-Tests. Issue #279
+ändert dabei weder Produktverhalten noch Reglertuning.

--- a/tests/test_core_without_home_assistant.py
+++ b/tests/test_core_without_home_assistant.py
@@ -1,0 +1,135 @@
+"""Prove that representative core behavior runs without Home Assistant."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class CoreWithoutHomeAssistantTests(unittest.TestCase):
+    def test_core_imports_and_test_doubles_need_no_home_assistant(self) -> None:
+        script = f"import sys; sys.path.insert(0, {str(ROOT)!r})\n" + textwrap.dedent(
+            """
+            import asyncio
+            from datetime import datetime, timedelta, timezone
+            import importlib.util
+            import sys
+
+            assert importlib.util.find_spec("homeassistant") is None
+
+            from custom_components.battery_smartflow_ai.core.clock import TestClock
+            from custom_components.battery_smartflow_ai.core.models import (
+                ChargeCommitState,
+                DeviceCapabilities,
+                DeviceCommand,
+                GridHistoryState,
+                MarketPrice,
+                MarketPriceDirection,
+                MarketPriceValidity,
+                RegulationRuntimeState,
+                RuntimeSnapshot,
+                StrategyIntent,
+                ValueValidity,
+            )
+            from custom_components.battery_smartflow_ai.core.testing import (
+                FakeDeviceBackend,
+                MemoryStateStore,
+            )
+            from custom_components.battery_smartflow_ai.automatic_strategy import AutomaticStrategy
+            from custom_components.battery_smartflow_ai.decision_engine import DecisionEngine
+            from custom_components.battery_smartflow_ai.economics import EconomicsEngine
+            from custom_components.battery_smartflow_ai.mode_arbiter import ModeArbiter
+            from custom_components.battery_smartflow_ai.regulation_power_controller import RegulationPowerController
+
+            assert "homeassistant" not in sys.modules
+            now = datetime(2026, 8, 28, 12, 0, tzinfo=timezone.utc)
+            clock = TestClock(now)
+            clock.advance(timedelta(seconds=30))
+            assert clock.utc_now() == now + timedelta(seconds=30)
+
+            snapshot = RuntimeSnapshot(
+                now=clock.utc_now(), soc=50.0, soc_min=10.0, soc_max=90.0,
+                emergency_soc=5.0, emergency_charge_w=500.0,
+                max_charge_w=1000.0, max_discharge_w=800.0,
+                grid_import_w=300.0, grid_export_w=0.0,
+                pv_w=100.0, house_load_w=400.0,
+                avg_charge_price=None, expensive_threshold=0.30,
+                very_expensive_threshold=0.40, profit_margin_pct=5.0,
+                ai_mode="automatic", manual_action=None, season="summer",
+                profile={"MAX_INPUT_W": 1000.0, "MAX_OUTPUT_W": 800.0},
+                prev_discharge_w=0.0, prev_charge_w=0.0,
+                battery_capacity_kwh=2.0,
+            )
+            result = DecisionEngine().evaluate(snapshot)
+            assert result is not None
+            assert snapshot.grid.import_power_w.value == 300.0
+            assert AutomaticStrategy() is not None
+            assert ChargeCommitState().phase == "waiting"
+            assert EconomicsEngine(currency="EUR").currency == "EUR"
+
+            intent = StrategyIntent(
+                "cover_deficit", "output", 300.0, "standalone_test"
+            )
+            arbiter = ModeArbiter().evaluate(
+                now=clock.utc_now(), intent=intent,
+                grid=GridHistoryState(
+                    grid_now_w=300.0, grid_avg_short_w=300.0,
+                    stable_import_cycles=3,
+                ),
+                runtime=RegulationRuntimeState(), current_ac_mode="output",
+            )
+            power = RegulationPowerController().calculate(
+                intent=intent, arbiter=arbiter,
+                grid=GridHistoryState(grid_now_w=300.0),
+                max_output_w=800.0,
+            )
+            assert power.final_power_w >= 0.0
+
+            zero_price = MarketPrice(
+                direction=MarketPriceDirection.IMPORT, current_price=0.0,
+                currency="EUR", unit="EUR/kWh", timestamp=clock.utc_now(),
+                source="test", validity=MarketPriceValidity.VALID,
+                is_dynamic=True, is_fallback=False,
+            )
+            assert zero_price.valid and zero_price.current_price == 0.0
+            assert ValueValidity.UNAVAILABLE != ValueValidity.VALID
+
+            capabilities = DeviceCapabilities.from_profile(snapshot.profile)
+            backend = FakeDeviceBackend(capabilities)
+            command = DeviceCommand("output", output_limit_w=300.0, reason="test")
+            store = MemoryStateStore()
+
+            async def exercise_ports():
+                assert (await store.load()).status.value == "empty"
+                assert (await store.save({"day": "2026-08-28"})).saved
+                loaded = await store.load()
+                loaded.data["day"] = "changed-only-in-copy"
+                assert (await store.load()).data["day"] == "2026-08-28"
+                execution = await backend.execute(command)
+                assert execution.status.value == "applied"
+                assert backend.commands == [command]
+
+            asyncio.run(exercise_ports())
+            assert "homeassistant" not in sys.modules
+            print("CORE_WITHOUT_HOME_ASSISTANT_OK")
+            """
+        )
+        completed = subprocess.run(
+            [sys.executable, "-I", "-c", script],
+            cwd=ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertIn("CORE_WITHOUT_HOME_ASSISTANT_OK", completed.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow normal core imports when Home Assistant is not installed while preserving the HA lifecycle path
- add deterministic MemoryStateStore and FakeDeviceBackend test doubles alongside TestClock
- prove representative decision, regulation, market, economics, persistence, and command behavior in an isolated HA-free Python process
- document the executable core/HA test boundary

## Validation
- 388 tests passed
- 348 subtests passed
- compileall passed
- git diff --check passed

Closes #279