### PR TITLE
V4.7.3: Lernplanung gegen Kleinstladungen stabilisieren

### DIFF
--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -38,7 +38,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "4.7.2"
+INTEGRATION_VERSION = "4.7.3"
 
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,

--- a/custom_components/battery_smartflow_ai/coordinator.py
+++ b/custom_components/battery_smartflow_ai/coordinator.py
@@ -7096,6 +7096,9 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 "learned_planning_required_charge_energy_kwh": float(
                     learned_charge_plan.required_charge_energy_kwh
                 ),
+                "learned_planning_minimum_actionable_charge_energy_kwh": float(
+                    learned_charge_plan.minimum_actionable_charge_energy_kwh
+                ),
                 "learned_planning_effective_charge_power_w": float(
                     learned_charge_plan.effective_charge_power_w
                 ),

--- a/custom_components/battery_smartflow_ai/learned_planning.py
+++ b/custom_components/battery_smartflow_ai/learned_planning.py
@@ -57,6 +57,8 @@ MIN_DATA_COVERAGE = 0.80
 DEFAULT_FALLBACK_CHARGE_POWER_W = 1200.0
 DEFAULT_PLANNING_CHARGE_EFFICIENCY = 0.90
 MIN_EFFECTIVE_CHARGE_POWER_W = 100.0
+MIN_ACTIONABLE_CHARGE_ENERGY_KWH = 0.05
+MIN_ACTIONABLE_CHARGE_SOC_PERCENT = 1.0
 
 MIN_LEARNED_CHARGE_POWER_SAMPLE_W = 300.0
 MIN_LEARNED_CHARGE_POWER_SAMPLES = 4
@@ -148,6 +150,7 @@ class LearnedChargePlan:
     forecast_adjustment_kwh: float = 0.0
     raw_required_charge_energy_kwh: float = 0.0
     required_charge_energy_kwh: float = 0.0
+    minimum_actionable_charge_energy_kwh: float = 0.0
     max_chargeable_energy_kwh: float = 0.0
 
     effective_charge_power_w: float = 0.0
@@ -614,6 +617,38 @@ def compute_required_charge_energy_kwh(
     return float(raw), float(required)
 
 
+def minimum_actionable_charge_energy_kwh(
+    total_battery_capacity_kwh: float,
+) -> float:
+    """Return the smallest learned charge need worth a new binding.
+
+    A learned plan cannot control less than one 100 W / 30 minute effective
+    window reliably, and many battery SoC sensors expose whole percentages.
+    Starting a new binding below both practical resolutions turns a few Wh of
+    recalculated need into a much larger charge pulse.
+    """
+
+    one_soc_step_kwh = max(
+        0.0,
+        float(total_battery_capacity_kwh or 0.0),
+    ) * (MIN_ACTIONABLE_CHARGE_SOC_PERCENT / 100.0)
+    return max(MIN_ACTIONABLE_CHARGE_ENERGY_KWH, one_soc_step_kwh)
+
+
+def actionable_required_charge_energy_kwh(
+    required_charge_energy_kwh: float,
+    total_battery_capacity_kwh: float,
+) -> float:
+    """Suppress a new learned binding below the actionable energy floor."""
+
+    required_kwh = max(0.0, float(required_charge_energy_kwh or 0.0))
+    if required_kwh < minimum_actionable_charge_energy_kwh(
+        total_battery_capacity_kwh,
+    ):
+        return 0.0
+    return required_kwh
+
+
 def learned_typical_charge_power_w(
     samples: list[LearningChargePowerSample],
     now: datetime,
@@ -1061,6 +1096,13 @@ def build_learned_charge_plan(
         available_energy_kwh=available_kwh,
         max_chargeable_kwh=chargeable_kwh,
     )
+    minimum_actionable_kwh = minimum_actionable_charge_energy_kwh(
+        total_battery_capacity_kwh,
+    )
+    required_kwh = actionable_required_charge_energy_kwh(
+        required_kwh,
+        total_battery_capacity_kwh,
+    )
 
     eff_power_w = effective_charge_power_w(
         profile_charge_limit_w=profile_charge_limit_w,
@@ -1085,6 +1127,10 @@ def build_learned_charge_plan(
             forecast_adjustment_kwh=round(forecast_kwh, 3),
             raw_required_charge_energy_kwh=round(raw_required_kwh, 3),
             required_charge_energy_kwh=0.0,
+            minimum_actionable_charge_energy_kwh=round(
+                minimum_actionable_kwh,
+                3,
+            ),
             max_chargeable_energy_kwh=round(chargeable_kwh, 3),
             effective_charge_power_w=round(eff_power_w, 1),
             requested_charge_power_w=0.0,
@@ -1113,6 +1159,10 @@ def build_learned_charge_plan(
             forecast_adjustment_kwh=round(forecast_kwh, 3),
             raw_required_charge_energy_kwh=round(raw_required_kwh, 3),
             required_charge_energy_kwh=round(required_kwh, 3),
+            minimum_actionable_charge_energy_kwh=round(
+                minimum_actionable_kwh,
+                3,
+            ),
             max_chargeable_energy_kwh=round(chargeable_kwh, 3),
             effective_charge_power_w=round(eff_power_w, 1),
             requested_charge_power_w=0.0,
@@ -1208,6 +1258,10 @@ def build_learned_charge_plan(
         forecast_adjustment_kwh=round(forecast_kwh, 3),
         raw_required_charge_energy_kwh=round(raw_required_kwh, 3),
         required_charge_energy_kwh=round(required_kwh, 3),
+        minimum_actionable_charge_energy_kwh=round(
+            minimum_actionable_kwh,
+            3,
+        ),
         max_chargeable_energy_kwh=round(chargeable_kwh, 3),
         effective_charge_power_w=round(eff_power_w, 1),
         requested_charge_power_w=round(requested_power_w, 1),

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": [],
-  "version": "4.7.2"
+  "version": "4.7.3"
 }

--- a/docs/anleitung.md
+++ b/docs/anleitung.md
@@ -2474,6 +2474,12 @@ Bis dahin bleibt klassische Planung aktiv. Sobald eine gelernte Planung eine
 Ladung anstößt, gelten dieselben Phasen und Abbruchbedingungen der
 AC-Ladebindung wie bei der klassischen Planung.
 
+Ein nach Zielerreichung neu berechneter Bedarf muss mindestens einer sinnvoll
+steuerbaren Energiemenge entsprechen. Als Untergrenze gilt ein SoC-Prozentpunkt
+der Gesamtkapazität, mindestens jedoch 0,05 kWh. Kleinere Abweichungen bleiben
+in der Diagnose sichtbar, erzeugen aber keine neue Ladebindung. Sobald der
+Bedarf diese Schwelle erreicht, plant BSFAI weiterhin normal neu.
+
 ---
 
 # 8.5 Stabilitätsmechanismen

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -2465,6 +2465,12 @@ Until then, classic planning remains active. As soon as a learned planning a
 charging, the same phases and termination conditions apply
 AC charge commitment as with classic planning.
 
+A newly calculated need after reaching the target must represent a technically
+controllable amount of energy. The floor is one percentage point of total
+battery capacity, but never less than 0.05 kWh. Smaller deviations remain
+visible in diagnostics but do not start another charge commitment. Once the
+need reaches this threshold, BSFAI continues to replan normally.
+
 ---
 
 # 8.5 Stability mechanisms

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -13,7 +13,7 @@ COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
 
 
 class DebugIntegrationContractTests(unittest.TestCase):
-    def test_manifest_and_runtime_version_match_v472_release(self) -> None:
+    def test_manifest_and_runtime_version_match_v473_release(self) -> None:
         manifest_version = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )["version"]
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "4.7.2")
+        self.assertEqual(manifest_version, "4.7.3")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_rc6_night_planning_regressions.py
+++ b/tests/test_rc6_night_planning_regressions.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta, timezone
 import json
 from pathlib import Path
 import unittest
+from unittest.mock import patch
 
 from support import bootstrap
 
@@ -13,14 +14,23 @@ from support import bootstrap
 bootstrap()
 
 from custom_components.battery_smartflow_ai.learned_planning import (  # noqa: E402
+    actionable_required_charge_energy_kwh,
+    build_learned_charge_plan,
     compute_window_slots,
     effective_charge_power_w,
+    minimum_actionable_charge_energy_kwh,
     optimize_charge_window,
     requested_charge_power_w,
     required_window_slots,
+    LearnedSlotModel,
+    LearningReadiness,
 )
 from custom_components.battery_smartflow_ai.market_price import (  # noqa: E402
+    MarketPrice,
+    MarketPriceDirection,
+    MarketPriceForecast,
     MarketPricePoint,
+    MarketPriceValidity,
 )
 
 
@@ -93,6 +103,121 @@ class Rc6NightPlanningRegressionTests(unittest.TestCase):
 
         self.assertAlmostEqual(requested, 758.52, places=2)
         self.assertLessEqual(requested, 800.0)
+
+    def test_joe_trace_ignores_need_below_one_soc_step(self) -> None:
+        minimum = minimum_actionable_charge_energy_kwh(5.32)
+
+        self.assertAlmostEqual(minimum, 0.0532)
+        self.assertLess(0.026, minimum)
+        for recalculated_need in (0.001, 0.002, 0.01, 0.026):
+            with self.subTest(recalculated_need=recalculated_need):
+                self.assertEqual(
+                    actionable_required_charge_energy_kwh(
+                        recalculated_need,
+                        5.32,
+                    ),
+                    0.0,
+                )
+
+    def test_material_replanned_need_remains_actionable(self) -> None:
+        minimum = minimum_actionable_charge_energy_kwh(5.32)
+
+        self.assertGreater(0.141, minimum)
+        self.assertEqual(
+            actionable_required_charge_energy_kwh(0.141, 5.32),
+            0.141,
+        )
+
+    def test_small_battery_keeps_physical_minimum_window_floor(self) -> None:
+        self.assertEqual(
+            minimum_actionable_charge_energy_kwh(1.92),
+            0.05,
+        )
+
+    def test_joe_trace_does_not_build_a_new_micro_charge_window(self) -> None:
+        now = datetime(2026, 9, 1, 1, 0, tzinfo=timezone.utc)
+        points = tuple(
+            MarketPricePoint(
+                start=now + timedelta(minutes=15 * index),
+                end=now + timedelta(minutes=15 * (index + 1)),
+                price=0.33,
+            )
+            for index in range(24)
+        )
+        market = MarketPrice(
+            direction=MarketPriceDirection.IMPORT,
+            current_price=0.33,
+            currency="EUR",
+            unit="EUR/kWh",
+            timestamp=now,
+            source="test.joe_trace",
+            validity=MarketPriceValidity.VALID,
+            is_dynamic=True,
+            is_fallback=False,
+            forecast=MarketPriceForecast(points=points, timestamp=now),
+        )
+        model = LearnedSlotModel(
+            slot_kwh=[0.01] * 96,
+            slot_sample_count=[13] * 96,
+            data_coverage=1.0,
+            history_days=13,
+            usable_days=13,
+            night_window_days=13,
+            morning_window_days=13,
+            evening_window_days=13,
+        )
+        readiness = LearningReadiness(
+            status="ready",
+            history_days=13,
+            usable_days=13,
+            night_window_days=13,
+            morning_window_days=13,
+            evening_window_days=13,
+            data_coverage=1.0,
+        )
+
+        with (
+            patch(
+                "custom_components.battery_smartflow_ai.learned_planning.expected_consumption_until",
+                return_value=1.0,
+            ),
+            patch(
+                "custom_components.battery_smartflow_ai.learned_planning.reserve_margin_kwh",
+                return_value=0.3,
+            ),
+            patch(
+                "custom_components.battery_smartflow_ai.learned_planning.forecast_adjustment_kwh",
+                return_value=0.15,
+            ),
+            patch(
+                "custom_components.battery_smartflow_ai.learned_planning.available_battery_energy_kwh",
+                return_value=1.424,
+            ),
+            patch(
+                "custom_components.battery_smartflow_ai.learned_planning.max_chargeable_energy_kwh",
+                return_value=4.0,
+            ),
+        ):
+            plan = build_learned_charge_plan(
+                model=model,
+                readiness=readiness,
+                now=now,
+                market_price=market,
+                forecast=None,
+                total_battery_capacity_kwh=5.32,
+                current_soc=37.0,
+                soc_min=10.0,
+                soc_max=100.0,
+                profile_charge_limit_w=2000.0,
+                current_effective_charge_cap_w=2000.0,
+                learned_typical_charge_power_w=2000.0,
+            )
+
+        self.assertAlmostEqual(plan.raw_required_charge_energy_kwh, 0.026)
+        self.assertEqual(plan.required_charge_energy_kwh, 0.0)
+        self.assertEqual(plan.mode, "ready")
+        self.assertEqual(plan.requested_charge_power_w, 0.0)
+        self.assertEqual(plan.effective_window_slots, 0)
 
     def test_control_context_uses_short_non_seasonal_labels(self) -> None:
         root = Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## Zusammenfassung

V4.7.3 verhindert wiederholte lernbasierte Kleinstladungen nach einem erreichten Ladeziel. Wenige neu berechnete Wattstunden dürfen nicht länger automatisch ein vollständiges 15-/30-Minuten-Ladefenster mit technischer Mindestleistung auslösen.

## Verhalten

Die kleinste neue Lernladung muss nun mindestens entsprechen:

- einem Prozentpunkt der gesamten Batteriekapazität,
- mindestens jedoch 0,05 kWh.

Kleinere Rohbedarfe bleiben für die Diagnose erhalten, werden aber nicht zu einem wirksamen Ladebedarf und erzeugen keine Ladebindung. Sobald der Bedarf die Schwelle erreicht, plant und lädt BSFAI weiterhin normal.

Für Joes Debugsequenz mit rund 5,32 kWh Gesamtkapazität bedeutet das:

- Aktionsschwelle: ca. 0,053 kWh
- 0,001 / 0,002 / 0,010 / 0,026 kWh: keine neue Ladebindung
- ursprünglicher Bedarf von 0,141 kWh: weiterhin normal planbar

## Unverändert

- gewichteter durchschnittlicher Ladepreis
- Gewinnmarge und wirtschaftliche Entladeschwelle
- Talpreis- und Peakpreislogik
- berechneter Verbrauch, Reserve und PV-Prognosezuschlag
- Schutz-, Not- und sonstige Ladepfade
- native PV-/AC-Aufteilung aus V4.7.2

## Diagnose und Dokumentation

- Rohbedarf bleibt sichtbar
- neue Aktionsschwelle wird im Debugpaket ausgegeben
- deutsche und englische Anleitung dokumentieren die Schwelle
- Version auf 4.7.3 angehoben

## Validierung

- Joes 0,026-kWh-Sequenz als vollständiger Planungsregressionstest
- materielle Neuplanung mit 0,141 kWh bleibt erlaubt
- kleine und größere Batteriesysteme abgedeckt
- 340 Unit- und Regressionstests erfolgreich
- JSON-Prüfung erfolgreich
- `git diff --check` erfolgreich

Closes #354