### PR TITLE
V5.0.0-dev2: fix Zendure Cloud MQTT connection

### DIFF
--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -38,7 +38,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "5.0.0-dev1"
+INTEGRATION_VERSION = "5.0.0-dev2"
 
 # V5 native Zendure discovery is observation-only in the first development
 # build. The App Token is account discovery material and must never be copied

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": ["paho-mqtt==2.1.0"],
-  "version": "5.0.0-dev1"
+  "version": "5.0.0-dev2"
 }

--- a/custom_components/battery_smartflow_ai/zendure_cloud_mqtt.py
+++ b/custom_components/battery_smartflow_ai/zendure_cloud_mqtt.py
@@ -157,8 +157,10 @@ class ZendureCloudMqttTransport:
         for device_id, _candidate_id, product_id in self._routes:
             if product_id:
                 topics.add(f"/{product_id}/{device_id}/#")
+                topics.add(f"iot/{product_id}/{device_id}/#")
             else:
                 topics.add(f"/+/{device_id}/#")
+                topics.add(f"iot/+/{device_id}/#")
         return tuple(sorted(topics))
 
     async def async_start(self, *, timeout: float = 15.0) -> None:
@@ -371,19 +373,11 @@ class PahoReadOnlyMqttSession:
         except ImportError as error:
             raise CloudMqttError("mqtt_dependency_missing") from error
 
-        parsed = urlsplit(
-            credentials.url
-            if "://" in credentials.url
-            else f"mqtts://{credentials.url}"
-        )
-        if not parsed.hostname or parsed.scheme not in {"mqtt", "mqtts", "ssl", "tcp"}:
-            raise CloudMqttError("invalid_broker_url")
-        self._host = parsed.hostname
-        self._tls = parsed.scheme in {"mqtts", "ssl"}
-        self._port = parsed.port or (8883 if self._tls else 1883)
+        self._host, self._port, self._tls = _parse_broker_url(credentials.url)
         self._client = mqtt.Client(
             mqtt.CallbackAPIVersion.VERSION2,
             client_id=credentials.client_id,
+            protocol=mqtt.MQTTv31,
         )
         self._client.username_pw_set(credentials.username, credentials.password)
         if self._tls:
@@ -445,3 +439,22 @@ class PahoReadOnlyMqttSession:
     def _paho_message(self, _client: Any, _userdata: Any, message: Any) -> None:
         if self._on_message is not None:
             self._on_message(str(message.topic), bytes(message.payload))
+
+
+def _parse_broker_url(value: str) -> tuple[str, int, bool]:
+    """Parse Zendure's schema-free port-1883 broker as plain MQTT.
+
+    TLS is enabled only when Zendure explicitly returns an MQTT TLS scheme.
+    This mirrors the official Zendure-HA Cloud connection behavior while
+    retaining support for an explicit secure endpoint.
+    """
+
+    parsed = urlsplit(value if "://" in value else f"mqtt://{value}")
+    if not parsed.hostname or parsed.scheme not in {"mqtt", "mqtts", "ssl", "tcp"}:
+        raise CloudMqttError("invalid_broker_url")
+    tls = parsed.scheme in {"mqtts", "ssl"}
+    try:
+        port = parsed.port or (8883 if tls else 1883)
+    except ValueError:
+        raise CloudMqttError("invalid_broker_url") from None
+    return parsed.hostname, port, tls

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -13,7 +13,7 @@ COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
 
 
 class DebugIntegrationContractTests(unittest.TestCase):
-    def test_manifest_and_runtime_version_match_v5_dev1_release(self) -> None:
+    def test_manifest_and_runtime_version_match_v5_dev2_release(self) -> None:
         manifest_version = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )["version"]
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "5.0.0-dev1")
+        self.assertEqual(manifest_version, "5.0.0-dev2")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_native_zendure_ha_integration.py
+++ b/tests/test_native_zendure_ha_integration.py
@@ -17,7 +17,7 @@ class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
         manifest = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )
-        self.assertEqual(manifest["version"], "5.0.0-dev1")
+        self.assertEqual(manifest["version"], "5.0.0-dev2")
         self.assertIn("paho-mqtt==2.1.0", manifest["requirements"])
 
     def test_options_flow_uses_a_password_field_and_never_suggests_token(self) -> None:

--- a/tests/test_zendure_cloud_mqtt.py
+++ b/tests/test_zendure_cloud_mqtt.py
@@ -7,12 +7,14 @@ from base64 import b64encode
 from datetime import datetime, timezone
 import inspect
 import json
+from pathlib import Path
 import unittest
 
 from custom_components.battery_smartflow_ai.zendure_cloud import ZendureCloudClient
 from custom_components.battery_smartflow_ai.zendure_cloud_mqtt import (
     ConnectionState,
     ZendureCloudMqttTransport,
+    _parse_broker_url,
 )
 
 
@@ -65,7 +67,15 @@ class CloudMqttTransportTests(unittest.IsolatedAsyncioTestCase):
         transport = ZendureCloudMqttTransport(self.data, session_factory=self.factory)
         await transport.async_start()
         self.assertEqual(transport.state, ConnectionState.CONNECTED)
-        self.assertEqual(self.sessions[0].subscriptions, ("/product-a/main-1/#", "/product-b/main-2/#"))
+        self.assertEqual(
+            self.sessions[0].subscriptions,
+            (
+                "/product-a/main-1/#",
+                "/product-b/main-2/#",
+                "iot/product-a/main-1/#",
+                "iot/product-b/main-2/#",
+            ),
+        )
         await transport.async_stop()
         self.assertTrue(self.sessions[0].disconnected)
 
@@ -134,6 +144,31 @@ class CloudMqttTransportTests(unittest.IsolatedAsyncioTestCase):
         transport = ZendureCloudMqttTransport(data, session_factory=self.factory)
         with self.assertRaisesRegex(Exception, "no_routable_devices"):
             await transport.async_start()
+
+    def test_schema_free_port_1883_is_plain_mqtt(self):
+        self.assertEqual(
+            _parse_broker_url("broker.example:1883"),
+            ("broker.example", 1883, False),
+        )
+
+    def test_tls_requires_an_explicit_secure_scheme(self):
+        self.assertEqual(
+            _parse_broker_url("mqtts://broker.example:8883"),
+            ("broker.example", 8883, True),
+        )
+        self.assertEqual(
+            _parse_broker_url("mqtt://broker.example:1883"),
+            ("broker.example", 1883, False),
+        )
+
+    def test_paho_uses_zendure_cloud_mqtt_31_protocol(self):
+        source = (
+            Path(__file__).resolve().parents[1]
+            / "custom_components"
+            / "battery_smartflow_ai"
+            / "zendure_cloud_mqtt.py"
+        ).read_text(encoding="utf-8")
+        self.assertIn("protocol=mqtt.MQTTv31", source)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- treat Zendure broker addresses without a URI scheme as plain MQTT instead of forcing TLS
- use the MQTT 3.1 protocol expected by the Zendure Cloud broker
- subscribe read-only to both Zendure Cloud topic families
- retain explicit TLS support for mqtts and ssl endpoints
- bump the development build to 5.0.0-dev2

## Field-test evidence

The first real V5 test successfully validated the App Token and discovered a SolarFlow 2400 AC, but initial sync ended with connection_timeout and no MQTT messages. The returned broker uses port 1883 without a URI scheme. The official Zendure-HA implementation connects that form as plain MQTT with MQTT 3.1 and subscribes both /product/device/# and iot/product/device/#.

The reported zero packs are a consequence of the missing MQTT telemetry: this SF2400AC device-list record contains neither packData nor packNum, so pack identities can only appear after MQTT reports arrive.

## Safety

This remains strictly subscriber-only. No publish, command or native hardware-write surface is added; Z-HA remains the only active control path.

## Validation

- 465 unit and regression tests passed
- syntax compilation passed
- schema-free 1883, explicit TLS, MQTT 3.1 and both topic families covered by regression tests
- git diff check passed

Closes #375