### PR TITLE
Release: Finalize V4.7.0

### DIFF
--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -38,7 +38,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "4.7.0-Beta1"
+INTEGRATION_VERSION = "4.7.0"
 
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": [],
-  "version": "4.7.0-Beta1"
+  "version": "4.7.0"
 }

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -13,7 +13,7 @@ COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
 
 
 class DebugIntegrationContractTests(unittest.TestCase):
-    def test_manifest_and_runtime_version_match_v470_beta1_release(self) -> None:
+    def test_manifest_and_runtime_version_match_v470_release(self) -> None:
         manifest_version = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )["version"]
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "4.7.0-Beta1")
+        self.assertEqual(manifest_version, "4.7.0")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:


### PR DESCRIPTION
## Summary
- lift the Home Assistant manifest version from 4.7.0-Beta1 to 4.7.0
- lift the runtime/debug integration version from 4.7.0-Beta1 to 4.7.0
- update the version consistency contract

## Release basis
- Beta1 and main were byte-for-byte identical before this version lift
- no functional commits followed Beta1
- real update installation loaded without broken or empty entities
- economic discharge resumed correctly after restart
- the real system then transitioned cleanly to PV-surplus charging

No strategy, regulation, entity, persistence, profile, adapter, or UI behavior changes between Beta1 and final.

## Validation
- 392 tests passed
- 355 subtests passed
- compileall passed
- manifest, strings, and all translations parsed as valid JSON
- git diff --check passed