### PR TITLE
V5: Add native Zendure device capability matrix

### DIFF
--- a/custom_components/battery_smartflow_ai/zendure_cloud.py
+++ b/custom_components/battery_smartflow_ai/zendure_cloud.py
@@ -23,6 +23,7 @@ from .core.models import (
     NativeDeviceIdentity,
     ZendureTransport,
 )
+from .zendure_device_matrix import resolve_zendure_device
 
 
 DEVICE_LIST_PATH = "/api/ha/deviceList"
@@ -30,31 +31,6 @@ CLIENT_ID = "zenHa"
 # Required by Zendure's HA endpoint.  Keep this protocol signing material in
 # the transport adapter; it is not user/account data and must not leave it.
 _SIGNING_KEY = "C*dafwArEOXK"
-
-_KNOWN_PRODUCT_MODELS = frozenset(
-    {
-        "ace1500",
-        "aio2400",
-        "solarflowaiozy",
-        "hub1200",
-        "solarflow2.0",
-        "hub2000",
-        "solarflowhub2000",
-        "hyper2000",
-        "hyper2000_3.0",
-        "solarflow800",
-        "solarflow800pro",
-        "solarflow800pro2",
-        "solarflow800plus",
-        "solarflow1600ac+",
-        "solarflow2400ac",
-        "solarflow2400ac+",
-        "solarflow2400pro",
-        "solarflow4000ac+",
-        "superbasev6400",
-        "superbasev4600",
-    }
-)
 
 
 class ZendureCloudError(Exception):
@@ -295,10 +271,7 @@ def _parse_device(value: Any) -> ZendureCloudDevice:
     candidate = DiscoveryCandidate(
         identity=identity,
         display_name=name,
-        supported=(
-            model is not None
-            and model.casefold().replace(" ", "") in _KNOWN_PRODUCT_MODELS
-        ),
+        supported=resolve_zendure_device(identity) is not None,
         pack_count=pack_count,
     )
     return ZendureCloudDevice(

--- a/custom_components/battery_smartflow_ai/zendure_device_matrix.py
+++ b/custom_components/battery_smartflow_ai/zendure_device_matrix.py
@@ -1,0 +1,302 @@
+"""Single native Zendure model/capability authority for V5."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+import re
+from types import MappingProxyType
+from typing import Mapping
+
+from .core.models import DeviceProfile, NativeDeviceIdentity, ZendureTransport
+from .device_profiles import DEVICE_PROFILE_MODELS
+
+
+class VerificationLevel(StrEnum):
+    """Evidence level; only VERIFIED may later participate in a write gate."""
+
+    VERIFIED = "verified"
+    REFERENCE_ONLY = "reference_only"
+    UNKNOWN = "unknown"
+    UNSUPPORTED = "unsupported"
+
+
+@dataclass(frozen=True, slots=True)
+class TransportCapability:
+    transport: ZendureTransport
+    read: VerificationLevel
+    write: VerificationLevel
+    discovery: VerificationLevel
+    notes: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class CalibrationCapability:
+    raw_status: VerificationLevel
+    next_due_from_device: VerificationLevel
+    notes: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class ZendureDeviceMatrixEntry:
+    """One exact native-model mapping without duplicating profile limits."""
+
+    profile_key: str
+    canonical_model: str
+    model_aliases: frozenset[str]
+    confirmed_product_ids: frozenset[str]
+    transports: Mapping[ZendureTransport, TransportCapability]
+    readable_main_properties: frozenset[str]
+    readable_pack_properties: frozenset[str]
+    writable_main_properties: Mapping[str, VerificationLevel]
+    neutral_device_targets: frozenset[str]
+    neutral_pack_targets: frozenset[str]
+    hems_status: VerificationLevel
+    calibration: CalibrationCapability
+    native_control_approved: bool = False
+
+    def __post_init__(self) -> None:
+        if self.profile_key not in DEVICE_PROFILE_MODELS:
+            raise ValueError("Native matrix references an unknown device profile")
+        if self.native_control_approved:
+            raise ValueError("Issue #326 must not approve native writes")
+        object.__setattr__(self, "transports", MappingProxyType(dict(self.transports)))
+        object.__setattr__(
+            self,
+            "writable_main_properties",
+            MappingProxyType(dict(self.writable_main_properties)),
+        )
+
+    @property
+    def profile(self) -> DeviceProfile:
+        """Use the established profile as the sole hardware-limit authority."""
+
+        return DEVICE_PROFILE_MODELS[self.profile_key]
+
+    def transport(self, value: ZendureTransport) -> TransportCapability:
+        return self.transports.get(
+            value,
+            TransportCapability(
+                value,
+                VerificationLevel.UNSUPPORTED,
+                VerificationLevel.UNSUPPORTED,
+                VerificationLevel.UNSUPPORTED,
+            ),
+        )
+
+
+_COMMON_MAIN_READS = frozenset(
+    {
+        "electricLevel",
+        "outputPackPower",
+        "packInputPower",
+        "gridInputPower",
+        "outputHomePower",
+        "solarInputPower",
+        "acMode",
+        "inputLimit",
+        "outputLimit",
+        "chargeMaxLimit",
+        "inverseMaxPower",
+        "minSoc",
+        "socSet",
+        "hemsState",
+        "faultLevel",
+        "heatState",
+        "hyperTmp",
+        "BatVolt",
+        "masterSoftVersion",
+    }
+)
+_COMMON_PACK_READS = frozenset(
+    {
+        "packType",
+        "softVersion",
+        "socLevel",
+        "power",
+        "totalVol",
+        "batcur",
+        "minVol",
+        "maxVol",
+        "maxTemp",
+        "state",
+        "faultLevel",
+        "heatState",
+    }
+)
+_REFERENCE_WRITES = {
+    "acMode": VerificationLevel.REFERENCE_ONLY,
+    "inputLimit": VerificationLevel.REFERENCE_ONLY,
+    "outputLimit": VerificationLevel.REFERENCE_ONLY,
+    "minSoc": VerificationLevel.REFERENCE_ONLY,
+    "socSet": VerificationLevel.REFERENCE_ONLY,
+}
+_COMMON_DEVICE_TARGETS = frozenset(
+    {
+        "soc_pct",
+        "charge_power_w",
+        "discharge_power_w",
+        "ac_input_power_w",
+        "ac_output_power_w",
+        "pv_power_w",
+        "mode",
+        "input_limit_w",
+        "output_limit_w",
+        "configured_charge_limit_w",
+        "configured_discharge_limit_w",
+        "min_soc_pct",
+        "max_soc_pct",
+        "hems_active",
+        "fault_code",
+        "protection_active",
+        "temperature_c",
+        "battery_voltage_v",
+        "firmware",
+    }
+)
+_COMMON_PACK_TARGETS = frozenset(
+    {
+        "pack_type",
+        "firmware",
+        "soc_pct",
+        "charge_power_w",
+        "discharge_power_w",
+        "voltage_v",
+        "current_a",
+        "cell_min_v",
+        "cell_max_v",
+        "temperature_c",
+        "state_code",
+        "fault_code",
+        "protection_active",
+    }
+)
+
+
+def _normalize_model(value: str) -> str:
+    return re.sub(r"[^a-z0-9+]", "", value.casefold())
+
+
+def _transport_matrix() -> Mapping[ZendureTransport, TransportCapability]:
+    """Return evidence for the four initial current-generation models."""
+
+    return {
+        ZendureTransport.CLOUD_MQTT: TransportCapability(
+            ZendureTransport.CLOUD_MQTT,
+            VerificationLevel.VERIFIED,
+            VerificationLevel.REFERENCE_ONLY,
+            VerificationLevel.VERIFIED,
+            ("Read-only in BSFAI until command verification is implemented",),
+        ),
+        ZendureTransport.ZENSDK: TransportCapability(
+            ZendureTransport.ZENSDK,
+            VerificationLevel.REFERENCE_ONLY,
+            VerificationLevel.REFERENCE_ONLY,
+            VerificationLevel.REFERENCE_ONLY,
+            ("Implementation and real-device verification follow in #340-#342",),
+        ),
+        ZendureTransport.LOCAL_MQTT: TransportCapability(
+            ZendureTransport.LOCAL_MQTT,
+            VerificationLevel.UNKNOWN,
+            VerificationLevel.UNKNOWN,
+            VerificationLevel.UNKNOWN,
+            ("Do not infer Local MQTT support from Cloud MQTT compatibility",),
+        ),
+    }
+
+
+def _entry(
+    profile_key: str,
+    canonical_model: str,
+    *aliases: str,
+    product_ids: tuple[str, ...] = (),
+) -> ZendureDeviceMatrixEntry:
+    return ZendureDeviceMatrixEntry(
+        profile_key=profile_key,
+        canonical_model=canonical_model,
+        model_aliases=frozenset(
+            _normalize_model(value) for value in (canonical_model, *aliases)
+        ),
+        confirmed_product_ids=frozenset(product_ids),
+        transports=_transport_matrix(),
+        readable_main_properties=_COMMON_MAIN_READS,
+        readable_pack_properties=_COMMON_PACK_READS,
+        writable_main_properties=_REFERENCE_WRITES,
+        neutral_device_targets=_COMMON_DEVICE_TARGETS,
+        neutral_pack_targets=_COMMON_PACK_TARGETS,
+        hems_status=VerificationLevel.REFERENCE_ONLY,
+        calibration=CalibrationCapability(
+            raw_status=VerificationLevel.REFERENCE_ONLY,
+            next_due_from_device=VerificationLevel.UNKNOWN,
+            notes=(
+                "socStatus/batCalTime require field interpretation",
+                "Zendure-HA nextCalibration is derived, not a device due date",
+            ),
+        ),
+    )
+
+
+ZENDURE_DEVICE_MATRIX: Mapping[str, ZendureDeviceMatrixEntry] = MappingProxyType(
+    {
+        entry.profile_key: entry
+        for entry in (
+            _entry(
+                "SF2400AC",
+                "SolarFlow 2400 AC",
+                "solarFlow2400AC",
+                "SF2400AC",
+                product_ids=("BC8B7F",),
+            ),
+            _entry(
+                "SF2400Pro",
+                "SolarFlow 2400 Pro",
+                "solarFlow2400Pro",
+                "SF2400Pro",
+            ),
+            _entry(
+                "SF2400AC+",
+                "SolarFlow 2400 AC+",
+                "solarFlow2400AC+",
+                "SF2400AC+",
+            ),
+            _entry(
+                "SF800Pro",
+                "SolarFlow 800 Pro",
+                "solarFlow800Pro",
+                "SF800Pro",
+                product_ids=("R3mn8U",),
+            ),
+        )
+    }
+)
+
+_BY_MODEL = {
+    alias: entry
+    for entry in ZENDURE_DEVICE_MATRIX.values()
+    for alias in entry.model_aliases
+}
+_BY_PRODUCT_ID = {
+    product_id: entry
+    for entry in ZENDURE_DEVICE_MATRIX.values()
+    for product_id in entry.confirmed_product_ids
+}
+
+
+def resolve_zendure_device(
+    identity: NativeDeviceIdentity,
+) -> ZendureDeviceMatrixEntry | None:
+    """Resolve only exact evidence; conflicting identity remains unsupported."""
+
+    by_model = (
+        _BY_MODEL.get(_normalize_model(identity.product_model))
+        if identity.product_model
+        else None
+    )
+    by_product = (
+        _BY_PRODUCT_ID.get(identity.product_id)
+        if identity.product_id
+        else None
+    )
+    if by_model is not None and by_product is not None and by_model is not by_product:
+        return None
+    return by_product or by_model

--- a/custom_components/battery_smartflow_ai/zendure_normalizer.py
+++ b/custom_components/battery_smartflow_ai/zendure_normalizer.py
@@ -19,6 +19,7 @@ from .core.models import (
 )
 from .zendure_cloud import ZendureCloudBootstrap
 from .zendure_cloud_mqtt import CloudMqttMessage
+from .zendure_device_matrix import resolve_zendure_device
 
 
 DEFAULT_STALE_AFTER_SECONDS = 30.0
@@ -218,14 +219,6 @@ PACK_PROPERTY_MAPPINGS = {
 }
 
 
-_DEVICE_TARGETS = frozenset(
-    item.target for item in MAIN_PROPERTY_MAPPINGS.values()
-)
-_PACK_TARGETS = frozenset(
-    item.target for item in PACK_PROPERTY_MAPPINGS.values()
-) | {"charge_power_w", "discharge_power_w"}
-
-
 @dataclass(frozen=True, slots=True)
 class NormalizationResult:
     state: NeutralDeviceState
@@ -283,8 +276,26 @@ class ZendureCloudNormalizer:
         self._unknown_pack = {
             candidate_id: set() for candidate_id in self._models
         }
-        self._supported_device_targets = supported_device_targets or {}
-        self._supported_pack_targets = supported_pack_targets or {}
+        matrix_device_targets: dict[str, frozenset[str]] = {}
+        matrix_pack_targets: dict[str, frozenset[str]] = {}
+        for item in bootstrap.devices:
+            entry = resolve_zendure_device(item.candidate.identity)
+            candidate_id = item.candidate.candidate_id
+            matrix_device_targets[candidate_id] = (
+                entry.neutral_device_targets if entry is not None else frozenset()
+            )
+            if entry is not None:
+                matrix_pack_targets[candidate_id] = entry.neutral_pack_targets
+        self._supported_device_targets = (
+            dict(supported_device_targets)
+            if supported_device_targets is not None
+            else matrix_device_targets
+        )
+        self._supported_pack_targets = (
+            dict(supported_pack_targets)
+            if supported_pack_targets is not None
+            else matrix_pack_targets
+        )
 
     def apply(
         self,
@@ -331,7 +342,7 @@ class ZendureCloudNormalizer:
         current = now or datetime.now(timezone.utc)
         online = self._online[system_id]
         values = self._device_values[system_id]
-        supported = self._supported_device_targets.get(system_id, _DEVICE_TARGETS)
+        supported = self._supported_device_targets.get(system_id, frozenset())
 
         def device_value(target: str) -> MeasuredValue[Any]:
             return self._value(values, target, supported, online, current)
@@ -471,7 +482,7 @@ class ZendureCloudNormalizer:
         now: datetime,
         online: bool | None,
     ) -> NeutralPackState:
-        supported = self._supported_pack_targets.get(pack_id, _PACK_TARGETS)
+        supported = self._supported_pack_targets.get(system_id, frozenset())
 
         def value(target: str) -> MeasuredValue[Any]:
             return self._value(

--- a/tests/test_zendure_device_matrix.py
+++ b/tests/test_zendure_device_matrix.py
@@ -1,0 +1,134 @@
+"""Safety contract for the initial native Zendure device matrix."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+import unittest
+
+from support import bootstrap
+
+
+bootstrap()
+
+from custom_components.battery_smartflow_ai.core.models import (  # noqa: E402
+    NativeDeviceIdentity,
+    ZendureTransport,
+)
+from custom_components.battery_smartflow_ai.device_profiles import (  # noqa: E402
+    DEVICE_PROFILE_MODELS,
+)
+from custom_components.battery_smartflow_ai.zendure_device_matrix import (  # noqa: E402
+    VerificationLevel,
+    ZENDURE_DEVICE_MATRIX,
+    resolve_zendure_device,
+)
+
+
+def identity(
+    *,
+    model: str | None = None,
+    product_id: str | None = None,
+    device_id: str = "device-1",
+) -> NativeDeviceIdentity:
+    return NativeDeviceIdentity(
+        transport=ZendureTransport.CLOUD_MQTT,
+        device_id=device_id,
+        product_id=product_id,
+        product_model=model,
+    )
+
+
+class ZendureDeviceMatrixTests(unittest.TestCase):
+    def test_all_initial_profiles_have_exact_model_mapping(self):
+        models = {
+            "SF2400AC": "SolarFlow 2400 AC",
+            "SF2400Pro": "SolarFlow 2400 Pro",
+            "SF2400AC+": "SolarFlow 2400 AC+",
+            "SF800Pro": "SolarFlow 800 Pro",
+        }
+        self.assertEqual(set(ZENDURE_DEVICE_MATRIX), set(models))
+        for profile_key, model in models.items():
+            with self.subTest(profile=profile_key):
+                entry = resolve_zendure_device(identity(model=model))
+                self.assertIsNotNone(entry)
+                self.assertIs(entry.profile, DEVICE_PROFILE_MODELS[profile_key])
+
+    def test_only_confirmed_product_ids_are_mapped(self):
+        self.assertEqual(
+            resolve_zendure_device(identity(product_id="BC8B7F")).profile_key,
+            "SF2400AC",
+        )
+        self.assertEqual(
+            resolve_zendure_device(identity(product_id="R3mn8U")).profile_key,
+            "SF800Pro",
+        )
+        self.assertIsNone(resolve_zendure_device(identity(product_id="guessed")))
+
+    def test_display_name_cannot_affect_resolution(self):
+        self.assertIsNone(
+            resolve_zendure_device(
+                identity(model="My SF800Pro in the basement")
+            )
+        )
+        self.assertIsNone(resolve_zendure_device(identity(model="SF800Pro2")))
+
+    def test_conflicting_verified_identity_is_rejected(self):
+        self.assertIsNone(
+            resolve_zendure_device(
+                identity(model="SF800Pro", product_id="BC8B7F")
+            )
+        )
+
+    def test_profile_is_only_hardware_limit_authority(self):
+        entry = ZENDURE_DEVICE_MATRIX["SF2400AC"]
+        hardware_limit = entry.profile.capabilities.max_input_w
+        runtime_report = {"inputLimit": 321, "chargeMaxLimit": 654}
+        self.assertEqual(
+            entry.profile.capabilities.max_input_w,
+            hardware_limit,
+        )
+        self.assertNotEqual(runtime_report["inputLimit"], hardware_limit)
+
+    def test_no_model_or_transport_is_approved_for_native_control(self):
+        for entry in ZENDURE_DEVICE_MATRIX.values():
+            with self.subTest(profile=entry.profile_key):
+                self.assertFalse(entry.native_control_approved)
+                self.assertNotIn(
+                    VerificationLevel.VERIFIED,
+                    entry.writable_main_properties.values(),
+                )
+                self.assertIs(
+                    entry.transport(ZendureTransport.CLOUD_MQTT).write,
+                    VerificationLevel.REFERENCE_ONLY,
+                )
+
+    def test_transports_remain_separate_evidence_domains(self):
+        entry = ZENDURE_DEVICE_MATRIX["SF800Pro"]
+        self.assertIs(
+            entry.transport(ZendureTransport.CLOUD_MQTT).read,
+            VerificationLevel.VERIFIED,
+        )
+        self.assertIs(
+            entry.transport(ZendureTransport.ZENSDK).read,
+            VerificationLevel.REFERENCE_ONLY,
+        )
+        self.assertIs(
+            entry.transport(ZendureTransport.LOCAL_MQTT).read,
+            VerificationLevel.UNKNOWN,
+        )
+
+    def test_pack_observation_does_not_enable_main_system_control(self):
+        entry = ZENDURE_DEVICE_MATRIX["SF2400Pro"]
+        self.assertIn("soc_pct", entry.neutral_pack_targets)
+        self.assertFalse(entry.native_control_approved)
+
+    def test_matrix_cannot_be_constructed_with_control_approval(self):
+        with self.assertRaisesRegex(ValueError, "must not approve native writes"):
+            replace(
+                ZENDURE_DEVICE_MATRIX["SF800Pro"],
+                native_control_approved=True,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add one authoritative native Zendure device/capability matrix for SF2400AC, SF2400Pro, SF2400AC+, and SF800Pro
- map only exact model identities and confirmed product IDs to existing DeviceProfiles
- keep Cloud MQTT, Local MQTT, and ZenSDK capability evidence explicitly separate
- mark native writes as reference-only and enforce that no model is approved for native control in this step
- derive neutral main-device and pack support from the matrix while keeping unknown devices observable but unsupported
- preserve existing DeviceProfiles as the sole source for immutable hardware limits

## Safety

- no command path or hardware write is added
- unknown, similar, or conflicting identities are not assigned a profile
- packs remain observational and never become independently controllable
- runtime limits remain measurements and cannot replace profile hardware maxima

## Validation

- 417 unit tests passed
- Python compileall passed
- git diff --check passed

Closes #326