### PR TITLE
Fix safe-idle startup in V5 dev4

### DIFF
--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -38,7 +38,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "5.0.0-dev3"
+INTEGRATION_VERSION = "5.0.0-dev4"
 
 # V5 native Zendure discovery is observation-only in the first development
 # build. The App Token is account discovery material and must never be copied

--- a/custom_components/battery_smartflow_ai/coordinator.py
+++ b/custom_components/battery_smartflow_ai/coordinator.py
@@ -99,6 +99,7 @@ from .const import (
     # statuses
     STATUS_OK,
     STATUS_SENSOR_INVALID,
+    AI_STATUS_STANDBY,
     RECO_STANDBY,
     RECO_CHARGE,
     RECO_DISCHARGE,

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": ["paho-mqtt==2.1.0"],
-  "version": "5.0.0-dev3"
+  "version": "5.0.0-dev4"
 }

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -13,7 +13,7 @@ COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
 
 
 class DebugIntegrationContractTests(unittest.TestCase):
-    def test_manifest_and_runtime_version_match_v5_dev3_release(self) -> None:
+    def test_manifest_and_runtime_version_match_v5_dev4_release(self) -> None:
         manifest_version = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )["version"]
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "5.0.0-dev3")
+        self.assertEqual(manifest_version, "5.0.0-dev4")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_native_zendure_ha_integration.py
+++ b/tests/test_native_zendure_ha_integration.py
@@ -17,7 +17,7 @@ class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
         manifest = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )
-        self.assertEqual(manifest["version"], "5.0.0-dev3")
+        self.assertEqual(manifest["version"], "5.0.0-dev4")
         self.assertIn("paho-mqtt==2.1.0", manifest["requirements"])
 
     def test_options_flow_uses_a_password_field_and_never_suggests_token(self) -> None:


### PR DESCRIPTION
## Summary

- import the existing \AI_STATUS_STANDBY\ constant used by the coordinator's safe-idle path
- prevent setup reloads from failing when required sensors are temporarily unavailable
- bump the prerelease version to \5.0.0-dev4\`n
## Scope

This is deliberately a narrow startup regression fix. It does not change decisions, device control, or the Cloud MQTT transport. The separate MQTT compatibility diagnostics remain tracked in #379.

## Validation

- 466 unit tests pass
- Python bytecode compilation passes
- \git diff --check\ passes

Closes #380