### PR TITLE
V5: Normalize native Zendure device and pack states

### DIFF
--- a/custom_components/battery_smartflow_ai/core/models/__init__.py
+++ b/custom_components/battery_smartflow_ai/core/models/__init__.py
@@ -24,6 +24,12 @@ from .market import (
     MarketPricePoint,
     MarketPriceValidity,
 )
+from .native_device_state import (
+    DeviceOperatingMode,
+    NeutralDeviceState,
+    NeutralPackState,
+    ReportedDeviceSetpoints,
+)
 from .regulation import (
     AutomaticStrategyResult,
     ChargeSourceAllocation,
@@ -68,6 +74,7 @@ __all__ = [
     "DeviceControlState",
     "DeviceInventory",
     "DeviceProfile",
+    "DeviceOperatingMode",
     "DeviceCommand",
     "DecisionContext",
     "GridHistoryState",
@@ -82,10 +89,13 @@ __all__ = [
     "MainDevice",
     "ModeArbiterResult",
     "NativeDeviceIdentity",
+    "NeutralDeviceState",
+    "NeutralPackState",
     "OffGridState",
     "PVState",
     "PowerControllerResult",
     "RegulationRuntimeState",
+    "ReportedDeviceSetpoints",
     "RuntimeSnapshot",
     "StrategicState",
     "StrategyContext",

--- a/custom_components/battery_smartflow_ai/core/models/native_device_state.py
+++ b/custom_components/battery_smartflow_ai/core/models/native_device_state.py
@@ -1,0 +1,79 @@
+"""Transport-neutral native device and battery-pack runtime states."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+
+from .inventory import ZendureTransport
+from .states import MeasuredValue
+
+
+class DeviceOperatingMode(StrEnum):
+    """Observed physical direction, independent of a vendor mode number."""
+
+    IDLE = "idle"
+    CHARGE = "charge"
+    DISCHARGE = "discharge"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True, slots=True)
+class ReportedDeviceSetpoints:
+    """Mutable device settings reported at runtime, never hardware maxima."""
+
+    input_limit_w: MeasuredValue[float]
+    output_limit_w: MeasuredValue[float]
+    configured_charge_limit_w: MeasuredValue[float]
+    configured_discharge_limit_w: MeasuredValue[float]
+    min_soc_pct: MeasuredValue[float]
+    max_soc_pct: MeasuredValue[float]
+
+
+@dataclass(frozen=True, slots=True)
+class NeutralPackState:
+    """Observed battery pack below one main system; never independently controlled."""
+
+    pack_id: str
+    parent_system_id: str
+    pack_type: MeasuredValue[str]
+    firmware: MeasuredValue[str]
+    soc_pct: MeasuredValue[float]
+    charge_power_w: MeasuredValue[float]
+    discharge_power_w: MeasuredValue[float]
+    voltage_v: MeasuredValue[float]
+    current_a: MeasuredValue[float]
+    cell_min_v: MeasuredValue[float]
+    cell_max_v: MeasuredValue[float]
+    temperature_c: MeasuredValue[float]
+    state_code: MeasuredValue[int]
+    fault_code: MeasuredValue[int]
+    protection_active: MeasuredValue[bool]
+    last_message_at: datetime | None
+
+
+@dataclass(frozen=True, slots=True)
+class NeutralDeviceState:
+    """One main system snapshot consumable without Zendure property knowledge."""
+
+    system_id: str
+    observed_transport: ZendureTransport
+    model: str | None
+    firmware: MeasuredValue[str]
+    online: MeasuredValue[bool]
+    soc_pct: MeasuredValue[float]
+    charge_power_w: MeasuredValue[float]
+    discharge_power_w: MeasuredValue[float]
+    ac_input_power_w: MeasuredValue[float]
+    ac_output_power_w: MeasuredValue[float]
+    pv_power_w: MeasuredValue[float]
+    mode: MeasuredValue[DeviceOperatingMode]
+    setpoints: ReportedDeviceSetpoints
+    hems_active: MeasuredValue[bool]
+    fault_code: MeasuredValue[int]
+    protection_active: MeasuredValue[bool]
+    temperature_c: MeasuredValue[float]
+    battery_voltage_v: MeasuredValue[float]
+    last_message_at: datetime | None
+    packs: tuple[NeutralPackState, ...]

--- a/custom_components/battery_smartflow_ai/core/models/states.py
+++ b/custom_components/battery_smartflow_ai/core/models/states.py
@@ -27,6 +27,9 @@ class ValueValidity(StrEnum):
     UNAVAILABLE = "unavailable"
     STALE = "stale"
     INVALID = "invalid"
+    UNSUPPORTED = "unsupported"
+    OFFLINE = "offline"
+    NEVER_RECEIVED = "never_received"
 
 
 @dataclass(frozen=True, slots=True)

--- a/custom_components/battery_smartflow_ai/zendure_initial_sync.py
+++ b/custom_components/battery_smartflow_ai/zendure_initial_sync.py
@@ -296,7 +296,9 @@ def _build_summary(
         )
         topic["updates"] += 1
         topic["last_seen"] = _iso(message.received_at)
-        for path, value in _property_items(message.parsed_payload):
+        for path, value, mapping_status in _summary_property_items(
+            message.parsed_payload
+        ):
             entry = properties.setdefault(
                 path,
                 {
@@ -305,7 +307,7 @@ def _build_summary(
                     "updates": 0,
                     "first_seen": _iso(message.received_at),
                     "last_seen": None,
-                    "mapping_status": "unmapped",
+                    "mapping_status": mapping_status,
                 },
             )
             value_type = _type_name(value)
@@ -347,6 +349,39 @@ def _property_items(value: Any, prefix: str = "") -> list[tuple[str, Any]]:
 
 def _property_paths(value: Any) -> set[str]:
     return {path for path, _value in _property_items(value)}
+
+
+def _summary_property_items(value: Any) -> list[tuple[str, Any, str]]:
+    """Expose mapper coverage without dropping unknown main or pack fields."""
+
+    from .zendure_normalizer import (  # avoid coupling the raw recorder at import
+        MAIN_PROPERTY_MAPPINGS,
+        PACK_PROPERTY_MAPPINGS,
+    )
+
+    result = [
+        (
+            path,
+            item,
+            "mapped" if path.split(".", 1)[0] in MAIN_PROPERTY_MAPPINGS else "unmapped",
+        )
+        for path, item in _property_items(value)
+    ]
+    if not isinstance(value, Mapping):
+        return result
+    packs = value.get("packData")
+    if not isinstance(packs, list):
+        return result
+    for pack in packs:
+        if not isinstance(pack, Mapping):
+            continue
+        for raw_name, item in pack.items():
+            if raw_name in {"sn", "packId", "packKey"}:
+                continue
+            path = f"packData[].{raw_name}"
+            mapped = raw_name in PACK_PROPERTY_MAPPINGS or raw_name == "power"
+            result.append((path, item, "mapped" if mapped else "unmapped"))
+    return result
 
 
 def _type_name(value: Any) -> str:

--- a/custom_components/battery_smartflow_ai/zendure_normalizer.py
+++ b/custom_components/battery_smartflow_ai/zendure_normalizer.py
@@ -1,0 +1,572 @@
+"""Map verified Zendure reports into transport-neutral V5 runtime states."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import StrEnum
+import math
+from typing import Any, Callable, Mapping
+
+from .core.models import (
+    DeviceOperatingMode,
+    MeasuredValue,
+    NeutralDeviceState,
+    NeutralPackState,
+    ReportedDeviceSetpoints,
+    ValueValidity,
+    ZendureTransport,
+)
+from .zendure_cloud import ZendureCloudBootstrap
+from .zendure_cloud_mqtt import CloudMqttMessage
+
+
+DEFAULT_STALE_AFTER_SECONDS = 30.0
+
+
+class MappingScope(StrEnum):
+    MAIN = "main"
+    PACK = "pack"
+
+
+@dataclass(frozen=True, slots=True)
+class PropertyMapping:
+    """Auditable raw-to-neutral conversion contract."""
+
+    raw_name: str
+    target: str
+    scope: MappingScope
+    raw_types: tuple[type, ...]
+    raw_unit: str | None
+    target_unit: str | None
+    scale: float = 1.0
+    sign: str = "positive_magnitude"
+    minimum: float | None = None
+    maximum: float | None = None
+    converter: Callable[[Any], Any] | None = None
+
+
+def _mode(value: Any) -> DeviceOperatingMode:
+    return {
+        0: DeviceOperatingMode.IDLE,
+        1: DeviceOperatingMode.CHARGE,
+        2: DeviceOperatingMode.DISCHARGE,
+    }.get(value, DeviceOperatingMode.UNKNOWN)
+
+
+def _binary(value: Any) -> bool:
+    if value in (0, False):
+        return False
+    if value in (1, True):
+        return True
+    raise ValueError("not_binary")
+
+
+def _kelvin_tenths_to_celsius(value: Any) -> float:
+    return round(float(value) / 10.0 - 273.15, 2)
+
+
+def _signed_16_tenths(value: Any) -> float:
+    number = int(value)
+    if number > 32767:
+        number -= 65536
+    return number / 10.0
+
+
+def _mapping(
+    raw_name: str,
+    target: str,
+    scope: MappingScope,
+    raw_types: tuple[type, ...],
+    raw_unit: str | None = None,
+    target_unit: str | None = None,
+    **kwargs: Any,
+) -> PropertyMapping:
+    return PropertyMapping(
+        raw_name,
+        target,
+        scope,
+        raw_types,
+        raw_unit,
+        target_unit,
+        **kwargs,
+    )
+
+
+MAIN_PROPERTY_MAPPINGS = {
+    item.raw_name: item
+    for item in (
+        _mapping(
+            "electricLevel", "soc_pct", MappingScope.MAIN,
+            (int, float), "%", "%", minimum=0, maximum=100,
+        ),
+        _mapping(
+            "outputPackPower", "charge_power_w", MappingScope.MAIN,
+            (int, float), "W", "W", minimum=0,
+        ),
+        _mapping(
+            "packInputPower", "discharge_power_w", MappingScope.MAIN,
+            (int, float), "W", "W", minimum=0,
+        ),
+        _mapping(
+            "gridInputPower", "ac_input_power_w", MappingScope.MAIN,
+            (int, float), "W", "W", minimum=0,
+        ),
+        _mapping(
+            "outputHomePower", "ac_output_power_w", MappingScope.MAIN,
+            (int, float), "W", "W", minimum=0,
+        ),
+        _mapping(
+            "solarInputPower", "pv_power_w", MappingScope.MAIN,
+            (int, float), "W", "W", minimum=0,
+        ),
+        _mapping("acMode", "mode", MappingScope.MAIN, (int,), converter=_mode),
+        _mapping(
+            "inputLimit", "input_limit_w", MappingScope.MAIN,
+            (int, float), "W", "W", minimum=0,
+        ),
+        _mapping(
+            "outputLimit", "output_limit_w", MappingScope.MAIN,
+            (int, float), "W", "W", minimum=0,
+        ),
+        _mapping(
+            "chargeMaxLimit", "configured_charge_limit_w", MappingScope.MAIN,
+            (int, float), "W", "W", minimum=0,
+        ),
+        _mapping(
+            "inverseMaxPower", "configured_discharge_limit_w",
+            MappingScope.MAIN, (int, float), "W", "W", minimum=0,
+        ),
+        _mapping(
+            "minSoc", "min_soc_pct", MappingScope.MAIN,
+            (int, float), "0.1 %", "%", scale=0.1, minimum=0, maximum=100,
+        ),
+        _mapping(
+            "socSet", "max_soc_pct", MappingScope.MAIN,
+            (int, float), "0.1 %", "%", scale=0.1, minimum=0, maximum=100,
+        ),
+        _mapping(
+            "hemsState", "hems_active", MappingScope.MAIN,
+            (bool, int), converter=_binary,
+        ),
+        _mapping("faultLevel", "fault_code", MappingScope.MAIN, (int,)),
+        _mapping(
+            "heatState", "protection_active", MappingScope.MAIN,
+            (bool, int), converter=_binary,
+        ),
+        _mapping(
+            "hyperTmp", "temperature_c", MappingScope.MAIN,
+            (int, float), "0.1 K", "°C",
+            converter=_kelvin_tenths_to_celsius,
+        ),
+        _mapping(
+            "BatVolt", "battery_voltage_v", MappingScope.MAIN,
+            (int, float), "0.01 V", "V", scale=0.01, minimum=0,
+        ),
+        _mapping(
+            "masterSoftVersion", "firmware", MappingScope.MAIN,
+            (str, int), converter=str,
+        ),
+    )
+}
+
+
+PACK_PROPERTY_MAPPINGS = {
+    item.raw_name: item
+    for item in (
+        _mapping(
+            "packType", "pack_type", MappingScope.PACK,
+            (str, int), converter=str,
+        ),
+        _mapping(
+            "softVersion", "firmware", MappingScope.PACK,
+            (str, int), converter=str,
+        ),
+        _mapping(
+            "socLevel", "soc_pct", MappingScope.PACK,
+            (int, float), "%", "%", minimum=0, maximum=100,
+        ),
+        _mapping(
+            "totalVol", "voltage_v", MappingScope.PACK,
+            (int, float), "0.01 V", "V", scale=0.01, minimum=0,
+        ),
+        _mapping(
+            "batcur", "current_a", MappingScope.PACK,
+            (int,), "0.1 A signed16", "A", sign="signed",
+            converter=_signed_16_tenths,
+        ),
+        _mapping(
+            "minVol", "cell_min_v", MappingScope.PACK,
+            (int, float), "0.01 V", "V", scale=0.01, minimum=0,
+        ),
+        _mapping(
+            "maxVol", "cell_max_v", MappingScope.PACK,
+            (int, float), "0.01 V", "V", scale=0.01, minimum=0,
+        ),
+        _mapping(
+            "maxTemp", "temperature_c", MappingScope.PACK,
+            (int, float), "0.1 K", "°C",
+            converter=_kelvin_tenths_to_celsius,
+        ),
+        _mapping("state", "state_code", MappingScope.PACK, (int,)),
+        _mapping("faultLevel", "fault_code", MappingScope.PACK, (int,)),
+        _mapping(
+            "heatState", "protection_active", MappingScope.PACK,
+            (bool, int), converter=_binary,
+        ),
+    )
+}
+
+
+_DEVICE_TARGETS = frozenset(
+    item.target for item in MAIN_PROPERTY_MAPPINGS.values()
+)
+_PACK_TARGETS = frozenset(
+    item.target for item in PACK_PROPERTY_MAPPINGS.values()
+) | {"charge_power_w", "discharge_power_w"}
+
+
+@dataclass(frozen=True, slots=True)
+class NormalizationResult:
+    state: NeutralDeviceState
+    unknown_main_properties: tuple[str, ...]
+    unknown_pack_properties: tuple[str, ...]
+
+
+@dataclass(slots=True)
+class _Observed:
+    value: Any
+    validity: ValueValidity
+    observed_at: datetime
+
+
+@dataclass(slots=True)
+class _PackAccumulator:
+    values: dict[str, _Observed]
+    last_message_at: datetime | None = None
+
+
+class ZendureCloudNormalizer:
+    """Incrementally normalize Cloud reports without strategy decisions."""
+
+    def __init__(
+        self,
+        bootstrap: ZendureCloudBootstrap,
+        *,
+        stale_after_seconds: float = DEFAULT_STALE_AFTER_SECONDS,
+        supported_device_targets: Mapping[str, frozenset[str]] | None = None,
+        supported_pack_targets: Mapping[str, frozenset[str]] | None = None,
+    ) -> None:
+        if stale_after_seconds <= 0:
+            raise ValueError("stale_after_seconds must be positive")
+        self._stale_after = stale_after_seconds
+        self._models = {
+            item.candidate.candidate_id: item.candidate.identity.product_model
+            for item in bootstrap.devices
+        }
+        self._online = {
+            item.candidate.candidate_id: item.online
+            for item in bootstrap.devices
+        }
+        self._device_values: dict[str, dict[str, _Observed]] = {
+            candidate_id: {} for candidate_id in self._models
+        }
+        self._pack_values: dict[str, dict[str, _PackAccumulator]] = {
+            candidate_id: {} for candidate_id in self._models
+        }
+        self._last_message: dict[str, datetime | None] = {
+            candidate_id: None for candidate_id in self._models
+        }
+        self._unknown_main = {
+            candidate_id: set() for candidate_id in self._models
+        }
+        self._unknown_pack = {
+            candidate_id: set() for candidate_id in self._models
+        }
+        self._supported_device_targets = supported_device_targets or {}
+        self._supported_pack_targets = supported_pack_targets or {}
+
+    def apply(
+        self,
+        message: CloudMqttMessage,
+        *,
+        now: datetime | None = None,
+    ) -> NormalizationResult | None:
+        system_id = message.device_candidate_id
+        if system_id is None or system_id not in self._models:
+            return None
+        observed_at = message.received_at
+        self._last_message[system_id] = observed_at
+        payload = message.parsed_payload
+        if isinstance(payload, Mapping):
+            properties = payload.get("properties")
+            if isinstance(properties, Mapping):
+                self._apply_properties(
+                    self._device_values[system_id],
+                    properties,
+                    MAIN_PROPERTY_MAPPINGS,
+                    self._unknown_main[system_id],
+                    observed_at,
+                )
+            self._apply_packs(system_id, payload.get("packData"), observed_at)
+        if message.topic.endswith("/properties/energy"):
+            self._device_values[system_id]["hems_active"] = _Observed(
+                True, ValueValidity.VALID, observed_at
+            )
+        return self.snapshot(system_id, now=now or observed_at)
+
+    def set_online(self, system_id: str, online: bool) -> None:
+        if system_id not in self._models:
+            raise KeyError(system_id)
+        self._online[system_id] = online
+
+    def snapshot(
+        self,
+        system_id: str,
+        *,
+        now: datetime | None = None,
+    ) -> NormalizationResult:
+        if system_id not in self._models:
+            raise KeyError(system_id)
+        current = now or datetime.now(timezone.utc)
+        online = self._online[system_id]
+        values = self._device_values[system_id]
+        supported = self._supported_device_targets.get(system_id, _DEVICE_TARGETS)
+
+        def device_value(target: str) -> MeasuredValue[Any]:
+            return self._value(values, target, supported, online, current)
+
+        packs = tuple(
+            self._pack_snapshot(system_id, pack_id, accumulator, current, online)
+            for pack_id, accumulator in sorted(
+                self._pack_values[system_id].items()
+            )
+        )
+        state = NeutralDeviceState(
+            system_id=system_id,
+            observed_transport=ZendureTransport.CLOUD_MQTT,
+            model=self._models[system_id],
+            firmware=device_value("firmware"),
+            online=MeasuredValue(
+                value=online,
+                validity=(
+                    ValueValidity.UNKNOWN
+                    if online is None
+                    else ValueValidity.VALID
+                ),
+                observed_at=self._last_message[system_id],
+            ),
+            soc_pct=device_value("soc_pct"),
+            charge_power_w=device_value("charge_power_w"),
+            discharge_power_w=device_value("discharge_power_w"),
+            ac_input_power_w=device_value("ac_input_power_w"),
+            ac_output_power_w=device_value("ac_output_power_w"),
+            pv_power_w=device_value("pv_power_w"),
+            mode=device_value("mode"),
+            setpoints=ReportedDeviceSetpoints(
+                input_limit_w=device_value("input_limit_w"),
+                output_limit_w=device_value("output_limit_w"),
+                configured_charge_limit_w=device_value(
+                    "configured_charge_limit_w"
+                ),
+                configured_discharge_limit_w=device_value(
+                    "configured_discharge_limit_w"
+                ),
+                min_soc_pct=device_value("min_soc_pct"),
+                max_soc_pct=device_value("max_soc_pct"),
+            ),
+            hems_active=device_value("hems_active"),
+            fault_code=device_value("fault_code"),
+            protection_active=device_value("protection_active"),
+            temperature_c=device_value("temperature_c"),
+            battery_voltage_v=device_value("battery_voltage_v"),
+            last_message_at=self._last_message[system_id],
+            packs=packs,
+        )
+        return NormalizationResult(
+            state,
+            tuple(sorted(self._unknown_main[system_id])),
+            tuple(sorted(self._unknown_pack[system_id])),
+        )
+
+    def _apply_properties(
+        self,
+        destination: dict[str, _Observed],
+        properties: Mapping[str, Any],
+        mappings: Mapping[str, PropertyMapping],
+        unknown: set[str],
+        observed_at: datetime,
+    ) -> None:
+        for raw_name, raw_value in properties.items():
+            mapping = mappings.get(str(raw_name))
+            if mapping is None:
+                unknown.add(str(raw_name))
+                continue
+            destination[mapping.target] = _normalize(
+                mapping, raw_value, observed_at
+            )
+
+    def _apply_packs(
+        self,
+        system_id: str,
+        raw_packs: Any,
+        observed_at: datetime,
+    ) -> None:
+        if not isinstance(raw_packs, list):
+            return
+        for raw_pack in raw_packs:
+            if not isinstance(raw_pack, Mapping):
+                continue
+            pack_id = _pack_id(raw_pack)
+            if pack_id is None:
+                self._unknown_pack[system_id].add("pack_without_identity")
+                continue
+            accumulator = self._pack_values[system_id].setdefault(
+                pack_id, _PackAccumulator({})
+            )
+            accumulator.last_message_at = observed_at
+            self._apply_properties(
+                accumulator.values,
+                {
+                    key: value
+                    for key, value in raw_pack.items()
+                    if key not in {"sn", "packId", "packKey", "power"}
+                },
+                PACK_PROPERTY_MAPPINGS,
+                self._unknown_pack[system_id],
+                observed_at,
+            )
+            self._apply_pack_power(accumulator, raw_pack, observed_at)
+
+    def _apply_pack_power(
+        self,
+        accumulator: _PackAccumulator,
+        raw_pack: Mapping[str, Any],
+        observed_at: datetime,
+    ) -> None:
+        power = raw_pack.get("power")
+        state = raw_pack.get("state")
+        if _is_number(power) and state in (0, 1, 2):
+            accumulator.values["charge_power_w"] = _Observed(
+                float(power) if state == 1 else 0.0,
+                ValueValidity.VALID,
+                observed_at,
+            )
+            accumulator.values["discharge_power_w"] = _Observed(
+                float(power) if state == 2 else 0.0,
+                ValueValidity.VALID,
+                observed_at,
+            )
+        elif power is not None:
+            for target in ("charge_power_w", "discharge_power_w"):
+                accumulator.values[target] = _Observed(
+                    None, ValueValidity.INVALID, observed_at
+                )
+
+    def _pack_snapshot(
+        self,
+        system_id: str,
+        pack_id: str,
+        accumulator: _PackAccumulator,
+        now: datetime,
+        online: bool | None,
+    ) -> NeutralPackState:
+        supported = self._supported_pack_targets.get(pack_id, _PACK_TARGETS)
+
+        def value(target: str) -> MeasuredValue[Any]:
+            return self._value(
+                accumulator.values, target, supported, online, now
+            )
+
+        return NeutralPackState(
+            pack_id=pack_id,
+            parent_system_id=system_id,
+            pack_type=value("pack_type"),
+            firmware=value("firmware"),
+            soc_pct=value("soc_pct"),
+            charge_power_w=value("charge_power_w"),
+            discharge_power_w=value("discharge_power_w"),
+            voltage_v=value("voltage_v"),
+            current_a=value("current_a"),
+            cell_min_v=value("cell_min_v"),
+            cell_max_v=value("cell_max_v"),
+            temperature_c=value("temperature_c"),
+            state_code=value("state_code"),
+            fault_code=value("fault_code"),
+            protection_active=value("protection_active"),
+            last_message_at=accumulator.last_message_at,
+        )
+
+    def _value(
+        self,
+        values: Mapping[str, _Observed],
+        target: str,
+        supported: frozenset[str],
+        online: bool | None,
+        now: datetime,
+    ) -> MeasuredValue[Any]:
+        if target not in supported:
+            return MeasuredValue.absent(ValueValidity.UNSUPPORTED)
+        observed = values.get(target)
+        if observed is None:
+            validity = (
+                ValueValidity.OFFLINE
+                if online is False
+                else ValueValidity.NEVER_RECEIVED
+            )
+            return MeasuredValue.absent(validity)
+        validity = observed.validity
+        if online is False:
+            validity = ValueValidity.OFFLINE
+        elif (
+            validity is ValueValidity.VALID
+            and (now - observed.observed_at).total_seconds() > self._stale_after
+        ):
+            validity = ValueValidity.STALE
+        return MeasuredValue(observed.value, validity, observed.observed_at)
+
+
+def _normalize(
+    mapping: PropertyMapping,
+    raw_value: Any,
+    observed_at: datetime,
+) -> _Observed:
+    if isinstance(raw_value, bool) and bool not in mapping.raw_types:
+        return _Observed(None, ValueValidity.INVALID, observed_at)
+    if not isinstance(raw_value, mapping.raw_types):
+        return _Observed(None, ValueValidity.INVALID, observed_at)
+    try:
+        if mapping.converter is not None:
+            value = mapping.converter(raw_value)
+        else:
+            value = round(float(raw_value) * mapping.scale, 9)
+            if mapping.raw_types == (int,) and mapping.scale == 1:
+                value = int(raw_value)
+        if isinstance(value, float) and not math.isfinite(value):
+            raise ValueError("non_finite")
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            if mapping.minimum is not None and value < mapping.minimum:
+                raise ValueError("below_range")
+            if mapping.maximum is not None and value > mapping.maximum:
+                raise ValueError("above_range")
+    except (TypeError, ValueError, OverflowError):
+        return _Observed(None, ValueValidity.INVALID, observed_at)
+    return _Observed(value, ValueValidity.VALID, observed_at)
+
+
+def _pack_id(raw_pack: Mapping[str, Any]) -> str | None:
+    for key in ("sn", "packId", "packKey"):
+        value = raw_pack.get(key)
+        if isinstance(value, (str, int)) and not isinstance(value, bool):
+            text = str(value).strip()
+            if text:
+                return text
+    return None
+
+
+def _is_number(value: Any) -> bool:
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(float(value))
+    )

--- a/tests/test_zendure_normalizer.py
+++ b/tests/test_zendure_normalizer.py
@@ -1,0 +1,340 @@
+"""Transport-neutral native Zendure state normalization tests."""
+
+from __future__ import annotations
+
+from base64 import b64encode
+from dataclasses import fields
+from datetime import datetime, timedelta, timezone
+import json
+import unittest
+
+from support import bootstrap
+
+
+bootstrap()
+
+from custom_components.battery_smartflow_ai.core.models import (  # noqa: E402
+    DeviceOperatingMode,
+    NeutralDeviceState,
+    ValueValidity,
+    ZendureTransport,
+)
+from custom_components.battery_smartflow_ai.zendure_cloud import (  # noqa: E402
+    ZendureCloudClient,
+)
+from custom_components.battery_smartflow_ai.zendure_cloud_mqtt import (  # noqa: E402
+    CloudMqttMessage,
+)
+from custom_components.battery_smartflow_ai.zendure_normalizer import (  # noqa: E402
+    MAIN_PROPERTY_MAPPINGS,
+    PACK_PROPERTY_MAPPINGS,
+    MappingScope,
+    ZendureCloudNormalizer,
+)
+from custom_components.battery_smartflow_ai.zendure_initial_sync import (  # noqa: E402
+    ZendureInitialSyncRecorder,
+)
+
+
+class Response:
+    def __init__(self, value):
+        self.value = value
+
+    async def json(self):
+        return self.value
+
+
+async def make_bootstrap():
+    token = b64encode(b"https://api.example.com.app-secret").decode()
+
+    async def post(*_args, **_kwargs):
+        return Response(
+            {
+                "code": 200,
+                "success": True,
+                "data": {
+                    "deviceList": [
+                        {
+                            "deviceKey": "device-1",
+                            "productKey": "product-1",
+                            "productModel": "SolarFlow2400AC",
+                            "deviceName": "Primary",
+                            "online": True,
+                        },
+                        {
+                            "deviceKey": "device-2",
+                            "productKey": "product-2",
+                            "productModel": "SolarFlow800Pro",
+                            "deviceName": "Secondary",
+                            "online": True,
+                        },
+                    ],
+                    "mqtt": {
+                        "clientId": "client-secret",
+                        "url": "mqtts://broker.secret:8883",
+                        "username": "user-secret",
+                        "password": "password-secret",
+                    },
+                },
+            }
+        )
+
+    return await ZendureCloudClient(post).async_discover(token)
+
+
+def report(at, payload, *, device="device-1", topic="properties/report"):
+    raw = json.dumps(payload).encode()
+    return CloudMqttMessage(
+        received_at=at,
+        topic=f"/product-1/{device}/{topic}",
+        payload=raw,
+        parsed_payload=payload,
+        payload_format="json",
+        device_candidate_id=f"cloud_mqtt:{device}",
+        pack_id=None,
+        known_topic=True,
+        session_number=1,
+    )
+
+
+class ZendureNormalizerTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.bootstrap = await make_bootstrap()
+        self.at = datetime(2026, 9, 2, 15, 0, tzinfo=timezone.utc)
+
+    def full_payload(self):
+        return {
+            "properties": {
+                "electricLevel": 55,
+                "outputPackPower": 276,
+                "packInputPower": 0,
+                "gridInputPower": 279,
+                "outputHomePower": 0,
+                "solarInputPower": 620,
+                "acMode": 1,
+                "inputLimit": 279,
+                "outputLimit": 0,
+                "chargeMaxLimit": 2400,
+                "inverseMaxPower": 1800,
+                "minSoc": 100,
+                "socSet": 930,
+                "hemsState": 0,
+                "faultLevel": 0,
+                "heatState": 0,
+                "hyperTmp": 2961,
+                "BatVolt": 4953,
+                "masterSoftVersion": 4106,
+                "futureProperty": {"kept": "only in raw diagnostics"},
+            },
+            "packData": [
+                {
+                    "sn": "pack-a",
+                    "packType": 5,
+                    "socLevel": 54,
+                    "state": 1,
+                    "power": 227,
+                    "maxTemp": 2961,
+                    "totalVol": 4940,
+                    "batcur": 46,
+                    "maxVol": 330,
+                    "minVol": 329,
+                    "softVersion": 4106,
+                    "heatState": 0,
+                    "futurePackProperty": 123,
+                },
+                {
+                    "sn": "pack-b",
+                    "packType": 300,
+                    "socLevel": 56,
+                    "state": 2,
+                    "power": 19,
+                    "maxTemp": 2941,
+                    "totalVol": 4930,
+                    "batcur": 65532,
+                    "maxVol": 329,
+                    "minVol": 328,
+                    "softVersion": 4123,
+                },
+            ],
+        }
+
+    async def test_complete_main_and_mixed_pack_state(self):
+        result = ZendureCloudNormalizer(self.bootstrap).apply(
+            report(self.at, self.full_payload())
+        )
+        self.assertIsNotNone(result)
+        state = result.state
+        self.assertIsInstance(state, NeutralDeviceState)
+        self.assertEqual(state.observed_transport, ZendureTransport.CLOUD_MQTT)
+        self.assertEqual(state.soc_pct.value, 55.0)
+        self.assertEqual(state.charge_power_w.value, 276.0)
+        self.assertEqual(state.discharge_power_w.value, 0.0)
+        self.assertEqual(state.ac_input_power_w.value, 279.0)
+        self.assertEqual(state.ac_output_power_w.value, 0.0)
+        self.assertEqual(state.pv_power_w.value, 620.0)
+        self.assertEqual(state.mode.value, DeviceOperatingMode.CHARGE)
+        self.assertEqual(state.setpoints.input_limit_w.value, 279.0)
+        self.assertEqual(state.setpoints.output_limit_w.value, 0.0)
+        self.assertEqual(state.setpoints.min_soc_pct.value, 10.0)
+        self.assertEqual(state.setpoints.max_soc_pct.value, 93.0)
+        self.assertFalse(state.hems_active.value)
+        self.assertAlmostEqual(state.temperature_c.value, 22.95)
+        self.assertEqual(state.battery_voltage_v.value, 49.53)
+        self.assertEqual(state.firmware.value, "4106")
+        self.assertEqual(len(state.packs), 2)
+        first, second = state.packs
+        self.assertEqual(first.pack_id, "pack-a")
+        self.assertEqual(first.parent_system_id, state.system_id)
+        self.assertEqual(first.charge_power_w.value, 227.0)
+        self.assertEqual(first.discharge_power_w.value, 0.0)
+        self.assertEqual(first.voltage_v.value, 49.4)
+        self.assertEqual(first.current_a.value, 4.6)
+        self.assertEqual(first.cell_min_v.value, 3.29)
+        self.assertEqual(first.cell_max_v.value, 3.3)
+        self.assertEqual(second.charge_power_w.value, 0.0)
+        self.assertEqual(second.discharge_power_w.value, 19.0)
+        self.assertEqual(second.current_a.value, -0.4)
+        self.assertEqual(result.unknown_main_properties, ("futureProperty",))
+        self.assertEqual(
+            result.unknown_pack_properties, ("futurePackProperty",)
+        )
+
+    async def test_incremental_update_preserves_previous_values_and_valid_zero(self):
+        normalizer = ZendureCloudNormalizer(self.bootstrap)
+        normalizer.apply(report(self.at, self.full_payload()))
+        result = normalizer.apply(
+            report(
+                self.at + timedelta(seconds=5),
+                {"properties": {"electricLevel": 0, "inputLimit": 0}},
+            )
+        )
+        self.assertEqual(result.state.soc_pct.value, 0.0)
+        self.assertTrue(result.state.soc_pct.valid)
+        self.assertEqual(result.state.setpoints.input_limit_w.value, 0.0)
+        self.assertEqual(result.state.pv_power_w.value, 620.0)
+        self.assertEqual(
+            result.state.pv_power_w.observed_at,
+            self.at,
+        )
+
+    async def test_missing_invalid_unsupported_stale_and_offline_are_distinct(self):
+        system_id = "cloud_mqtt:device-1"
+        normalizer = ZendureCloudNormalizer(
+            self.bootstrap,
+            stale_after_seconds=10,
+            supported_device_targets={
+                system_id: frozenset({"soc_pct", "pv_power_w"})
+            },
+        )
+        initial = normalizer.snapshot(system_id, now=self.at)
+        self.assertEqual(
+            initial.state.soc_pct.validity,
+            ValueValidity.NEVER_RECEIVED,
+        )
+        self.assertEqual(
+            initial.state.hems_active.validity,
+            ValueValidity.UNSUPPORTED,
+        )
+        invalid = normalizer.apply(
+            report(self.at, {"properties": {"electricLevel": "55"}})
+        )
+        self.assertEqual(invalid.state.soc_pct.validity, ValueValidity.INVALID)
+        normalizer.apply(
+            report(self.at, {"properties": {"electricLevel": 55}})
+        )
+        stale = normalizer.snapshot(
+            system_id, now=self.at + timedelta(seconds=11)
+        )
+        self.assertEqual(stale.state.soc_pct.value, 55.0)
+        self.assertEqual(stale.state.soc_pct.validity, ValueValidity.STALE)
+        normalizer.set_online(system_id, False)
+        offline = normalizer.snapshot(system_id, now=self.at)
+        self.assertEqual(offline.state.soc_pct.value, 55.0)
+        self.assertEqual(offline.state.soc_pct.validity, ValueValidity.OFFLINE)
+        self.assertFalse(offline.state.online.value)
+
+    async def test_out_of_range_and_non_finite_values_are_invalid(self):
+        normalizer = ZendureCloudNormalizer(self.bootstrap)
+        invalid = normalizer.apply(
+            report(
+                self.at,
+                {
+                    "properties": {
+                        "electricLevel": 101,
+                        "solarInputPower": float("inf"),
+                    }
+                },
+            )
+        )
+        self.assertEqual(invalid.state.soc_pct.validity, ValueValidity.INVALID)
+        self.assertEqual(invalid.state.pv_power_w.validity, ValueValidity.INVALID)
+
+    async def test_hems_energy_topic_is_observed_as_blocker_input_only(self):
+        normalizer = ZendureCloudNormalizer(self.bootstrap)
+        result = normalizer.apply(
+            report(self.at, {}, topic="properties/energy")
+        )
+        self.assertTrue(result.state.hems_active.value)
+        self.assertTrue(result.state.hems_active.valid)
+
+    async def test_unknown_device_message_is_not_guessed(self):
+        normalizer = ZendureCloudNormalizer(self.bootstrap)
+        unknown = report(self.at, self.full_payload(), device="not-discovered")
+        self.assertIsNone(normalizer.apply(unknown))
+
+    async def test_mapping_contract_records_units_scale_sign_type_and_scope(self):
+        min_soc = MAIN_PROPERTY_MAPPINGS["minSoc"]
+        current = PACK_PROPERTY_MAPPINGS["batcur"]
+        self.assertEqual(min_soc.target, "min_soc_pct")
+        self.assertEqual(min_soc.scale, 0.1)
+        self.assertEqual(min_soc.scope, MappingScope.MAIN)
+        self.assertEqual(current.raw_types, (int,))
+        self.assertEqual(current.raw_unit, "0.1 A signed16")
+        self.assertEqual(current.target_unit, "A")
+        self.assertEqual(current.sign, "signed")
+
+    async def test_neutral_models_have_no_credentials_or_raw_property_names(self):
+        field_names = {item.name for item in fields(NeutralDeviceState)}
+        forbidden = {
+            "username",
+            "password",
+            "client_id",
+            "broker",
+            "electricLevel",
+            "inputLimit",
+            "outputLimit",
+        }
+        self.assertFalse(field_names & forbidden)
+        state = ZendureCloudNormalizer(self.bootstrap).apply(
+            report(self.at, self.full_payload())
+        ).state
+        representation = repr(state)
+        for secret in (
+            "client-secret",
+            "user-secret",
+            "password-secret",
+            "broker.secret",
+        ):
+            self.assertNotIn(secret, representation)
+
+    async def test_initial_sync_summary_reports_mapper_coverage_for_packs(self):
+        recorder = ZendureInitialSyncRecorder(
+            self.bootstrap,
+            quiet_period=1,
+            hard_timeout=2,
+        )
+        recorder.observe_message(report(self.at, self.full_payload()))
+        summary = recorder.finish(complete=True, reason="test").as_dict()[
+            "bsfai_interpretation"
+        ]["properties"]
+        self.assertEqual(summary["electricLevel"]["mapping_status"], "mapped")
+        self.assertEqual(summary["futureProperty"]["mapping_status"], "unmapped")
+        self.assertEqual(summary["packData[].socLevel"]["mapping_status"], "mapped")
+        self.assertEqual(
+            summary["packData[].futurePackProperty"]["mapping_status"],
+            "unmapped",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add transport-neutral runtime models for native main systems, reported setpoints and subordinate battery packs
- map verified Zendure Cloud properties into neutral SoC, battery flow, AC flow, PV, mode, limits, HEMS, temperature, voltage, fault and protection fields
- keep battery charge/discharge flow separate from AC grid input/output flow
- normalize pack SoC, directional power, voltage, signed current, cell extrema, temperature, firmware and state
- preserve incremental values and explicit observation timestamps
- distinguish valid zero, never received, unsupported, invalid, stale and offline values
- retain unknown properties diagnostically without assigning guessed semantics
- mark known versus unmapped main and pack properties in the initial-sync summary
- keep reported device setpoints separate from profile-owned hardware maxima

## Safety boundary
This is a read-only normalization layer. It contains no strategy decisions, PowerController behavior, credentials, publish path or native device command.

## Validation
- 408 unit tests passed
- 9 dedicated normalizer tests passed
- existing initial-sync tests passed
- Python compilation passed
- git diff --check passed

Closes #325