### PR TITLE
V4.7.1: Aktive Peak-Entladung bei lernendem Wartezustand stabilisieren

### DIFF
--- a/custom_components/battery_smartflow_ai/automatic_strategy.py
+++ b/custom_components/battery_smartflow_ai/automatic_strategy.py
@@ -5,6 +5,20 @@ from typing import Any
 from .regulation_models import SeasonContext, StrategyContext
 
 
+ECONOMIC_DISCHARGE_REASONS = {
+    "adaptive_peak_discharge",
+    "very_expensive_force_discharge",
+    "price_based_discharge",
+}
+
+ECONOMIC_DISCHARGE_NEUTRAL_HOLD_REASONS = {
+    "idle",
+    "state_idle",
+    "standby",
+    "learned_charge_window_wait",
+}
+
+
 def _clamp01(value: float) -> float:
     """Clamp a numeric value to the range 0.0 ... 1.0."""
     return max(0.0, min(1.0, float(value)))
@@ -73,6 +87,41 @@ def maintain_active_economic_discharge(
         and effective_price_reached
         and (strategy_allows_discharge or inherited_active_discharge)
     )
+
+
+def economic_discharge_continuation_reason(
+    *,
+    hold_active: bool,
+    decision_action: str,
+    decision_reason: str,
+    previous_source_reason: str,
+) -> str | None:
+    """Return the economic source reason that may continue through neutral hold.
+
+    A waiting learned charge plan is neutral with respect to an already active
+    economic discharge.  It must not turn the output off merely because the
+    discharge itself, together with PV, reduced visible grid import.  Preserve
+    the source reason as well so the adaptive-peak diagnostic does not flap
+    while the same peak discharge remains active.
+    """
+
+    action = str(decision_action or "")
+    reason = str(decision_reason or "")
+    previous = str(previous_source_reason or "")
+
+    if action == "discharge" and reason in ECONOMIC_DISCHARGE_REASONS:
+        return reason
+
+    if not bool(hold_active) or action != "idle":
+        return None
+
+    if reason not in ECONOMIC_DISCHARGE_NEUTRAL_HOLD_REASONS:
+        return None
+
+    if previous in ECONOMIC_DISCHARGE_REASONS:
+        return previous
+
+    return "price_based_discharge"
 
 
 class AutomaticStrategy:

--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -38,7 +38,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "4.7.0"
+INTEGRATION_VERSION = "4.7.1"
 
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,

--- a/custom_components/battery_smartflow_ai/coordinator.py
+++ b/custom_components/battery_smartflow_ai/coordinator.py
@@ -156,6 +156,7 @@ from .economics import (
 )
 from .automatic_strategy import (
     AutomaticStrategy,
+    economic_discharge_continuation_reason,
     forecast_supports_early_pv_passthrough,
     maintain_active_economic_discharge,
 )
@@ -522,6 +523,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "regulation_post_output_overshoot_hold_until": None,
             "regulation_pv_charge_latch_started_ts": None,
             "regulation_discharge_latch_started_ts": None,
+            "automatic_economic_discharge_source_reason": "",
             "regulation_passthrough_latch_started_ts": None,
             "regulation_skipped_write_reason": "none",
 
@@ -4639,6 +4641,25 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
             original_discharge_reason = str(decision.reason or "")
 
+            previous_economic_discharge_source_reason = str(
+                self._persist.get(
+                    "automatic_economic_discharge_source_reason",
+                    "",
+                )
+                or ""
+            )
+
+            economic_discharge_source_reason = (
+                economic_discharge_continuation_reason(
+                    hold_active=automatic_economic_hold_active,
+                    decision_action=str(decision.action or ""),
+                    decision_reason=original_discharge_reason,
+                    previous_source_reason=(
+                        previous_economic_discharge_source_reason
+                    ),
+                )
+            )
+
             previous_discharge_w = max(
                 0.0,
                 float(
@@ -4697,11 +4718,17 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 discharge_hold_mode_active
                 and ai_mode != AI_MODE_MANUAL
                 and decision.action == "idle"
-                and original_discharge_reason in {
-                    "idle",
-                    "state_idle",
-                    "standby",
-                }
+                and (
+                    (
+                        autarky_cover_mode_active
+                        and original_discharge_reason
+                        in {"idle", "state_idle", "standby"}
+                    )
+                    or (
+                        automatic_economic_hold_active
+                        and economic_discharge_source_reason is not None
+                    )
+                )
                 and active_discharge_output_w > 0.0
                 and float(soc) > float(soc_min)
                 and not bool(discharge_blocked_by_soc_min)
@@ -4722,7 +4749,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 hold_reason = (
                     "summer_cover_deficit"
                     if autarky_cover_mode_active
-                    else "price_based_discharge"
+                    else economic_discharge_source_reason
                 )
 
                 decision = DecisionResult(
@@ -4762,6 +4789,19 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             else:
                 self._persist["summer_discharge_latch_reason"] = "none"
                 self._persist["automatic_discharge_latch_reason"] = "none"
+
+            if (
+                ai_mode == AI_MODE_AUTOMATIC
+                and economic_discharge_source_reason is not None
+                and str(decision.action or "") == "discharge"
+            ):
+                self._persist[
+                    "automatic_economic_discharge_source_reason"
+                ] = economic_discharge_source_reason
+            else:
+                self._persist[
+                    "automatic_economic_discharge_source_reason"
+                ] = ""
             
             regulation_runtime = self._get_regulation_runtime_state()
 

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": [],
-  "version": "4.7.0"
+  "version": "4.7.1"
 }

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -13,7 +13,7 @@ COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
 
 
 class DebugIntegrationContractTests(unittest.TestCase):
-    def test_manifest_and_runtime_version_match_v470_release(self) -> None:
+    def test_manifest_and_runtime_version_match_v471_release(self) -> None:
         manifest_version = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )["version"]
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "4.7.0")
+        self.assertEqual(manifest_version, "4.7.1")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_rc5_discharge_feedback_regressions.py
+++ b/tests/test_rc5_discharge_feedback_regressions.py
@@ -11,6 +11,7 @@ bootstrap()
 
 from custom_components.battery_smartflow_ai.automatic_strategy import (  # noqa: E402
     AutomaticStrategy,
+    economic_discharge_continuation_reason,
     maintain_active_economic_discharge,
 )
 
@@ -111,6 +112,48 @@ class Rc5DischargeFeedbackRegressionTests(unittest.TestCase):
                     "automatic_mode_active": False,
                     "effective_price_reached": True,
                 }
+            )
+        )
+
+    def test_learned_wait_preserves_active_adaptive_peak_source(self) -> None:
+        self.assertEqual(
+            economic_discharge_continuation_reason(
+                hold_active=True,
+                decision_action="idle",
+                decision_reason="learned_charge_window_wait",
+                previous_source_reason="adaptive_peak_discharge",
+            ),
+            "adaptive_peak_discharge",
+        )
+
+    def test_neutral_hold_without_source_uses_economic_fallback(self) -> None:
+        self.assertEqual(
+            economic_discharge_continuation_reason(
+                hold_active=True,
+                decision_action="idle",
+                decision_reason="learned_charge_window_wait",
+                previous_source_reason="",
+            ),
+            "price_based_discharge",
+        )
+
+    def test_protection_reason_cannot_continue_economic_discharge(self) -> None:
+        self.assertIsNone(
+            economic_discharge_continuation_reason(
+                hold_active=True,
+                decision_action="idle",
+                decision_reason="cell_voltage_cutoff_block",
+                previous_source_reason="adaptive_peak_discharge",
+            )
+        )
+
+    def test_inactive_hold_clears_previous_peak_source(self) -> None:
+        self.assertIsNone(
+            economic_discharge_continuation_reason(
+                hold_active=False,
+                decision_action="idle",
+                decision_reason="learned_charge_window_wait",
+                previous_source_reason="adaptive_peak_discharge",
             )
         )
 


### PR DESCRIPTION
## Zusammenfassung

Behebt das in Discussion #123 mit V4.7.0 reproduzierte Flattern der Peak-Entladung beim SF800Pro.

Wenn die aktive Entladung zusammen mit PV den Netzbezug auf nahezu null reduzierte, blockierte der automatische Kontext einen neuen Entladekandidaten mit `pv_covers_load_blocks_discharge`. Der neutrale Kandidat `learned_charge_window_wait` setzte anschließend den Ausgang auf 0 W. Der dadurch erneut entstehende Netzbezug startete `adaptive_peak_discharge` wieder.

## Änderung

- erweitert die vorhandene Fortsetzung einer aktiven wirtschaftlichen Entladung auf den neutralen Zustand `learned_charge_window_wait`
- bewahrt den ursprünglichen wirtschaftlichen Entladegrund, insbesondere `adaptive_peak_discharge`
- hält dadurch sowohl die Ausgangsleistung als auch den Sensor „Adaptiver Peak erkannt“ stabil
- lässt Schutzgründe, Moduswechsel und nicht mehr erreichte Preisschwellen weiterhin unverändert aussteigen
- hebt Manifest- und Laufzeitversion auf 4.7.1 an

## Regressionstests

Ergänzt Tests für:

- Fortsetzung eines aktiven adaptiven Peaks durch `learned_charge_window_wait`
- wirtschaftlichen Fallback ohne gespeicherten Ursprungsgrund
- Schutzgründe, die den Hold nicht passieren dürfen
- inaktiven Hold, der keinen alten Peak-Grund fortführt
- bestehende PV-Passthrough- und reale Ausstiegsbedingungen

## Validierung

- `396 passed, 355 subtests passed`
- Python-Compileall erfolgreich
- `git diff --check` ohne Fehler

Closes #316