### PR TITLE
V5.0.0-dev3: align Paho Cloud session with Zendure HA

### DIFF
--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -38,7 +38,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "5.0.0-dev2"
+INTEGRATION_VERSION = "5.0.0-dev3"
 
 # V5 native Zendure discovery is observation-only in the first development
 # build. The App Token is account discovery material and must never be copied

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": ["paho-mqtt==2.1.0"],
-  "version": "5.0.0-dev2"
+  "version": "5.0.0-dev3"
 }

--- a/custom_components/battery_smartflow_ai/zendure_cloud_mqtt.py
+++ b/custom_components/battery_smartflow_ai/zendure_cloud_mqtt.py
@@ -174,7 +174,7 @@ class ZendureCloudMqttTransport:
         self._stopping = False
         self._connected.clear()
         self._state = ConnectionState.CONNECTING
-        self._open_session()
+        await self._open_session()
         try:
             await asyncio.wait_for(self._connected.wait(), timeout=timeout)
         except TimeoutError:
@@ -195,16 +195,21 @@ class ZendureCloudMqttTransport:
                 pass
         session, self._session = self._session, None
         if session is not None:
-            session.disconnect()
+            try:
+                await asyncio.to_thread(session.disconnect)
+            except Exception:
+                _LOGGER.warning("Zendure Cloud MQTT cleanup failed")
         self._connected.clear()
         self._state = ConnectionState.STOPPED
 
-    def _open_session(self) -> None:
+    async def _open_session(self) -> None:
         self._session_number += 1
         session = self._session_factory(self._bootstrap.mqtt)
         session.set_callbacks(self._on_connect, self._on_disconnect, self._on_message)
         self._session = session
-        session.connect()
+        # Zendure-HA establishes its Cloud connection with paho's synchronous
+        # connect call. Run that DNS/TCP operation outside HA's event loop.
+        await asyncio.to_thread(session.connect)
 
     def _threadsafe(self, callback: Callable[..., None], *args: Any) -> None:
         if self._loop is not None:
@@ -261,9 +266,12 @@ class ZendureCloudMqttTransport:
             self._connected.clear()
             old, self._session = self._session, None
             if old is not None:
-                old.disconnect()
+                try:
+                    await asyncio.to_thread(old.disconnect)
+                except Exception:
+                    _LOGGER.warning("Zendure Cloud MQTT reconnect cleanup failed")
             try:
-                self._open_session()
+                await self._open_session()
                 await asyncio.wait_for(self._connected.wait(), timeout=15.0)
                 return
             except Exception as error:  # backend errors are sanitized before logging
@@ -400,7 +408,7 @@ class PahoReadOnlyMqttSession:
         self._client.on_message = self._paho_message
 
     def connect(self) -> None:
-        self._client.connect_async(self._host, self._port, keepalive=60)
+        self._client.connect(self._host, self._port, keepalive=60)
         self._client.loop_start()
 
     def subscribe(self, topics: tuple[str, ...]) -> None:
@@ -410,8 +418,10 @@ class PahoReadOnlyMqttSession:
                 raise CloudMqttError("subscribe_failed")
 
     def disconnect(self) -> None:
-        self._client.disconnect()
-        self._client.loop_stop()
+        try:
+            self._client.disconnect()
+        finally:
+            self._client.loop_stop()
 
     def _paho_connect(
         self,

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -13,7 +13,7 @@ COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
 
 
 class DebugIntegrationContractTests(unittest.TestCase):
-    def test_manifest_and_runtime_version_match_v5_dev2_release(self) -> None:
+    def test_manifest_and_runtime_version_match_v5_dev3_release(self) -> None:
         manifest_version = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )["version"]
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "5.0.0-dev2")
+        self.assertEqual(manifest_version, "5.0.0-dev3")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_native_zendure_ha_integration.py
+++ b/tests/test_native_zendure_ha_integration.py
@@ -17,7 +17,7 @@ class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
         manifest = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )
-        self.assertEqual(manifest["version"], "5.0.0-dev2")
+        self.assertEqual(manifest["version"], "5.0.0-dev3")
         self.assertIn("paho-mqtt==2.1.0", manifest["requirements"])
 
     def test_options_flow_uses_a_password_field_and_never_suggests_token(self) -> None:

--- a/tests/test_zendure_cloud_mqtt.py
+++ b/tests/test_zendure_cloud_mqtt.py
@@ -49,6 +49,15 @@ class FakeSession:
     def drop(self): self.on_disconnect("network lost")
 
 
+class HangingSession(FakeSession):
+    def connect(self):
+        return None
+
+    def disconnect(self):
+        self.disconnected = True
+        raise RuntimeError("not connected")
+
+
 class CloudMqttTransportTests(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
         self.sessions = []
@@ -144,6 +153,17 @@ class CloudMqttTransportTests(unittest.IsolatedAsyncioTestCase):
         transport = ZendureCloudMqttTransport(data, session_factory=self.factory)
         with self.assertRaisesRegex(Exception, "no_routable_devices"):
             await transport.async_start()
+
+    async def test_cleanup_failure_does_not_mask_connection_timeout(self):
+        session = HangingSession(None)
+        transport = ZendureCloudMqttTransport(
+            self.data,
+            session_factory=lambda _credentials: session,
+        )
+        with self.assertRaisesRegex(Exception, "connection_timeout"):
+            await transport.async_start(timeout=0.01)
+        self.assertEqual(transport.state, ConnectionState.STOPPED)
+        self.assertTrue(session.disconnected)
 
     def test_schema_free_port_1883_is_plain_mqtt(self):
         self.assertEqual(


### PR DESCRIPTION
## Summary

- establish the Paho Cloud connection synchronously like the official Zendure-HA implementation
- move the blocking DNS/TCP connect operation off the Home Assistant event loop
- start the Paho network loop after the TCP connection has been established
- make disconnect and reconnect cleanup exception-safe
- preserve the original connection timeout instead of replacing it with a generic cleanup failure
- bump the development build to 5.0.0-dev3

## Field-test evidence

Dev2 still discovered the SolarFlow 2400 AC successfully. Initial sync then spent exactly 15 seconds in connecting and reported mqtt_connect_failed, while the final connection state remained connecting. This proves the timeout path was entered and a cleanup exception masked the original connection_timeout. The official Zendure-HA adapter uses paho connect rather than connect_async for this Cloud broker.

## Safety

The transport remains strictly subscriber-only. No publish, command, or native hardware-write surface is added. Z-HA remains the sole active control path.

## Validation

- 466 unit and regression tests passed
- explicit regression verifies cleanup failure cannot mask connection_timeout
- syntax compilation and diff checks passed
- all privacy, initial-sync, MQTT read-only and V4.7 regression contracts remain green

Closes #377