### PR TITLE
Release: Prepare V4.7.0-Beta1

### DIFF
--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -38,7 +38,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "4.6.0"
+INTEGRATION_VERSION = "4.7.0-Beta1"
 
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": [],
-  "version": "4.6.0"
+  "version": "4.7.0-Beta1"
 }

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -13,7 +13,7 @@ COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
 
 
 class DebugIntegrationContractTests(unittest.TestCase):
-    def test_manifest_and_runtime_version_match_v460_rc4_release(self) -> None:
+    def test_manifest_and_runtime_version_match_v470_beta1_release(self) -> None:
         manifest_version = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )["version"]
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "4.6.0")
+        self.assertEqual(manifest_version, "4.7.0-Beta1")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:


### PR DESCRIPTION
## Summary
- set the Home Assistant manifest version to 4.7.0-Beta1
- set the runtime/debug integration version to 4.7.0-Beta1
- update the version consistency contract

This finalization changes no strategy, regulation, entity, persistence, or adapter behavior. It packages the merged work from issues #265 through #280 as the first V4.7 prerelease.

## Validation
- 392 tests passed
- 355 subtests passed
- compileall passed
- manifest, strings, and all translations parsed as valid JSON
- git diff --check passed