### PR TITLE
V5 dev2: Zendure Secret- und Datenschutzmodell

### DIFF
--- a/custom_components/battery_smartflow_ai/debug_package.py
+++ b/custom_components/battery_smartflow_ai/debug_package.py
@@ -7,62 +7,16 @@ and persistence are added by the later V4.4.0 work items.
 
 from __future__ import annotations
 
-from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from enum import Enum
-import re
 from typing import Any, Mapping
 
 from .core.clock import SystemClock
+from .zendure_privacy import sanitize_zendure_diagnostics
 
 
 DEBUG_SCHEMA_NAME = "battery_smartflow_ai.debug"
 DEBUG_SCHEMA_VERSION = 1
-
-_SECRET_KEY_PARTS = (
-    "access_token",
-    "api_key",
-    "apikey",
-    "auth",
-    "bearer",
-    "client_secret",
-    "credential",
-    "password",
-    "private_key",
-    "refresh_token",
-    "secret",
-    "token",
-)
-_REDACTED = "[REDACTED]"
-_AUTHORIZATION_PATTERN = re.compile(
-    r"(?i)\bauthorization(\s*[:=]\s*)(?:(bearer|basic)\s+)?[^\s,;&]+"
-)
-_BEARER_PATTERN = re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._~+/=-]+")
-_SECRET_ASSIGNMENT_PATTERN = re.compile(
-    r"(?i)\b("
-    r"access[_ -]?token|refresh[_ -]?token|api[_ -]?key|client[_ -]?secret|"
-    r"password|secret|token"
-    r")\b(\s*[:=]\s*)([^\s,;&]+)"
-)
-
-
-def _redact_text(value: str) -> str:
-    """Remove common inline credential forms from free diagnostic text."""
-
-    value = _AUTHORIZATION_PATTERN.sub(
-        lambda match: (
-            f"Authorization{match.group(1)}"
-            f"{match.group(2).title() + ' ' if match.group(2) else ''}{_REDACTED}"
-        ),
-        value,
-    )
-    value = _BEARER_PATTERN.sub(f"Bearer {_REDACTED}", value)
-    return _SECRET_ASSIGNMENT_PATTERN.sub(
-        lambda match: f"{match.group(1)}{match.group(2)}{_REDACTED}",
-        value,
-    )
-
 
 def _iso_utc(value: datetime) -> str:
     """Return a stable ISO-8601 UTC timestamp."""
@@ -72,24 +26,6 @@ def _iso_utc(value: datetime) -> str:
     return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
-def _json_safe(value: Any) -> Any:
-    """Convert common runtime values into deterministic JSON-safe values."""
-
-    if isinstance(value, str):
-        return _redact_text(value)
-    if value is None or isinstance(value, (bool, int, float)):
-        return value
-    if isinstance(value, datetime):
-        return _iso_utc(value)
-    if isinstance(value, Enum):
-        return _json_safe(value.value)
-    if isinstance(value, Mapping):
-        return {str(key): _json_safe(item) for key, item in value.items()}
-    if isinstance(value, (list, tuple, set, frozenset)):
-        return [_json_safe(item) for item in value]
-    return str(value)
-
-
 def redact_secrets(value: Any) -> Any:
     """Return a JSON-safe deep copy with secret-looking mapping values removed.
 
@@ -97,26 +33,7 @@ def redact_secrets(value: Any) -> Any:
     accidentally persist an unfiltered package through the supported API.
     """
 
-    safe = _json_safe(deepcopy(value))
-    return _redact_json_safe(safe)
-
-
-def _redact_json_safe(value: Any) -> Any:
-    """Redact an already copied and normalized JSON-compatible value."""
-
-    safe = value
-    if isinstance(safe, dict):
-        redacted: dict[str, Any] = {}
-        for key, item in safe.items():
-            normalized = key.casefold().replace("-", "_").replace(" ", "_")
-            if any(part in normalized for part in _SECRET_KEY_PARTS):
-                redacted[key] = _REDACTED
-            else:
-                redacted[key] = _redact_json_safe(item)
-        return redacted
-    if isinstance(safe, list):
-        return [_redact_json_safe(item) for item in safe]
-    return safe
+    return sanitize_zendure_diagnostics(value)
 
 
 @dataclass(slots=True)

--- a/custom_components/battery_smartflow_ai/zendure_privacy.py
+++ b/custom_components/battery_smartflow_ai/zendure_privacy.py
@@ -1,0 +1,246 @@
+"""Central diagnostic privacy boundary for native Zendure data.
+
+Credentials remain transport-layer inputs.  This module only creates detached,
+JSON-safe diagnostic representations and must never be used as an internal
+device identity store.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import datetime, timezone
+from enum import Enum
+import re
+from typing import Any, Mapping
+
+
+REDACTED = "[REDACTED]"
+
+_SECRET_MARKERS = (
+    "accesstoken",
+    "apikey",
+    "appkey",
+    "auth",
+    "bearer",
+    "clientid",
+    "clientsecret",
+    "cookie",
+    "credential",
+    "nonce",
+    "password",
+    "privatekey",
+    "refreshtoken",
+    "secret",
+    "signature",
+    "ssid",
+    "token",
+    "username",
+)
+_NETWORK_MARKERS = (
+    "apibase",
+    "apiurl",
+    "baseurl",
+    "broker",
+    "endpoint",
+    "hostname",
+    "ipaddress",
+    "mqtturl",
+)
+_IDENTITY_KEYS = {
+    "deviceid": "DEVICE",
+    "devicekey": "DEVICE",
+    "packid": "PACK",
+    "packkey": "PACK",
+    "productkey": "PRODUCT",
+    "serial": "SERIAL",
+    "serialnumber": "SERIAL",
+    "sn": "SERIAL",
+    "snnumber": "SERIAL",
+}
+_IDENTITY_CONTAINERS = {
+    "devices": "DEVICE",
+    "devicemap": "DEVICE",
+    "packs": "PACK",
+    "packmap": "PACK",
+}
+_AUTHORIZATION_PATTERN = re.compile(
+    r"(?i)\bauthorization(\s*[:=]\s*)(?:(bearer|basic)\s+)?[^\s,;&]+"
+)
+_BEARER_PATTERN = re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._~+/=-]+")
+_SECRET_ASSIGNMENT_PATTERN = re.compile(
+    r"(?i)\b("
+    r"access[_ -]?token|refresh[_ -]?token|api[_ -]?key|app[_ -]?key|"
+    r"client[_ -]?(?:id|secret)|password|secret|signature|token|"
+    r"username|ssid"
+    r")\b(\s*[:=]\s*)([^\s,;&]+)"
+)
+_NETWORK_URL_PATTERN = re.compile(r"(?i)\b(?:https?|mqtts?)://[^\s,;&]+")
+_IPV4_PATTERN = re.compile(r"(?<![\d.])(?:\d{1,3}\.){3}\d{1,3}(?![\d.])")
+_LOCAL_HOST_PATTERN = re.compile(r"(?i)\b[a-z0-9][a-z0-9.-]*\.local\b")
+
+
+def _normalized_key(value: Any) -> str:
+    return re.sub(r"[^a-z0-9]", "", str(value).casefold())
+
+
+def _identity_kind(key: Any) -> str | None:
+    return _IDENTITY_KEYS.get(_normalized_key(key))
+
+
+def _is_secret_key(key: Any) -> bool:
+    normalized = _normalized_key(key)
+    return any(marker in normalized for marker in _SECRET_MARKERS)
+
+
+def _is_network_key(key: Any) -> bool:
+    normalized = _normalized_key(key)
+    return normalized in {"host", "ip", "server", "url"} or any(
+        marker in normalized for marker in _NETWORK_MARKERS
+    )
+
+
+def _iso_utc(value: datetime) -> str:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError("Diagnostic timestamps must be timezone-aware")
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, str):
+        return value
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    if isinstance(value, datetime):
+        return _iso_utc(value)
+    if isinstance(value, Enum):
+        return _json_safe(value.value)
+    if isinstance(value, Mapping):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return [_json_safe(item) for item in value]
+    return str(value)
+
+
+class ZendureDiagnosticSanitizer:
+    """Create one package-local, privacy-safe diagnostic view."""
+
+    def __init__(self) -> None:
+        self._aliases: dict[tuple[str, str], str] = {}
+        self._secret_values: set[str] = set()
+        self._identity_values: dict[str, str] = {}
+
+    def sanitize(self, value: Any) -> Any:
+        """Return a detached JSON-safe copy with secrets and identities removed."""
+
+        safe = _json_safe(deepcopy(value))
+        self._discover(safe)
+        return self._sanitize_value(safe)
+
+    def sanitize_exception(self, error: BaseException) -> str:
+        """Return an exception summary safe for logs and diagnostics."""
+
+        return self._sanitize_text(f"{type(error).__name__}: {error}")
+
+    def _alias(self, kind: str, value: Any) -> str:
+        original = str(value)
+        key = (kind, original)
+        if key not in self._aliases:
+            number = 1 + sum(
+                1 for existing_kind, _ in self._aliases if existing_kind == kind
+            )
+            self._aliases[key] = f"ZD_{kind}_A{number}"
+        return self._aliases[key]
+
+    def _discover(self, value: Any, container_kind: str | None = None) -> None:
+        if isinstance(value, dict):
+            for key, item in value.items():
+                if container_kind is not None:
+                    original_key = str(key)
+                    alias = self._alias(container_kind, original_key)
+                    if len(original_key) >= 4:
+                        self._identity_values[original_key] = alias
+                if _is_secret_key(key):
+                    if isinstance(item, (str, int, float)) and not isinstance(item, bool):
+                        text = str(item)
+                        if len(text) >= 4:
+                            self._secret_values.add(text)
+                    continue
+                kind = _identity_kind(key)
+                if kind is not None and item is not None:
+                    original = str(item)
+                    alias = self._alias(kind, original)
+                    if len(original) >= 4:
+                        self._identity_values[original] = alias
+                self._discover(
+                    item,
+                    _IDENTITY_CONTAINERS.get(_normalized_key(key)),
+                )
+            return
+        if isinstance(value, list):
+            for item in value:
+                self._discover(item)
+
+    def _sanitize_value(self, value: Any) -> Any:
+        if isinstance(value, dict):
+            result: dict[str, Any] = {}
+            for key, item in value.items():
+                safe_key = self._sanitize_mapping_key(str(key))
+                if _is_secret_key(key) or _is_network_key(key):
+                    result[safe_key] = REDACTED
+                    continue
+                kind = _identity_kind(key)
+                if kind is not None and item is not None:
+                    result[safe_key] = self._alias(kind, item)
+                    continue
+                result[safe_key] = self._sanitize_value(item)
+            return result
+        if isinstance(value, list):
+            return [self._sanitize_value(item) for item in value]
+        if isinstance(value, str):
+            return self._sanitize_text(value)
+        return value
+
+    def _sanitize_mapping_key(self, value: str) -> str:
+        """Replace identity-bearing map keys without rewriting schema names."""
+
+        text = value
+        for original, alias in sorted(
+            self._identity_values.items(),
+            key=lambda item: len(item[0]),
+            reverse=True,
+        ):
+            text = text.replace(original, alias)
+        return text
+
+    def _sanitize_text(self, value: str) -> str:
+        text = _AUTHORIZATION_PATTERN.sub(
+            lambda match: (
+                f"Authorization{match.group(1)}"
+                f"{match.group(2).title() + ' ' if match.group(2) else ''}"
+                f"{REDACTED}"
+            ),
+            value,
+        )
+        text = _BEARER_PATTERN.sub(f"Bearer {REDACTED}", text)
+        text = _SECRET_ASSIGNMENT_PATTERN.sub(
+            lambda match: f"{match.group(1)}{match.group(2)}{REDACTED}",
+            text,
+        )
+        text = _NETWORK_URL_PATTERN.sub(REDACTED, text)
+        text = _IPV4_PATTERN.sub(REDACTED, text)
+        text = _LOCAL_HOST_PATTERN.sub(REDACTED, text)
+        for secret in sorted(self._secret_values, key=len, reverse=True):
+            text = text.replace(secret, REDACTED)
+        for original, alias in sorted(
+            self._identity_values.items(),
+            key=lambda item: len(item[0]),
+            reverse=True,
+        ):
+            text = text.replace(original, alias)
+        return text
+
+
+def sanitize_zendure_diagnostics(value: Any) -> Any:
+    """Sanitize one complete diagnostic payload with one alias namespace."""
+
+    return ZendureDiagnosticSanitizer().sanitize(value)

--- a/docs/architecture/zendure-communication-research-v5.0.0.md
+++ b/docs/architecture/zendure-communication-research-v5.0.0.md
@@ -567,6 +567,7 @@ initial read model.
 
 ### Issue #320: secrets and privacy
 
+- Binding model: `zendure-secrets-privacy-v5.0.0.md`.
 - secure token/MQTT credential storage and reauth;
 - salted diagnostic identity fingerprints;
 - signing implementation isolation;

--- a/docs/architecture/zendure-secrets-privacy-v5.0.0.md
+++ b/docs/architecture/zendure-secrets-privacy-v5.0.0.md
@@ -1,0 +1,210 @@
+# V5.0.0 Zendure secrets and diagnostic privacy model
+
+Status: binding foundation for issues #320 and #322–#324  
+Runtime baseline: V4.7.3  
+Scope: Cloud bootstrap, Cloud MQTT, Local MQTT, ZenSDK and all diagnostic output
+
+## 1. Trust boundaries
+
+Native Zendure communication is split into three layers:
+
+1. **Credential and transport adapters** may temporarily hold the exact values
+   required for authentication, signing and connection setup.
+2. **Native device adapters** receive authenticated messages and convert them
+   into identity-aware raw device observations.
+3. **Neutral device state, RuntimeSnapshot, Strategy and PowerController** must
+   never receive tokens, MQTT credentials, signing material or raw connection
+   endpoints.
+
+Credentials are not device state. A transport adapter may reference a stable
+internal device identity, but a neutral device model must not reference the
+credential object that made a message available.
+
+## 2. Classification
+
+### Secrets: always remove
+
+- complete App/Home-Assistant token and decoded token text;
+- `appKey`, API keys, access/refresh tokens and private keys;
+- Authorization, Bearer and Basic headers;
+- request signatures, signing material, cookies and session credentials;
+- Cloud- and Local-MQTT client ID, username and password;
+- Wi-Fi SSID/password and other provisioning credentials;
+- values in future fields whose names identify them as credentials or secrets.
+
+Secret values become `[REDACTED]`. They never become hashes or aliases because
+diagnostic equality for credentials is not a supported use case.
+
+### Sensitive identities: package-local pseudonyms
+
+- `deviceKey`, device IDs and device-map keys;
+- main-device and pack serials (`serial`, `sn`, `snNumber`);
+- pack IDs/keys and pack-map keys;
+- `productKey` where it participates in routing or account identity;
+- occurrences of the same identifiers inside MQTT topics, URLs and error text.
+
+Examples:
+
+- `ZD_DEVICE_A1`
+- `ZD_SERIAL_A1`
+- `ZD_PACK_A1`
+- `ZD_PRODUCT_A1`
+
+Equal source identities receive the same alias everywhere in one export. Alias
+namespaces restart for every export. They are deliberately unsuitable for
+cross-export or cross-installation tracking and are not internal device IDs.
+
+### Network and user identifiers: remove
+
+- complete API endpoints and broker URLs;
+- IP addresses and full `.local` hostnames;
+- user-defined names when a capture path enables name anonymization;
+- any network identifier that embeds a serial or device ID.
+
+Transport class (`cloud_mqtt`, `local_mqtt`, `zensdk`), normalized region/host
+class and connection state may be exposed separately when later adapters can
+derive them without retaining the original endpoint.
+
+### Safe technical data
+
+After sanitizing identities and credentials, diagnostics may contain:
+
+- verified model, firmware and capability labels;
+- transport class, lifecycle phase and timing;
+- numeric power, energy, voltage, temperature and SoC measurements;
+- valid zero, missing, null, stale and invalid as distinct states;
+- payload key/schema inventories;
+- MQTT QoS/retained flags and request/response status classes;
+- configured/available/fresh/readback-match booleans.
+
+## 3. Central sanitizing boundary
+
+`zendure_privacy.ZendureDiagnosticSanitizer` is the shared implementation for
+native Zendure payloads and the existing BSFAI debug pipeline. Supported output
+paths must pass through this boundary before serialization, logging or entity
+attribute creation.
+
+The sanitizer:
+
+1. creates a detached JSON-safe copy;
+2. performs a complete discovery pass for secrets and identities;
+3. assigns package-local typed aliases;
+4. recursively sanitizes mapping values, mapping keys and sequences;
+5. replaces discovered identities inside MQTT topics and free text;
+6. removes inline Authorization/Bearer credentials and assignments;
+7. preserves numeric zero, null and boolean values exactly.
+
+The discovery pass is required because an MQTT topic can occur before the
+`deviceKey` field that explains the identity embedded in that topic.
+
+Unknown nested properties are not exempt. Every mapping and sequence passes
+through the same recursive boundary, and future credential-looking field names
+are conservatively redacted.
+
+## 4. Exception and logging policy
+
+Never log raw HTTP responses, MQTT payloads, connection objects or `repr()` of
+requests/exceptions that may carry credentials.
+
+A transport operation creates one sanitizer context, registers its credential
+and identity inputs by sanitizing the structured context, and uses
+`sanitize_exception()` for any externally supplied exception text.
+
+Allowed:
+
+```text
+Zendure Cloud MQTT authentication failed for ZD_DEVICE_A1
+```
+
+Forbidden:
+
+```text
+MQTT login failed username=<full> password=<full> device=<full deviceKey>
+```
+
+Operational logs should prefer controlled reason enums over remote free text.
+Sanitized remote detail belongs in diagnostics only when it materially helps
+support.
+
+## 5. Home Assistant persistence and reauthentication
+
+Issues #322 and later must follow these rules:
+
+- persist only credentials actually required to reconnect;
+- use the integration ConfigEntry data/options mechanisms;
+- do not create a separate plaintext credential file;
+- do not copy secrets into coordinator persistence, learned state or debug
+  configuration;
+- pass credentials directly from the HA adapter to the owning transport;
+- token replacement updates the owning ConfigEntry value and recreates the
+  affected transport context;
+- reauthentication UI and errors expose only controlled reason/status values;
+- unload/reload drops in-memory connection credentials with the transport.
+
+Home Assistant ConfigEntry storage is not presented as encrypted secret
+storage. The safety objective is least duplication, platform-owned persistence
+and zero diagnostic/log/entity exposure.
+
+## 6. Home Assistant entity contract
+
+Entities and attributes may expose model, product family, transport class,
+online state, capabilities and package-local diagnostic aliases where useful.
+
+They must never expose:
+
+- credentials or signature material;
+- full device, pack or serial identities;
+- full API/broker endpoints, IP addresses or hostnames;
+- raw unfiltered request, response or MQTT payloads.
+
+Internal stable device identity for the registry is owned by issue #321. The
+diagnostic aliases in this document must not be used as registry identifiers.
+
+## 7. Initial-sync capture contract
+
+Issue #324 may retain a near-complete ordered initial-sync capture only after
+the complete capture object has passed through one sanitizer instance.
+
+The capture writer must:
+
+- sanitize before writing, not after reopening a raw file;
+- never create a temporary unredacted capture;
+- run a second sanitizing pass at the serialization edge as defence in depth;
+- use one alias namespace for HTTP bootstrap, topics, payloads and pack data;
+- fail closed when serialization or sanitizing cannot complete;
+- report controlled errors without including the rejected raw value.
+
+Captures may preserve unknown property names and safe values. A property name
+that looks like a secret, credential, identity or network address is sanitized
+even when the firmware field was not known when BSFAI was released.
+
+## 8. Test contract
+
+Automated tests cover:
+
+- App token, `appKey`, client ID, username and password removal;
+- nested and unknown credential fields;
+- Authorization/Bearer and inline assignment removal;
+- device, pack, serial and product aliases;
+- consistent aliases across fields, mapping keys, topics and free text;
+- IDs encountered after the topic in the original payload;
+- endpoint, broker, IP and hostname removal;
+- exception text containing discovered secret/identity values;
+- source immutability and JSON-safe timestamps;
+- preservation of zero, null and boolean distinctions;
+- package-local alias namespace reset;
+- compatibility of the existing V4 debug-package pipeline.
+
+## 9. Handoff to later V5 issues
+
+- **#321** defines real internal device/pack identities. Diagnostic aliases are
+  not candidates for that model.
+- **#322** stores the App token minimally and keeps decoding/signing inside the
+  Cloud transport adapter.
+- **#323** owns Cloud-MQTT credentials and must never add them to device state.
+- **#324** uses one sanitizer context for the complete initial-sync capture.
+- **#325+** receive only sanitized diagnostics and credential-free normalized
+  observations.
+
+No native network request or device write is introduced by issue #320.
+

--- a/tests/test_zendure_privacy.py
+++ b/tests/test_zendure_privacy.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+import unittest
+
+from support import bootstrap
+
+
+bootstrap()
+
+from custom_components.battery_smartflow_ai.zendure_privacy import (  # noqa: E402
+    REDACTED,
+    ZendureDiagnosticSanitizer,
+    sanitize_zendure_diagnostics,
+)
+
+
+class ZendurePrivacyTests(unittest.TestCase):
+    def test_cloud_bootstrap_secrets_are_removed_recursively(self) -> None:
+        source = {
+            "token": "complete-app-token",
+            "data": {
+                "appKey": "secret-app-key",
+                "mqtt": {
+                    "clientId": "secret-client",
+                    "username": "secret-user",
+                    "password": "secret-password",
+                },
+            },
+        }
+
+        result = sanitize_zendure_diagnostics(source)
+        encoded = json.dumps(result)
+
+        self.assertNotIn("complete-app-token", encoded)
+        self.assertNotIn("secret-app-key", encoded)
+        self.assertNotIn("secret-client", encoded)
+        self.assertNotIn("secret-user", encoded)
+        self.assertNotIn("secret-password", encoded)
+        self.assertEqual(result["token"], REDACTED)
+
+    def test_device_pack_and_serial_aliases_are_consistent_per_export(self) -> None:
+        result = sanitize_zendure_diagnostics(
+            {
+                "deviceKey": "device-key-123",
+                "device_id": "device-key-123",
+                "snNumber": "serial-main-456",
+                "packData": [
+                    {"packId": "pack-789", "sn": "pack-serial-789"},
+                    {"pack_id": "pack-789", "sn": "pack-serial-789"},
+                ],
+            }
+        )
+
+        self.assertEqual(result["deviceKey"], "ZD_DEVICE_A1")
+        self.assertEqual(result["device_id"], "ZD_DEVICE_A1")
+        self.assertEqual(result["snNumber"], "ZD_SERIAL_A1")
+        self.assertEqual(result["packData"][0]["packId"], "ZD_PACK_A1")
+        self.assertEqual(result["packData"][1]["pack_id"], "ZD_PACK_A1")
+        self.assertEqual(result["packData"][0]["sn"], "ZD_SERIAL_A2")
+        self.assertEqual(result["packData"][1]["sn"], "ZD_SERIAL_A2")
+
+    def test_topic_is_cleaned_even_when_identity_appears_later(self) -> None:
+        result = sanitize_zendure_diagnostics(
+            {
+                "topic": "iot/device-key-123/properties/report",
+                "payload": {"deviceKey": "device-key-123", "power": 0},
+            }
+        )
+
+        self.assertEqual(
+            result["topic"],
+            "iot/ZD_DEVICE_A1/properties/report",
+        )
+        self.assertEqual(result["payload"]["power"], 0)
+
+    def test_device_ids_used_as_mapping_keys_are_pseudonymized(self) -> None:
+        result = sanitize_zendure_diagnostics(
+            {
+                "devices": {
+                    "device-key-123": {
+                        "topic": "iot/device-key-123/properties/report",
+                        "power": 500,
+                    }
+                }
+            }
+        )
+
+        self.assertIn("ZD_DEVICE_A1", result["devices"])
+        self.assertNotIn("device-key-123", json.dumps(result))
+        self.assertEqual(
+            result["devices"]["ZD_DEVICE_A1"]["topic"],
+            "iot/ZD_DEVICE_A1/properties/report",
+        )
+
+    def test_unknown_nested_credential_fields_use_same_boundary(self) -> None:
+        result = sanitize_zendure_diagnostics(
+            {
+                "unknown": [
+                    {
+                        "futureCredentialBlob": "future-secret",
+                        "newProperty": {"api-signature": "signed-secret"},
+                    }
+                ]
+            }
+        )
+
+        self.assertEqual(
+            result["unknown"][0]["futureCredentialBlob"],
+            REDACTED,
+        )
+        self.assertEqual(
+            result["unknown"][0]["newProperty"]["api-signature"],
+            REDACTED,
+        )
+
+    def test_network_identifiers_are_not_exported(self) -> None:
+        result = sanitize_zendure_diagnostics(
+            {
+                "apiUrl": "https://example.invalid/api",
+                "url": "mqtts://broker.invalid:8883",
+                "mqttUrl": "mqtts://broker.invalid:8883",
+                "ip": "192.0.2.10",
+                "hostname": "zendure-device-serial.local",
+                "transport": "cloud_mqtt",
+            }
+        )
+
+        self.assertEqual(result["apiUrl"], REDACTED)
+        self.assertEqual(result["url"], REDACTED)
+        self.assertEqual(result["mqttUrl"], REDACTED)
+        self.assertEqual(result["ip"], REDACTED)
+        self.assertEqual(result["hostname"], REDACTED)
+        self.assertEqual(result["transport"], "cloud_mqtt")
+
+    def test_network_values_embedded_in_exception_text_are_removed(self) -> None:
+        result = ZendureDiagnosticSanitizer().sanitize_exception(
+            RuntimeError(
+                "failed at https://api.example.invalid/path via 192.0.2.10 "
+                "and zendure-device.local"
+            )
+        )
+
+        self.assertNotIn("api.example.invalid", result)
+        self.assertNotIn("192.0.2.10", result)
+        self.assertNotIn("zendure-device.local", result)
+
+    def test_exception_path_uses_discovered_secret_and_identity_values(self) -> None:
+        sanitizer = ZendureDiagnosticSanitizer()
+        sanitizer.sanitize(
+            {
+                "username": "mqtt-user-123",
+                "password": "mqtt-password-456",
+                "deviceKey": "device-key-789",
+            }
+        )
+
+        result = sanitizer.sanitize_exception(
+            RuntimeError(
+                "login failed for mqtt-user-123 / mqtt-password-456 "
+                "on device-key-789"
+            )
+        )
+
+        self.assertNotIn("mqtt-user-123", result)
+        self.assertNotIn("mqtt-password-456", result)
+        self.assertNotIn("device-key-789", result)
+        self.assertIn("ZD_DEVICE_A1", result)
+
+    def test_inline_authorization_and_assignments_are_removed(self) -> None:
+        result = sanitize_zendure_diagnostics(
+            {
+                "error": (
+                    "Authorization: Bearer abc.def "
+                    "username=mqtt-user password=mqtt-pass appKey=app-secret"
+                )
+            }
+        )["error"]
+
+        self.assertNotIn("abc.def", result)
+        self.assertNotIn("mqtt-user", result)
+        self.assertNotIn("mqtt-pass", result)
+        self.assertNotIn("app-secret", result)
+
+    def test_source_is_not_mutated_and_json_values_remain_distinct(self) -> None:
+        timestamp = datetime(2026, 9, 1, 12, 0, tzinfo=timezone.utc)
+        source = {
+            "deviceKey": "device-key-123",
+            "values": {"zero": 0, "missing": None, "online": False},
+            "timestamp": timestamp,
+        }
+
+        result = sanitize_zendure_diagnostics(source)
+
+        self.assertEqual(source["deviceKey"], "device-key-123")
+        self.assertIs(source["timestamp"], timestamp)
+        self.assertEqual(result["values"]["zero"], 0)
+        self.assertIsNone(result["values"]["missing"])
+        self.assertIs(result["values"]["online"], False)
+        self.assertEqual(result["timestamp"], "2026-09-01T12:00:00Z")
+
+    def test_alias_namespace_is_package_local(self) -> None:
+        first = sanitize_zendure_diagnostics({"deviceKey": "device-one"})
+        second = sanitize_zendure_diagnostics({"deviceKey": "device-two"})
+
+        self.assertEqual(first["deviceKey"], "ZD_DEVICE_A1")
+        self.assertEqual(second["deviceKey"], "ZD_DEVICE_A1")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Zusammenfassung

- führt mit `ZendureDiagnosticSanitizer` eine zentrale Datenschutzgrenze für native Zendure-Daten ein
- entfernt App-Token, `appKey`, MQTT-Zugangsdaten, Signaturen, Netzwerkadressen und unbekannte verschachtelte Geheimnisfelder
- pseudonymisiert Geräte-, Pack-, Serien- und Produktkennungen innerhalb eines Diagnoseexports konsistent – auch in Mapping-Schlüsseln, MQTT-Themen und Fehlermeldungen
- bindet den bestehenden V4-Debugpaket-Export an dieselbe zentrale Bereinigung an
- dokumentiert verbindlich Speicherung, Reauthentifizierung, Logging, HA-Entitäten und den späteren Initial-Sync-Capture
- enthält bewusst noch keine native Netzwerkverbindung und keinen Schreibzugriff auf Zendure-Hardware

## Validierung

- `python -m unittest discover -s tests -p 'test_*.py'`
- 351 Tests erfolgreich
- `git diff --check`

Closes #320