### PR TITLE
V5: Add privacy-safe Zendure initial-sync capture

### DIFF
--- a/custom_components/battery_smartflow_ai/zendure_cloud.py
+++ b/custom_components/battery_smartflow_ai/zendure_cloud.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 from base64 import b64decode
 import binascii
+from copy import deepcopy
 from dataclasses import dataclass, field
 import hashlib
 import secrets
@@ -111,6 +112,9 @@ class ZendureCloudBootstrap:
 
     devices: tuple[ZendureCloudDevice, ...]
     mqtt: CloudMqttCredentials = field(repr=False)
+    raw_device_list: tuple[Mapping[str, Any], ...] = field(
+        default=(), repr=False
+    )
 
     def __repr__(self) -> str:
         return f"ZendureCloudBootstrap(devices={len(self.devices)}, mqtt=[REDACTED])"
@@ -239,7 +243,14 @@ def _parse_bootstrap(payload: Any) -> ZendureCloudBootstrap:
     if len(candidate_ids) != len(set(candidate_ids)):
         raise ZendureCloudError("duplicate_device_id")
     mqtt = _parse_mqtt(data.get("mqtt"))
-    return ZendureCloudBootstrap(devices=devices, mqtt=mqtt)
+    raw_device_list = tuple(
+        deepcopy(dict(item)) for item in raw_devices if isinstance(item, Mapping)
+    )
+    return ZendureCloudBootstrap(
+        devices=devices,
+        mqtt=mqtt,
+        raw_device_list=raw_device_list,
+    )
 
 
 _KNOWN_DEVICE_FIELDS = {

--- a/custom_components/battery_smartflow_ai/zendure_initial_sync.py
+++ b/custom_components/battery_smartflow_ai/zendure_initial_sync.py
@@ -1,0 +1,397 @@
+"""Event-driven, privacy-safe Zendure initial-sync capture for V5."""
+
+from __future__ import annotations
+
+import asyncio
+from base64 import b64encode
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+import tempfile
+import time
+from typing import Any, Callable, Mapping
+
+from .zendure_cloud import ZendureCloudBootstrap
+from .zendure_cloud_mqtt import (
+    CloudMqttMessage,
+    ConnectionState,
+    ZendureCloudMqttTransport,
+)
+from .zendure_privacy import ZendureDiagnosticSanitizer
+
+
+SCHEMA = "battery_smartflow_ai.zendure_initial_sync"
+SCHEMA_VERSION = 1
+INITIAL_SYNC_DIRECTORY = Path("bsfai") / "debug"
+DEFAULT_QUIET_PERIOD = 3.0
+DEFAULT_HARD_TIMEOUT = 30.0
+DEFAULT_MAX_EXPORT_BYTES = 32 * 1024 * 1024
+
+
+class InitialSyncExportError(RuntimeError):
+    """Raised when a sanitized capture cannot be exported safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class InitialSyncCaptureResult:
+    """Completed or diagnostically useful partial initial-sync capture."""
+
+    started_at: datetime
+    finished_at: datetime
+    complete: bool
+    completion_reason: str
+    discovery: tuple[Mapping[str, Any], ...]
+    connection_events: tuple[Mapping[str, Any], ...]
+    messages: tuple[CloudMqttMessage, ...]
+    expected_devices: tuple[str, ...]
+
+    def as_dict(self) -> dict[str, Any]:
+        """Build one detached package and sanitize it with one alias namespace."""
+
+        raw_messages = [_raw_message(item) for item in self.messages]
+        package = {
+            "meta": {
+                "schema": SCHEMA,
+                "schema_version": SCHEMA_VERSION,
+                "started_at": _iso(self.started_at),
+                "finished_at": _iso(self.finished_at),
+                "complete": self.complete,
+                "completion_reason": self.completion_reason,
+                "read_only": True,
+            },
+            "raw_communication": {
+                "device_list": [dict(item) for item in self.discovery],
+                "connection_events": [dict(item) for item in self.connection_events],
+                "mqtt_messages": raw_messages,
+            },
+            "bsfai_interpretation": _build_summary(
+                self.discovery,
+                self.messages,
+                self.expected_devices,
+            ),
+        }
+        return ZendureDiagnosticSanitizer().sanitize(package)
+
+
+@dataclass(frozen=True, slots=True)
+class InitialSyncExportResult:
+    path: Path
+    size_bytes: int
+
+
+class ZendureInitialSyncRecorder:
+    """Track novelty and completion without becoming a long-term logger."""
+
+    def __init__(
+        self,
+        bootstrap: ZendureCloudBootstrap,
+        *,
+        quiet_period: float = DEFAULT_QUIET_PERIOD,
+        hard_timeout: float = DEFAULT_HARD_TIMEOUT,
+        clock: Callable[[], datetime] | None = None,
+        monotonic: Callable[[], float] = time.monotonic,
+    ) -> None:
+        if quiet_period <= 0 or hard_timeout <= quiet_period:
+            raise ValueError("hard_timeout must be greater than quiet_period")
+        self._bootstrap = bootstrap
+        self._quiet_period = quiet_period
+        self._hard_timeout = hard_timeout
+        self._clock = clock or (lambda: datetime.now(timezone.utc))
+        self._monotonic = monotonic
+        self._started_at = self._clock()
+        self._started_monotonic = monotonic()
+        self._last_novel = self._started_monotonic
+        self._seen_topics: set[str] = set()
+        self._seen_properties: set[str] = set()
+        self._seen_devices: set[str] = set()
+        self._messages: list[CloudMqttMessage] = []
+        self._connection_events: list[dict[str, Any]] = []
+        self._last_state: ConnectionState | None = None
+        self._expected_devices = tuple(
+            sorted(
+                item.candidate.candidate_id
+                for item in bootstrap.devices
+                if item.candidate.identity.device_id is not None
+            )
+        )
+
+    def observe_connection(self, state: ConnectionState) -> None:
+        if state == self._last_state:
+            return
+        self._last_state = state
+        self._connection_events.append(
+            {"timestamp": _iso(self._clock()), "state": state.value}
+        )
+
+    def observe_message(self, message: CloudMqttMessage) -> None:
+        """Record every message; only novel structure extends the quiet phase."""
+
+        self._messages.append(message)
+        novel = message.topic not in self._seen_topics
+        self._seen_topics.add(message.topic)
+        properties = _property_paths(message.parsed_payload)
+        if properties - self._seen_properties:
+            novel = True
+        self._seen_properties.update(properties)
+        if message.device_candidate_id is not None:
+            self._seen_devices.add(message.device_candidate_id)
+        if novel:
+            self._last_novel = self._monotonic()
+
+    def completion(self) -> tuple[bool, str] | None:
+        now = self._monotonic()
+        if now - self._started_monotonic >= self._hard_timeout:
+            return False, "hard_timeout"
+        all_devices_seen = bool(self._expected_devices) and set(
+            self._expected_devices
+        ).issubset(self._seen_devices)
+        if all_devices_seen and now - self._last_novel >= self._quiet_period:
+            return True, "initial_sync_quiet"
+        return None
+
+    def finish(
+        self,
+        *,
+        complete: bool,
+        reason: str,
+    ) -> InitialSyncCaptureResult:
+        return InitialSyncCaptureResult(
+            started_at=self._started_at,
+            finished_at=self._clock(),
+            complete=complete,
+            completion_reason=reason,
+            discovery=self._bootstrap.raw_device_list,
+            connection_events=tuple(self._connection_events),
+            messages=tuple(self._messages),
+            expected_devices=self._expected_devices,
+        )
+
+
+async def async_capture_initial_sync(
+    bootstrap: ZendureCloudBootstrap,
+    transport: ZendureCloudMqttTransport,
+    *,
+    quiet_period: float = DEFAULT_QUIET_PERIOD,
+    hard_timeout: float = DEFAULT_HARD_TIMEOUT,
+    poll_interval: float = 0.1,
+    clock: Callable[[], datetime] | None = None,
+    monotonic: Callable[[], float] = time.monotonic,
+) -> InitialSyncCaptureResult:
+    """Capture discovery and MQTT startup until structural traffic is quiet."""
+
+    recorder = ZendureInitialSyncRecorder(
+        bootstrap,
+        quiet_period=quiet_period,
+        hard_timeout=hard_timeout,
+        clock=clock,
+        monotonic=monotonic,
+    )
+    cursor = 0
+    recorder.observe_connection(transport.state)
+    try:
+        await transport.async_start(timeout=min(15.0, hard_timeout))
+    except Exception as error:
+        recorder.observe_connection(transport.state)
+        return recorder.finish(
+            complete=False,
+            reason=_safe_failure_reason(error),
+        )
+
+    while True:
+        recorder.observe_connection(transport.state)
+        messages = transport.messages
+        for message in messages[cursor:]:
+            recorder.observe_message(message)
+        cursor = len(messages)
+        completed = recorder.completion()
+        if completed is not None:
+            complete, reason = completed
+            return recorder.finish(complete=complete, reason=reason)
+        await asyncio.sleep(poll_interval)
+
+
+def export_initial_sync_capture(
+    capture: InitialSyncCaptureResult,
+    *,
+    config_directory: str | Path,
+    max_export_bytes: int = DEFAULT_MAX_EXPORT_BYTES,
+) -> InitialSyncExportResult:
+    """Atomically export only the already sanitized JSON representation."""
+
+    try:
+        payload = (
+            json.dumps(
+                capture.as_dict(),
+                ensure_ascii=False,
+                separators=(",", ":"),
+                allow_nan=False,
+            )
+            + "\n"
+        ).encode("utf-8")
+    except (TypeError, ValueError) as error:
+        raise InitialSyncExportError("capture_serialization_failed") from error
+    if not 0 < len(payload) <= max_export_bytes:
+        raise InitialSyncExportError("capture_size_limit_exceeded")
+
+    directory = Path(config_directory).resolve() / INITIAL_SYNC_DIRECTORY
+    temporary: Path | None = None
+    try:
+        directory.mkdir(parents=True, exist_ok=True)
+        destination = _available_destination(directory, capture.finished_at)
+        descriptor, name = tempfile.mkstemp(
+            prefix=".zendure_initial_sync_", suffix=".tmp", dir=directory
+        )
+        temporary = Path(name)
+        with os.fdopen(descriptor, "wb") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, destination)
+        temporary = None
+    except OSError as error:
+        raise InitialSyncExportError("capture_write_failed") from error
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+    return InitialSyncExportResult(destination, len(payload))
+
+
+def _raw_message(message: CloudMqttMessage) -> dict[str, Any]:
+    if message.payload_format == "binary":
+        payload: Any = {"base64": b64encode(message.payload).decode("ascii")}
+    else:
+        payload = message.parsed_payload
+    return {
+        "timestamp": _iso(message.received_at),
+        "transport": "cloud_mqtt",
+        "device_id": message.device_candidate_id,
+        "pack_id": message.pack_id,
+        "topic": message.topic,
+        "payload_format": message.payload_format,
+        "payload": payload,
+        "known_topic": message.known_topic,
+        "session": message.session_number,
+    }
+
+
+def _build_summary(
+    discovery: tuple[Mapping[str, Any], ...],
+    messages: tuple[CloudMqttMessage, ...],
+    expected_devices: tuple[str, ...],
+) -> dict[str, Any]:
+    topics: dict[str, dict[str, Any]] = {}
+    properties: dict[str, dict[str, Any]] = {}
+    seen_devices: set[str] = set()
+    packs: set[str] = set()
+    for message in messages:
+        if message.device_candidate_id:
+            seen_devices.add(message.device_candidate_id)
+        if message.pack_id:
+            packs.add(message.pack_id)
+        topic = topics.setdefault(
+            message.topic,
+            {"updates": 0, "first_seen": _iso(message.received_at), "last_seen": None},
+        )
+        topic["updates"] += 1
+        topic["last_seen"] = _iso(message.received_at)
+        for path, value in _property_items(message.parsed_payload):
+            entry = properties.setdefault(
+                path,
+                {
+                    "types": [],
+                    "example": value,
+                    "updates": 0,
+                    "first_seen": _iso(message.received_at),
+                    "last_seen": None,
+                    "mapping_status": "unmapped",
+                },
+            )
+            value_type = _type_name(value)
+            if value_type not in entry["types"]:
+                entry["types"].append(value_type)
+            entry["updates"] += 1
+            entry["last_seen"] = _iso(message.received_at)
+    return {
+        "device_count": len(expected_devices),
+        "devices_with_messages": sorted(seen_devices),
+        "devices_without_messages": sorted(set(expected_devices) - seen_devices),
+        "pack_ids": sorted(packs),
+        "models": sorted(
+            {
+                str(item.get("productModel"))
+                for item in discovery
+                if item.get("productModel") is not None
+            }
+        ),
+        "topics": topics,
+        "properties": properties,
+    }
+
+
+def _property_items(value: Any, prefix: str = "") -> list[tuple[str, Any]]:
+    if not isinstance(value, Mapping):
+        return []
+    root = value.get("properties") if not prefix else value
+    if not isinstance(root, Mapping):
+        return []
+    result: list[tuple[str, Any]] = []
+    for key, item in root.items():
+        path = f"{prefix}.{key}" if prefix else str(key)
+        result.append((path, item))
+        if isinstance(item, Mapping):
+            result.extend(_property_items(item, path))
+    return result
+
+
+def _property_paths(value: Any) -> set[str]:
+    return {path for path, _value in _property_items(value)}
+
+
+def _type_name(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, int):
+        return "integer"
+    if isinstance(value, float):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, list):
+        return "array"
+    if isinstance(value, Mapping):
+        return "object"
+    return type(value).__name__
+
+
+def _iso(value: datetime) -> str:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValueError("capture timestamps must be timezone-aware")
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _available_destination(directory: Path, timestamp: datetime) -> Path:
+    stamp = timestamp.astimezone(timezone.utc).strftime("%Y-%m-%d_%H-%M-%S")
+    stem = f"zendure_initial_sync_{stamp}"
+    for suffix in range(10_000):
+        marker = "" if suffix == 0 else f"_{suffix}"
+        candidate = directory / f"{stem}{marker}.json"
+        if not candidate.exists():
+            return candidate
+    raise InitialSyncExportError("capture_filename_unavailable")
+
+
+def _safe_failure_reason(error: Exception) -> str:
+    reason = getattr(error, "reason", None)
+    allowed = {
+        "cannot_connect",
+        "connection_timeout",
+        "invalid_broker_url",
+        "mqtt_dependency_missing",
+        "no_routable_devices",
+        "subscribe_failed",
+    }
+    return str(reason) if reason in allowed else "mqtt_connect_failed"

--- a/custom_components/battery_smartflow_ai/zendure_privacy.py
+++ b/custom_components/battery_smartflow_ai/zendure_privacy.py
@@ -63,6 +63,7 @@ _IDENTITY_CONTAINERS = {
     "packs": "PACK",
     "packmap": "PACK",
 }
+_PERSONAL_KEYS = {"devicename"}
 _AUTHORIZATION_PATTERN = re.compile(
     r"(?i)\bauthorization(\s*[:=]\s*)(?:(bearer|basic)\s+)?[^\s,;&]+"
 )
@@ -97,6 +98,10 @@ def _is_network_key(key: Any) -> bool:
     return normalized in {"host", "ip", "server", "url"} or any(
         marker in normalized for marker in _NETWORK_MARKERS
     )
+
+
+def _is_personal_key(key: Any) -> bool:
+    return _normalized_key(key) in _PERSONAL_KEYS
 
 
 def _iso_utc(value: datetime) -> str:
@@ -185,7 +190,11 @@ class ZendureDiagnosticSanitizer:
             result: dict[str, Any] = {}
             for key, item in value.items():
                 safe_key = self._sanitize_mapping_key(str(key))
-                if _is_secret_key(key) or _is_network_key(key):
+                if (
+                    _is_secret_key(key)
+                    or _is_network_key(key)
+                    or _is_personal_key(key)
+                ):
                     result[safe_key] = REDACTED
                     continue
                 kind = _identity_kind(key)

--- a/tests/test_zendure_initial_sync.py
+++ b/tests/test_zendure_initial_sync.py
@@ -1,0 +1,386 @@
+"""Privacy-safe Zendure initial-sync capture tests."""
+
+from __future__ import annotations
+
+from base64 import b64encode
+from datetime import datetime, timedelta, timezone
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+from support import bootstrap
+
+
+bootstrap()
+
+from custom_components.battery_smartflow_ai.zendure_cloud import (  # noqa: E402
+    ZendureCloudClient,
+)
+from custom_components.battery_smartflow_ai.zendure_cloud_mqtt import (  # noqa: E402
+    CloudMqttMessage,
+    ConnectionState,
+)
+from custom_components.battery_smartflow_ai.zendure_initial_sync import (  # noqa: E402
+    InitialSyncExportError,
+    ZendureInitialSyncRecorder,
+    async_capture_initial_sync,
+    export_initial_sync_capture,
+)
+
+
+class Response:
+    def __init__(self, data):
+        self.data = data
+
+    async def json(self):
+        return self.data
+
+
+async def make_bootstrap():
+    token = b64encode(b"https://api.example.com.app-key-secret").decode()
+
+    async def post(*_args, **_kwargs):
+        return Response(
+            {
+                "code": 200,
+                "success": True,
+                "data": {
+                    "deviceList": [
+                        {
+                            "deviceKey": "real-device-1",
+                            "snNumber": "real-serial-1",
+                            "productKey": "product-a",
+                            "productModel": "SolarFlow2400AC",
+                            "deviceName": "Garage battery",
+                            "firmwareVersion": "2.3.4",
+                            "packData": [
+                                {
+                                    "packId": "real-pack-1",
+                                    "snNumber": "real-pack-serial-1",
+                                }
+                            ],
+                        },
+                        {
+                            "deviceKey": "real-device-2",
+                            "productKey": "product-b",
+                            "productModel": "FutureModel",
+                            "deviceName": "Second battery",
+                        },
+                    ],
+                    "mqtt": {
+                        "clientId": "mqtt-client-secret",
+                        "url": "mqtts://broker.secret:8883",
+                        "username": "mqtt-user-secret",
+                        "password": "mqtt-password-secret",
+                    },
+                },
+            }
+        )
+
+    return await ZendureCloudClient(post).async_discover(token)
+
+
+def message(
+    at: datetime,
+    device: str,
+    topic_device: str,
+    payload,
+    *,
+    pack: str | None = None,
+    payload_format: str = "json",
+    raw: bytes | None = None,
+):
+    return CloudMqttMessage(
+        received_at=at,
+        topic=f"/product-a/{topic_device}/properties/report",
+        payload=raw if raw is not None else json.dumps(payload).encode(),
+        parsed_payload=payload,
+        payload_format=payload_format,
+        device_candidate_id=device,
+        pack_id=pack,
+        known_topic=True,
+        session_number=1,
+    )
+
+
+class MutableTime:
+    def __init__(self):
+        self.elapsed = 0.0
+        self.wall = datetime(2026, 9, 2, 14, 0, tzinfo=timezone.utc)
+
+    def monotonic(self):
+        return self.elapsed
+
+    def clock(self):
+        return self.wall + timedelta(seconds=self.elapsed)
+
+    def advance(self, seconds):
+        self.elapsed += seconds
+
+
+class InitialSyncCaptureTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.bootstrap = await make_bootstrap()
+        self.time = MutableTime()
+
+    def recorder(self, **kwargs):
+        return ZendureInitialSyncRecorder(
+            self.bootstrap,
+            quiet_period=2.0,
+            hard_timeout=10.0,
+            clock=self.time.clock,
+            monotonic=self.time.monotonic,
+            **kwargs,
+        )
+
+    async def test_discovery_raw_response_is_retained_inside_transport_boundary(self):
+        self.assertEqual(len(self.bootstrap.raw_device_list), 2)
+        self.assertEqual(
+            self.bootstrap.raw_device_list[0]["firmwareVersion"], "2.3.4"
+        )
+        self.assertNotIn("mqtt-password-secret", repr(self.bootstrap))
+
+    async def test_quiet_completion_requires_every_main_device(self):
+        recorder = self.recorder()
+        recorder.observe_message(
+            message(
+                self.time.clock(),
+                "cloud_mqtt:real-device-1",
+                "real-device-1",
+                {"properties": {"socLevel": 60}},
+            )
+        )
+        self.time.advance(3)
+        self.assertIsNone(recorder.completion())
+        recorder.observe_message(
+            message(
+                self.time.clock(),
+                "cloud_mqtt:real-device-2",
+                "real-device-2",
+                {"properties": {"electricLevel": 44}},
+            )
+        )
+        self.time.advance(2.1)
+        self.assertEqual(recorder.completion(), (True, "initial_sync_quiet"))
+
+    async def test_only_novel_topics_or_properties_extend_quiet_period(self):
+        recorder = self.recorder()
+        first = message(
+            self.time.clock(),
+            "cloud_mqtt:real-device-1",
+            "real-device-1",
+            {"properties": {"socLevel": 60}},
+        )
+        recorder.observe_message(first)
+        self.time.advance(1.5)
+        recorder.observe_message(
+            message(
+                self.time.clock(),
+                "cloud_mqtt:real-device-1",
+                "real-device-1",
+                {"properties": {"socLevel": 61}},
+            )
+        )
+        self.time.advance(0.6)
+        recorder.observe_message(
+            message(
+                self.time.clock(),
+                "cloud_mqtt:real-device-2",
+                "real-device-2",
+                {"properties": {"electricLevel": 40}},
+            )
+        )
+        self.time.advance(2.1)
+        self.assertEqual(recorder.completion(), (True, "initial_sync_quiet"))
+
+    async def test_timeout_produces_useful_incomplete_capture(self):
+        recorder = self.recorder()
+        recorder.observe_connection(ConnectionState.CONNECTED)
+        recorder.observe_message(
+            message(
+                self.time.clock(),
+                "cloud_mqtt:real-device-1",
+                "real-device-1",
+                {"properties": {"socLevel": 60}},
+            )
+        )
+        self.time.advance(10)
+        complete, reason = recorder.completion()
+        result = recorder.finish(complete=complete, reason=reason)
+        self.assertFalse(result.complete)
+        self.assertEqual(result.completion_reason, "hard_timeout")
+        self.assertEqual(len(result.messages), 1)
+
+    async def test_export_has_raw_and_summary_with_complete_nested_properties(self):
+        recorder = self.recorder()
+        recorder.observe_connection(ConnectionState.CONNECTED)
+        recorder.observe_message(
+            message(
+                self.time.clock(),
+                "cloud_mqtt:real-device-1",
+                "real-device-1",
+                {
+                    "deviceKey": "real-device-1",
+                    "properties": {
+                        "socLevel": 60,
+                        "packData": {
+                            "packId": "real-pack-1",
+                            "cell": {"voltage": 3.42},
+                        },
+                        "futureUnknown": [1, 2, 3],
+                    },
+                },
+                pack="real-pack-1",
+            )
+        )
+        result = recorder.finish(complete=True, reason="initial_sync_quiet")
+        data = result.as_dict()
+        self.assertIn("raw_communication", data)
+        self.assertIn("bsfai_interpretation", data)
+        properties = data["bsfai_interpretation"]["properties"]
+        self.assertIn("socLevel", properties)
+        self.assertIn("packData.cell.voltage", properties)
+        self.assertIn("futureUnknown", properties)
+        self.assertEqual(properties["futureUnknown"]["types"], ["array"])
+
+    async def test_all_secrets_and_identities_are_consistently_sanitized(self):
+        recorder = self.recorder()
+        recorder.observe_message(
+            message(
+                self.time.clock(),
+                "cloud_mqtt:real-device-1",
+                "real-device-1",
+                {
+                    "deviceKey": "real-device-1",
+                    "packId": "real-pack-1",
+                    "properties": {
+                        "password": "payload-secret",
+                        "token": "payload-token",
+                    },
+                },
+                pack="real-pack-1",
+            )
+        )
+        text = json.dumps(
+            recorder.finish(complete=True, reason="test").as_dict()
+        )
+        for secret in (
+            "real-device-1",
+            "real-device-2",
+            "real-serial-1",
+            "real-pack-1",
+            "payload-secret",
+            "payload-token",
+            "mqtt-password-secret",
+            "Garage battery",
+            "Second battery",
+        ):
+            self.assertNotIn(secret, text)
+        self.assertIn("ZD_DEVICE_A1", text)
+        self.assertIn("ZD_PACK_A1", text)
+
+    async def test_binary_and_invalid_json_are_preserved(self):
+        recorder = self.recorder()
+        recorder.observe_message(
+            message(
+                self.time.clock(),
+                "cloud_mqtt:real-device-1",
+                "real-device-1",
+                b"\xff\x00",
+                payload_format="binary",
+                raw=b"\xff\x00",
+            )
+        )
+        raw = recorder.finish(complete=False, reason="test").as_dict()[
+            "raw_communication"
+        ]["mqtt_messages"][0]
+        self.assertEqual(raw["payload"], {"base64": "/wA="})
+
+    async def test_atomic_export_creates_shareable_json(self):
+        recorder = self.recorder()
+        result = recorder.finish(complete=False, reason="hard_timeout")
+        with tempfile.TemporaryDirectory() as directory:
+            exported = export_initial_sync_capture(
+                result, config_directory=directory
+            )
+            self.assertTrue(exported.path.is_file())
+            self.assertEqual(exported.path.parent, Path(directory) / "bsfai" / "debug")
+            data = json.loads(exported.path.read_text(encoding="utf-8"))
+            self.assertEqual(
+                data["meta"]["schema"],
+                "battery_smartflow_ai.zendure_initial_sync",
+            )
+            self.assertFalse(data["meta"]["complete"])
+            self.assertFalse(list(exported.path.parent.glob("*.tmp")))
+
+    async def test_export_size_limit_is_enforced(self):
+        result = self.recorder().finish(complete=False, reason="test")
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(
+                InitialSyncExportError, "capture_size_limit_exceeded"
+            ):
+                export_initial_sync_capture(
+                    result,
+                    config_directory=directory,
+                    max_export_bytes=1,
+                )
+
+    async def test_orchestrator_returns_partial_result_on_connection_failure(self):
+        class FailedTransport:
+            state = ConnectionState.DISCONNECTED
+            messages = ()
+
+            async def async_start(self, *, timeout):
+                raise RuntimeError("mqtt-user-secret")
+
+        result = await async_capture_initial_sync(
+            self.bootstrap,
+            FailedTransport(),
+            quiet_period=0.01,
+            hard_timeout=0.1,
+        )
+        self.assertFalse(result.complete)
+        self.assertEqual(result.completion_reason, "mqtt_connect_failed")
+        self.assertNotIn("mqtt-user-secret", json.dumps(result.as_dict()))
+
+    async def test_orchestrator_completes_after_real_quiet_period(self):
+        messages = (
+            message(
+                self.time.clock(),
+                "cloud_mqtt:real-device-1",
+                "real-device-1",
+                {"properties": {"socLevel": 60}},
+            ),
+            message(
+                self.time.clock(),
+                "cloud_mqtt:real-device-2",
+                "real-device-2",
+                {"properties": {"socLevel": 50}},
+            ),
+        )
+
+        class ConnectedTransport:
+            state = ConnectionState.DISCONNECTED
+
+            async def async_start(self, *, timeout):
+                self.state = ConnectionState.CONNECTED
+
+            @property
+            def messages(self):
+                return messages
+
+        result = await async_capture_initial_sync(
+            self.bootstrap,
+            ConnectedTransport(),
+            quiet_period=0.01,
+            hard_timeout=0.2,
+            poll_interval=0.002,
+        )
+        self.assertTrue(result.complete)
+        self.assertEqual(result.completion_reason, "initial_sync_quiet")
+        self.assertEqual(len(result.messages), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_zendure_privacy.py
+++ b/tests/test_zendure_privacy.py
@@ -207,6 +207,14 @@ class ZendurePrivacyTests(unittest.TestCase):
         self.assertEqual(first["deviceKey"], "ZD_DEVICE_A1")
         self.assertEqual(second["deviceKey"], "ZD_DEVICE_A1")
 
+    def test_user_defined_device_name_is_not_exported(self) -> None:
+        result = ZendureDiagnosticSanitizer().sanitize(
+            {"deviceName": "Thomas Garage Battery", "productModel": "SF2400AC"}
+        )
+
+        self.assertEqual(result["deviceName"], REDACTED)
+        self.assertEqual(result["productModel"], "SF2400AC")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- retain a detached copy of the complete deviceList response inside the native transport boundary
- capture discovery, connection states and all initial Cloud MQTT traffic in chronological order
- finish automatically after every discovered main device has reported and no new topic/property appears during the quiet period
- preserve a bounded hard-timeout result as an explicitly incomplete but still useful capture
- export raw communication and a compact BSFAI topic/property/type summary in one atomic JSON package
- pseudonymize device, serial, product and pack identities consistently across discovery, topics, payloads and summaries
- remove credentials, network endpoints and user-defined Zendure device names at the export boundary
- preserve unknown/nested properties plus text and base64-encoded binary payloads

## Safety boundary
The capture consumes only the subscriber data introduced in #323. It sends no native command and exposes no MQTT publish path.

## Validation
- 399 unit tests passed
- 11 dedicated initial-sync capture tests passed
- Python compilation passed
- git diff --check passed

Closes #324