### PR TITLE
V5: Add hierarchical native device overview

### DIFF
--- a/custom_components/battery_smartflow_ai/native_device_overview.py
+++ b/custom_components/battery_smartflow_ai/native_device_overview.py
@@ -1,0 +1,142 @@
+"""Privacy-safe hierarchical projection for the native device overview."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import hashlib
+from types import MappingProxyType
+from typing import Mapping
+
+from .core.models import (
+    DeviceControlState,
+    DeviceInventory,
+    MeasuredValue,
+    NeutralDeviceState,
+    ZendureTransport,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class PackOverview:
+    public_id: str
+    parent_public_id: str
+    pack_model: str | None
+    firmware: MeasuredValue[str]
+    measurements: Mapping[str, MeasuredValue]
+    last_message_at: datetime | None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "measurements", MappingProxyType(dict(self.measurements))
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class MainSystemOverview:
+    public_id: str
+    display_name: str
+    model: str | None
+    product_id: str | None
+    profile_key: str | None
+    control_state: DeviceControlState
+    control_enabled: bool
+    actively_controlled: bool
+    status_text: str
+    selected_transport: ZendureTransport
+    available_transports: tuple[ZendureTransport, ...]
+    online: bool
+    hems_active: bool
+    last_message_at: datetime | None
+    packs: tuple[PackOverview, ...]
+
+
+def build_native_device_overview(
+    inventory: DeviceInventory,
+    states: Mapping[str, NeutralDeviceState],
+) -> tuple[MainSystemOverview, ...]:
+    """Build an unbounded hierarchy without exposing stable source identities."""
+
+    result = []
+    for system_id, device in sorted(inventory.devices.items()):
+        state = states.get(system_id)
+        public_id = _public_id("DEVICE", system_id)
+        identity = device.native_identities[0] if device.native_identities else None
+        packs = []
+        state_packs = {item.pack_id: item for item in state.packs} if state else {}
+        for pack_id, pack_identity in sorted(inventory.packs.items()):
+            if pack_identity.parent_system_id != system_id:
+                continue
+            observed = state_packs.get(pack_id)
+            if observed is None:
+                continue
+            packs.append(
+                PackOverview(
+                    public_id=_public_id("PACK", pack_id),
+                    parent_public_id=public_id,
+                    pack_model=pack_identity.pack_type,
+                    firmware=observed.firmware,
+                    measurements=MappingProxyType(
+                        {
+                            "soc_pct": observed.soc_pct,
+                            "charge_power_w": observed.charge_power_w,
+                            "discharge_power_w": observed.discharge_power_w,
+                            "voltage_v": observed.voltage_v,
+                            "current_a": observed.current_a,
+                            "cell_min_v": observed.cell_min_v,
+                            "cell_max_v": observed.cell_max_v,
+                            "temperature_c": observed.temperature_c,
+                            "state_code": observed.state_code,
+                            "fault_code": observed.fault_code,
+                            "protection_active": observed.protection_active,
+                        }
+                    ),
+                    last_message_at=observed.last_message_at,
+                )
+            )
+        result.append(
+            MainSystemOverview(
+                public_id=public_id,
+                display_name=device.display_name,
+                model=device.model,
+                product_id=identity.product_id if identity else None,
+                profile_key=device.profile_key,
+                control_state=device.control_state,
+                control_enabled=device.control_state in {
+                    DeviceControlState.ENABLED,
+                    DeviceControlState.ACTIVE,
+                },
+                actively_controlled=(
+                    device.control_state is DeviceControlState.ACTIVE
+                ),
+                status_text=_status_text(device.control_state),
+                selected_transport=device.selected_transport,
+                available_transports=tuple(
+                    sorted(device.available_transports, key=lambda item: item.value)
+                ),
+                online=device.online,
+                hems_active=device.hems_active,
+                last_message_at=state.last_message_at if state else None,
+                packs=tuple(packs),
+            )
+        )
+    return tuple(result)
+
+
+def _public_id(kind: str, value: str) -> str:
+    digest = hashlib.sha256(f"bsfai:{kind}:{value}".encode()).hexdigest()[:12]
+    return f"ZD_{kind}_{digest}"
+
+
+def _status_text(state: DeviceControlState) -> str:
+    return {
+        DeviceControlState.OBSERVATION: "Observation mode",
+        DeviceControlState.ELIGIBLE: "Eligible for control",
+        DeviceControlState.ENABLED: "Control enabled",
+        DeviceControlState.ACTIVE: "Actively controlled",
+        DeviceControlState.HEMS_BLOCKED: "Observation mode - Zendure HEMS active",
+        DeviceControlState.UNSUPPORTED: (
+            "Observation mode - device profile not supported"
+        ),
+        DeviceControlState.OFFLINE: "Observation mode - device offline",
+    }[state]

--- a/tests/test_native_device_overview.py
+++ b/tests/test_native_device_overview.py
@@ -1,0 +1,120 @@
+"""Hierarchical, privacy-safe native device overview tests."""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+import unittest
+
+from support import bootstrap
+
+bootstrap()
+
+from custom_components.battery_smartflow_ai.core.models import (  # noqa: E402
+    BatteryPackIdentity, DeviceControlState, DeviceInventory, MainDevice,
+    MeasuredValue, NativeDeviceIdentity, ZendureTransport,
+)
+from custom_components.battery_smartflow_ai.native_device_overview import (  # noqa: E402
+    build_native_device_overview,
+)
+
+
+def measured(value):
+    return MeasuredValue.available(value)
+
+
+def observed_pack(pack_id, parent):
+    values = dict(
+        pack_id=pack_id, parent_system_id=parent, firmware=measured("1.2.3"),
+        soc_pct=measured(55.0), charge_power_w=measured(100.0),
+        discharge_power_w=measured(0.0), voltage_v=measured(49.5),
+        current_a=measured(2.0), cell_min_v=measured(3.29),
+        cell_max_v=measured(3.31), temperature_c=measured(25.0),
+        state_code=measured(1), fault_code=measured(0),
+        protection_active=measured(False),
+        last_message_at=datetime(2026, 9, 2, tzinfo=timezone.utc),
+    )
+    return SimpleNamespace(**values)
+
+
+class NativeDeviceOverviewTests(unittest.TestCase):
+    def test_multiple_systems_and_duplicate_names_remain_separate(self):
+        inventory = DeviceInventory(devices=(
+            MainDevice("main-secret-a", "Battery", model="SF2400AC"),
+            MainDevice("main-secret-b", "Battery", model="SF800Pro"),
+        ))
+        overview = build_native_device_overview(inventory, {})
+        self.assertEqual(len(overview), 2)
+        self.assertNotEqual(overview[0].public_id, overview[1].public_id)
+        self.assertEqual({item.display_name for item in overview}, {"Battery"})
+
+    def test_unknown_pack_model_keeps_verified_measurements(self):
+        main = MainDevice("main-secret", "Main")
+        inventory = DeviceInventory(
+            devices=(main,),
+            packs=(BatteryPackIdentity("pack-secret", main.system_id),),
+        )
+        state = SimpleNamespace(
+            packs=(observed_pack("pack-secret", main.system_id),),
+            last_message_at=datetime(2026, 9, 2, tzinfo=timezone.utc),
+        )
+        item = build_native_device_overview(inventory, {main.system_id: state})[0]
+        self.assertEqual(len(item.packs), 1)
+        self.assertIsNone(item.packs[0].pack_model)
+        self.assertEqual(item.packs[0].measurements["soc_pct"].value, 55.0)
+        self.assertFalse(hasattr(item.packs[0], "capacity"))
+        self.assertFalse(hasattr(item.packs[0], "cell_count"))
+        self.assertEqual(item.packs[0].parent_public_id, item.public_id)
+
+    def test_sensitive_full_identifiers_never_enter_projection(self):
+        identity = NativeDeviceIdentity(
+            ZendureTransport.CLOUD_MQTT,
+            device_id="full-device-secret",
+            serial_number="full-serial-secret",
+            product_id="BC8B7F",
+            product_model="SolarFlow2400AC",
+        )
+        main = MainDevice(
+            "logical-system-secret", "Allowed display name",
+            native_identities=(identity,),
+            selected_transport=ZendureTransport.CLOUD_MQTT,
+            available_transports=frozenset({ZendureTransport.CLOUD_MQTT}),
+        )
+        text = repr(build_native_device_overview(DeviceInventory(devices=(main,)), {}))
+        self.assertNotIn("full-device-secret", text)
+        self.assertNotIn("full-serial-secret", text)
+        self.assertNotIn("logical-system-secret", text)
+        self.assertIn("BC8B7F", text)
+
+    def test_management_states_are_visible_and_control_defaults_off(self):
+        devices = tuple(
+            MainDevice(
+                f"main-{state.value}", state.value,
+                supported=state is not DeviceControlState.UNSUPPORTED,
+                online=state is not DeviceControlState.OFFLINE,
+                hems_active=state is DeviceControlState.HEMS_BLOCKED,
+                control_state=state,
+            )
+            for state in (
+                DeviceControlState.OBSERVATION,
+                DeviceControlState.HEMS_BLOCKED,
+                DeviceControlState.UNSUPPORTED,
+                DeviceControlState.OFFLINE,
+            )
+        )
+        overview = build_native_device_overview(DeviceInventory(devices=devices), {})
+        self.assertTrue(all(not item.control_enabled for item in overview))
+        self.assertTrue(any("HEMS active" in item.status_text for item in overview))
+        self.assertTrue(any("not supported" in item.status_text for item in overview))
+
+    def test_disappeared_pack_and_device_do_not_trigger_failover(self):
+        active = MainDevice.from_v4_config_entry("entry")
+        other = MainDevice("other", "Other")
+        inventory = DeviceInventory(devices=(active, other))
+        inventory.mark_unavailable(active.system_id)
+        overview = build_native_device_overview(inventory, {})
+        by_name = {item.display_name: item for item in overview}
+        self.assertFalse(by_name["Battery SmartFlow AI"].actively_controlled)
+        self.assertFalse(by_name["Other"].actively_controlled)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a privacy-safe hierarchical overview projection for every observed Zendure main system and its packs
- expose management state, profile, selected and available transports, HEMS, online state, and last data receipt separately from control activation
- keep pack identity, parent association, and optional pack model separate
- retain verified pack measurements when the pack model is unknown without inventing capacity, cell count, limits, or capabilities
- generate pseudonymous UI identifiers while excluding full device, serial, pack, and logical system IDs
- preserve the V5 single-active-device rule and never fail over automatically

## Safety

- newly observed devices remain control-disabled
- unsupported, HEMS-blocked, and offline systems remain visible in observation status
- no command path, native write, or multi-battery regulation is added

## Validation

- 451 unit tests passed
- Python compileall passed
- git diff --check passed

Closes #329