### PR TITLE
V4.7.4: Keep active PV charge in ramp-down path

### DIFF
--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -38,7 +38,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "4.7.3"
+INTEGRATION_VERSION = "4.7.4"
 
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,

--- a/custom_components/battery_smartflow_ai/decision_engine.py
+++ b/custom_components/battery_smartflow_ai/decision_engine.py
@@ -782,6 +782,11 @@ class PvRule(BaseRule):
             and engine._discharge_protection_active(ctx)
         )
 
+        charge_already_active = bool(ctx.pv_charge_latched)
+        active_charge_can_ramp_down = (
+            engine._active_pv_charge_can_ramp_down(ctx)
+        )
+
         # A previous 60 W discharge keepalive must not suppress PV surplus charge.
         # If there is real PV surplus, PV charging may take over even when
         # prev_discharge_w is still > 0 from the previous cycle.
@@ -789,13 +794,16 @@ class PvRule(BaseRule):
             prev_discharge_w,
             float(ctx.last_output_w or 0.0),
         ) > 0.0
+        if charge_already_active and active_charge_can_ramp_down:
+            # Confirmed current INPUT wins over stale OUTPUT evidence from a
+            # preceding regulation phase. The input controller will reduce the
+            # charge before any real direction handover is considered.
+            discharge_active = False
         if discharge_active and not engine._pv_surplus_blocks_discharge(ctx):
             return None
 
         start_counter = int(ctx.pv_charge_start_counter or 0)
         stop_counter = int(ctx.pv_charge_stop_counter or 0)
-
-        charge_already_active = bool(ctx.pv_charge_latched)
 
         sf800_passthrough_enabled = engine._pv_houseload_passthrough_enabled(ctx)
 
@@ -843,6 +851,10 @@ class PvRule(BaseRule):
             and (
                 not battery_discharge_source_active
                 or source_verified_hold_surplus
+                # Issue #360: a stale previous OUTPUT value must not suppress
+                # the currently confirmed INPUT latch when reducing that input
+                # would explain the complete grid import.
+                or active_charge_can_ramp_down
             )
         )
 
@@ -877,6 +889,20 @@ class PvRule(BaseRule):
                     return None
             else:
                 charge_w = max(charge_w, engine._charge_keepalive_w(ctx))
+
+            # V4.7.4 / issue #360:
+            # A small import during active PV charging can be caused by the
+            # current battery input itself.  Keep the PV-charge intent alive so
+            # the technical delta controller can reduce INPUT progressively.
+            # Falling through to AutarkyLoadCoverageRule would request OUTPUT;
+            # the arbiter correctly blocks that immediate direction change but
+            # the blocked command would otherwise collapse INPUT straight to
+            # 0 W and create export before charging starts again.
+            if (
+                charge_w <= 0.0
+                and active_charge_can_ramp_down
+            ):
+                charge_w = prev_charge_w
 
         if (
             soft_start_ready
@@ -1474,6 +1500,35 @@ class DecisionEngine:
         # No real active discharge, only idle/old keepalive:
         # PV surplus should block starting or keeping economic discharge.
         return True
+
+    @staticmethod
+    def _active_pv_charge_can_ramp_down(ctx: DecisionContext) -> bool:
+        """Return whether removing current INPUT explains the grid import.
+
+        If the residual import after subtracting the previous battery input is
+        still above the configured target band, there is a real house deficit
+        and the normal Autarky handover remains authoritative.
+        """
+
+        if not bool(ctx.pv_charge_latched):
+            return False
+
+        previous_input_w = max(0.0, float(ctx.prev_charge_w or 0.0))
+        if previous_input_w <= 0.0:
+            return False
+
+        import_w = max(0.0, float(ctx.grid_import_w or 0.0))
+        target_import_w = max(
+            0.0,
+            float(ctx.profile.get("TARGET_IMPORT_W", 0.0) or 0.0),
+        )
+        charge_deadband_w = max(
+            0.0,
+            float(ctx.profile.get("CHARGE_DEADBAND_W", 0.0) or 0.0),
+        )
+
+        residual_import_w = max(0.0, import_w - previous_input_w)
+        return residual_import_w <= target_import_w + charge_deadband_w
 
     def _pv_attributable_export_w(self, ctx: DecisionContext) -> float:
         """Return export that cannot be explained by battery discharge.

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": [],
-  "version": "4.7.3"
+  "version": "4.7.4"
 }

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -13,7 +13,7 @@ COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
 
 
 class DebugIntegrationContractTests(unittest.TestCase):
-    def test_manifest_and_runtime_version_match_v473_release(self) -> None:
+    def test_manifest_and_runtime_version_match_v474_release(self) -> None:
         manifest_version = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )["version"]
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "4.7.3")
+        self.assertEqual(manifest_version, "4.7.4")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_dev9_scenarios.py
+++ b/tests/test_dev9_scenarios.py
@@ -213,6 +213,64 @@ class Dev9ModeScenarios(unittest.TestCase):
         )
 
         self.assertEqual(result.reason, "summer_cover_deficit")
+
+    def test_active_pv_charge_reduces_input_before_autarky_handover(self) -> None:
+        """Issue #190: 53 W import must not collapse 278 W INPUT to zero."""
+
+        result = DecisionEngine().evaluate(
+            context(
+                ai_mode=AI_MODE_SUMMER,
+                soc=45.0,
+                soc_min=12.0,
+                grid_import_w=53.0,
+                grid_export_w=0.0,
+                pv_w=417.0,
+                house_load_w=179.0,
+                prev_charge_w=278.0,
+                # Reproduce the stale prior OUTPUT evidence from the trace.
+                # Before #360 this prevents the PV-charge keepalive and lets
+                # Autarky request the blocked INPUT -> OUTPUT handover.
+                last_output_w=800.0,
+                pv_charge_start_export_w=0.0,
+                pv_charge_latched=True,
+                pv_charge_stop_counter=0,
+                profile={
+                    **PROFILE,
+                    "PV_HOUSELOAD_PASSTHROUGH": True,
+                },
+            )
+        )
+
+        self.assertEqual(result.action, "charge")
+        self.assertEqual(result.reason, "pv_surplus_charge")
+        self.assertGreater(result.charge_w, 0.0)
+        self.assertLess(result.charge_w, 278.0)
+
+    def test_real_deficit_still_hands_active_pv_charge_to_autarky(self) -> None:
+        """A load deficit remaining after INPUT removal still permits OUTPUT."""
+
+        result = DecisionEngine().evaluate(
+            context(
+                ai_mode=AI_MODE_SUMMER,
+                soc=45.0,
+                soc_min=12.0,
+                grid_import_w=1073.0,
+                grid_export_w=0.0,
+                pv_w=1232.0,
+                house_load_w=1748.0,
+                prev_charge_w=566.0,
+                pv_charge_start_export_w=0.0,
+                pv_charge_latched=True,
+                pv_charge_stop_counter=8,
+                profile={
+                    **PROFILE,
+                    "PV_HOUSELOAD_PASSTHROUGH": True,
+                },
+            )
+        )
+
+        self.assertEqual(result.action, "discharge")
+        self.assertEqual(result.reason, "summer_cover_deficit")
         self.assertEqual(result.action, "discharge")
         self.assertGreater(result.discharge_w, 0.0)
 


### PR DESCRIPTION
## Summary
- keep a confirmed active PV charge in the input path when removing its current input fully explains the measured grid import
- ignore stale prior-output evidence during that controlled input ramp-down
- preserve the normal Autarky handover when a real house deficit remains after input removal
- lift the maintenance release version to 4.7.4

## Regression evidence
The 30-minute trace in #190 contains five identical failures where 255-362 W active input collapsed to 0 W on only 27-58 W import. The new regression reproduces the 17:43:28 event (278 W input, 53 W import) including stale prior-output evidence.

## Validation
- full V4.7.4 suite: 342 tests passed
- focused mode/regression suite: 28 tests passed
- `git diff --check`

## Branch safety
This PR targets the dedicated `v4.7-maintenance` branch created directly from tag `4.7.3`. It contains no V5 files. The behavioral fix will be forward-ported separately to `main`.

Closes #360