### PR TITLE
V5: Add restart-safe V4.7 upgrade migration

### DIFF
--- a/custom_components/battery_smartflow_ai/__init__.py
+++ b/custom_components/battery_smartflow_ai/__init__.py
@@ -126,6 +126,17 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         new_options.pop("regulation_v42_enabled", None)
         new_version = 3
 
+    if new_version == 3:
+        from .v5_migration import initial_v5_migration_state
+
+        # Retain every V4.7 setting and the authoritative Z-HA path. Native
+        # discovery and identity migration are not native-write consent.
+        new_data.setdefault(
+            "v5_migration",
+            dict(initial_v5_migration_state(entry.entry_id).as_dict()),
+        )
+        new_version = 4
+
     if (
         new_version != entry.version
         or new_data != dict(entry.data)

--- a/custom_components/battery_smartflow_ai/config_flow.py
+++ b/custom_components/battery_smartflow_ai/config_flow.py
@@ -147,7 +147,7 @@ def _validate_feed_in_tariff(value: Any) -> float:
 class ZendureSmartFlowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Config flow for Battery SmartFlow AI."""
 
-    VERSION = 3
+    VERSION = 4
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None):
         if user_input is not None:

--- a/custom_components/battery_smartflow_ai/coordinator.py
+++ b/custom_components/battery_smartflow_ai/coordinator.py
@@ -177,6 +177,7 @@ from .adapters.home_assistant.device_backend import (
 )
 from .adapters.home_assistant.clock import HomeAssistantClock
 from .adapters.home_assistant.state_store import HomeAssistantStateStore
+from .v5_migration import migrate_persisted_v47_state
 from .command_effectiveness import (
     CommandEffectivenessConfig,
     CommandEffectivenessState,
@@ -585,7 +586,10 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     async def _load(self) -> None:
         load_result = await self._state_store.load()
         if load_result.usable:
-            loaded_data = dict(load_result.data)
+            loaded_data = migrate_persisted_v47_state(
+                load_result.data,
+                legacy_system_id=f"config_entry:{self.entry.entry_id}",
+            )
             migrate_legacy_price_fields(loaded_data)
             self._persist.update(loaded_data)
 

--- a/custom_components/battery_smartflow_ai/v5_migration.py
+++ b/custom_components/battery_smartflow_ai/v5_migration.py
@@ -1,0 +1,96 @@
+"""Idempotent V4.7-to-V5 migration without native control activation."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+from enum import StrEnum
+from types import MappingProxyType
+from typing import Any, Mapping
+
+from .core.models import BindingState, DiscoveryCandidate
+from .zendure_device_matrix import resolve_zendure_device
+
+V5_MIGRATION_SCHEMA = 1
+
+
+class MigrationPhase(StrEnum):
+    ZHA_TRANSITION = "zha_transition"
+    NATIVE_MATCH_REQUIRED = "native_match_required"
+    SHADOW_READY = "shadow_ready"
+
+
+@dataclass(frozen=True, slots=True)
+class V5MigrationState:
+    schema_version: int
+    phase: MigrationPhase
+    legacy_system_id: str
+    binding_state: BindingState
+    native_candidate_id: str | None
+    native_control_enabled: bool
+    legacy_zha_enabled: bool
+
+    def __post_init__(self) -> None:
+        if self.native_control_enabled:
+            raise ValueError("config migration must not activate native control")
+        if not self.legacy_zha_enabled:
+            raise ValueError("config migration must retain the Z-HA path")
+
+    def as_dict(self) -> Mapping[str, Any]:
+        return MappingProxyType({
+            "schema_version": self.schema_version,
+            "phase": self.phase.value,
+            "legacy_system_id": self.legacy_system_id,
+            "binding_state": self.binding_state.value,
+            "native_candidate_id": self.native_candidate_id,
+            "native_control_enabled": self.native_control_enabled,
+            "legacy_zha_enabled": self.legacy_zha_enabled,
+        })
+
+
+def initial_v5_migration_state(entry_id: str) -> V5MigrationState:
+    if not entry_id:
+        raise ValueError("entry_id is required")
+    return V5MigrationState(
+        V5_MIGRATION_SCHEMA,
+        MigrationPhase.ZHA_TRANSITION,
+        f"config_entry:{entry_id}",
+        BindingState.UNMATCHED,
+        None,
+        False,
+        True,
+    )
+
+
+def match_v4_device(
+    *, legacy_profile: str | None,
+    candidates: tuple[DiscoveryCandidate, ...],
+) -> tuple[DiscoveryCandidate, ...]:
+    """Return candidates for confirmation; never match names or order."""
+
+    if legacy_profile is None:
+        return ()
+    return tuple(
+        candidate for candidate in candidates
+        if candidate.supported
+        and (entry := resolve_zendure_device(candidate.identity)) is not None
+        and entry.profile_key == legacy_profile
+    )
+
+
+def migrate_persisted_v47_state(
+    state: Mapping[str, Any], *, legacy_system_id: str,
+) -> dict[str, Any]:
+    """Preserve the flat V4 document and add restart-safe ownership metadata."""
+
+    migrated = deepcopy(dict(state))
+    migrated.setdefault("v5_migration_schema", V5_MIGRATION_SCHEMA)
+    migrated.setdefault("v5_legacy_system_id", legacy_system_id)
+    migrated["v5_native_control_enabled"] = False
+    migrated.setdefault("v5_native_candidate_id", None)
+    migrated.setdefault("v5_binding_state", BindingState.UNMATCHED.value)
+    migrated["v5_legacy_zha_enabled"] = True
+    migrated.setdefault("v5_economics_owner", legacy_system_id)
+    if migrated.get("charge_commit_active"):
+        migrated.setdefault("v5_charge_commit_owner", legacy_system_id)
+    return migrated

--- a/tests/test_v470_backward_compatibility.py
+++ b/tests/test_v470_backward_compatibility.py
@@ -83,16 +83,25 @@ class ConfigEntryUpgradeCompatibilityTests(unittest.TestCase):
 
                 assert await integration.async_migrate_entry(hass, entry)
                 update = hass.config_entries.updates[-1][1]
-                assert update["version"] == 3
+                assert update["version"] == 4
                 assert update["data"] == {
                     "soc_entity": "sensor.existing_soc",
                     "custom": "keep",
                     "pack_capacity_kwh": 2.88,
+                    "v5_migration": {
+                        "schema_version": 1,
+                        "phase": "zha_transition",
+                        "legacy_system_id": "config_entry:existing-entry-id",
+                        "binding_state": "unmatched",
+                        "native_candidate_id": None,
+                        "native_control_enabled": False,
+                        "legacy_zha_enabled": True,
+                    },
                 }
                 assert update["options"] == {"soc_min": 12.0}
 
                 current = SimpleNamespace(
-                    entry_id="current-entry-id", version=3,
+                    entry_id="current-entry-id", version=4,
                     data={"soc_entity": "sensor.current_soc"},
                     options={"soc_min": 10.0},
                 )

--- a/tests/test_v5_migration.py
+++ b/tests/test_v5_migration.py
@@ -1,0 +1,100 @@
+"""V4.7-to-V5 configuration and persistence migration contracts."""
+
+import unittest
+
+from support import bootstrap
+
+bootstrap()
+
+from custom_components.battery_smartflow_ai.core.models import (  # noqa: E402
+    DiscoveryCandidate, NativeDeviceIdentity, ZendureTransport,
+)
+from custom_components.battery_smartflow_ai.v5_migration import (  # noqa: E402
+    initial_v5_migration_state, match_v4_device, migrate_persisted_v47_state,
+)
+
+
+def candidate(device_id, model, supported=True, name="Same display name"):
+    return DiscoveryCandidate(
+        NativeDeviceIdentity(
+            ZendureTransport.CLOUD_MQTT,
+            device_id=device_id,
+            product_model=model,
+        ),
+        name,
+        supported,
+    )
+
+
+class V5MigrationTests(unittest.TestCase):
+    def test_initial_state_retains_zha_and_never_enables_native_writes(self):
+        state = initial_v5_migration_state("entry-1")
+        self.assertTrue(state.legacy_zha_enabled)
+        self.assertFalse(state.native_control_enabled)
+        self.assertIsNone(state.native_candidate_id)
+
+    def test_persistence_migration_preserves_all_v47_values_and_totals(self):
+        old = {
+            "learned_load_slots": {"12:00": 1.25},
+            "economics_money_state": {"grid_charge_cost": 12.34},
+            "economics_energy_state": {"pv_charge_kwh": 56.7},
+            "charge_commit_active": True,
+            "charge_commit_target_soc": 80,
+            "custom_future_value": [1, 2, 3],
+        }
+        migrated = migrate_persisted_v47_state(
+            old, legacy_system_id="config_entry:entry-1"
+        )
+        for key, value in old.items():
+            self.assertEqual(migrated[key], value)
+        self.assertEqual(
+            migrated["v5_charge_commit_owner"], "config_entry:entry-1"
+        )
+        self.assertEqual(migrated["v5_economics_owner"], "config_entry:entry-1")
+        self.assertFalse(migrated["v5_native_control_enabled"])
+        self.assertTrue(migrated["v5_legacy_zha_enabled"])
+        self.assertIsNot(migrated["learned_load_slots"], old["learned_load_slots"])
+
+    def test_persistence_migration_is_idempotent_and_restart_safe(self):
+        once = migrate_persisted_v47_state(
+            {"charge_commit_active": False},
+            legacy_system_id="config_entry:entry-1",
+        )
+        twice = migrate_persisted_v47_state(
+            once, legacy_system_id="config_entry:entry-1"
+        )
+        self.assertEqual(once, twice)
+
+    def test_matching_uses_supported_matrix_profile_not_name_or_order(self):
+        candidates = (
+            candidate("wrong", "SolarFlow800Pro"),
+            candidate("right", "SolarFlow2400AC"),
+            candidate("unknown", "SF2400AC lookalike", False),
+        )
+        matches = match_v4_device(
+            legacy_profile="SF2400AC", candidates=candidates
+        )
+        self.assertEqual([item.identity.device_id for item in matches], ["right"])
+
+    def test_ambiguous_matches_remain_for_explicit_user_choice(self):
+        matches = match_v4_device(
+            legacy_profile="SF2400AC",
+            candidates=(
+                candidate("first", "SolarFlow2400AC"),
+                candidate("second", "SF2400AC"),
+            ),
+        )
+        self.assertEqual(len(matches), 2)
+
+    def test_missing_or_unknown_device_never_gets_fallback_match(self):
+        self.assertEqual(
+            match_v4_device(
+                legacy_profile="SF2400AC",
+                candidates=(candidate("future", "FutureModel"),),
+            ),
+            (),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- bump the Home Assistant ConfigEntry schema to version 4 and add an idempotent V4.7-to-V5 migration state
- preserve every existing config data and option key while retaining the current Z-HA control path
- keep native control disabled after migration and require a later explicit confirmation
- migrate the existing flat persistent state without resetting learned planning, charge commitments, economics totals, or unknown future fields
- assign legacy economics and active commitment ownership to the existing V4 logical system until identity confirmation
- match migration candidates only through supported device-matrix profiles, never display name or discovery order
- return all ambiguous candidates for explicit user choice rather than selecting one

## Compatibility and safety

- existing ConfigEntry and entity identifiers stay unchanged
- unknown or missing native devices are not matched
- no native write path or credential copy is introduced
- repeated migration produces the same state without duplication

## Validation

- 457 unit tests passed
- Python compileall passed
- git diff --check passed

Closes #330