### PR TITLE
Add Cloud MQTT 5 diagnostics for V5 dev5

### DIFF
--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -38,7 +38,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "5.0.0-dev4"
+INTEGRATION_VERSION = "5.0.0-dev5"
 
 # V5 native Zendure discovery is observation-only in the first development
 # build. The App Token is account discovery material and must never be copied

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": ["paho-mqtt==2.1.0"],
-  "version": "5.0.0-dev4"
+  "version": "5.0.0-dev5"
 }

--- a/custom_components/battery_smartflow_ai/zendure_cloud_mqtt.py
+++ b/custom_components/battery_smartflow_ai/zendure_cloud_mqtt.py
@@ -90,6 +90,9 @@ class ReadOnlyMqttSession(Protocol):
 
     def disconnect(self) -> None: ...
 
+    @property
+    def connection_phase(self) -> str: ...
+
 
 SessionFactory = Callable[[CloudMqttCredentials], ReadOnlyMqttSession]
 
@@ -119,6 +122,7 @@ class ZendureCloudMqttTransport:
         self._reconnect_task: asyncio.Task[None] | None = None
         self._session_number = 0
         self._last_message_at: datetime | None = None
+        self._last_connection_phase = "not_started"
         self._devices = {
             item.candidate.candidate_id: CloudMqttDeviceState(
                 online=item.online
@@ -148,6 +152,22 @@ class ZendureCloudMqttTransport:
     @property
     def device_states(self) -> Mapping[str, CloudMqttDeviceState]:
         return dict(self._devices)
+
+    @property
+    def connection_variant(self) -> str:
+        """Return a safe identifier for the currently tested Cloud dialect."""
+
+        return "mqtt5_clean"
+
+    @property
+    def connection_phase(self) -> str:
+        """Return the furthest privacy-safe connection phase observed."""
+
+        if self._session is not None:
+            return str(
+                getattr(self._session, "connection_phase", self._last_connection_phase)
+            )
+        return self._last_connection_phase
 
     @property
     def topics(self) -> tuple[str, ...]:
@@ -195,6 +215,9 @@ class ZendureCloudMqttTransport:
                 pass
         session, self._session = self._session, None
         if session is not None:
+            self._last_connection_phase = str(
+                getattr(session, "connection_phase", self._last_connection_phase)
+            )
             try:
                 await asyncio.to_thread(session.disconnect)
             except Exception:
@@ -382,10 +405,11 @@ class PahoReadOnlyMqttSession:
             raise CloudMqttError("mqtt_dependency_missing") from error
 
         self._host, self._port, self._tls = _parse_broker_url(credentials.url)
+        self._connection_phase = "created"
         self._client = mqtt.Client(
             mqtt.CallbackAPIVersion.VERSION2,
             client_id=credentials.client_id,
-            protocol=mqtt.MQTTv31,
+            protocol=mqtt.MQTTv5,
         )
         self._client.username_pw_set(credentials.username, credentials.password)
         if self._tls:
@@ -393,6 +417,10 @@ class PahoReadOnlyMqttSession:
         self._on_connect: ConnectCallback | None = None
         self._on_disconnect: DisconnectCallback | None = None
         self._on_message: MessageCallback | None = None
+
+    @property
+    def connection_phase(self) -> str:
+        return self._connection_phase
 
     def set_callbacks(
         self,
@@ -406,9 +434,11 @@ class PahoReadOnlyMqttSession:
         self._client.on_connect = self._paho_connect
         self._client.on_disconnect = self._paho_disconnect
         self._client.on_message = self._paho_message
+        self._client.on_socket_open = self._paho_socket_open
 
     def connect(self) -> None:
-        self._client.connect(self._host, self._port, keepalive=60)
+        self._connection_phase = "dns_or_tcp_connect"
+        self._client.connect_async(self._host, self._port, keepalive=60)
         self._client.loop_start()
 
     def subscribe(self, topics: tuple[str, ...]) -> None:
@@ -431,9 +461,15 @@ class PahoReadOnlyMqttSession:
         reason_code: Any,
         _properties: Any,
     ) -> None:
+        self._connection_phase = (
+            "mqtt_connack_accepted" if int(reason_code) == 0 else "mqtt_connack_rejected"
+        )
         if self._on_connect is not None:
             successful = int(reason_code) == 0
             self._on_connect(successful, None if successful else str(reason_code))
+
+    def _paho_socket_open(self, _client: Any, _userdata: Any, _socket: Any) -> None:
+        self._connection_phase = "tcp_connected_waiting_for_mqtt_connack"
 
     def _paho_disconnect(
         self,

--- a/custom_components/battery_smartflow_ai/zendure_initial_sync.py
+++ b/custom_components/battery_smartflow_ai/zendure_initial_sync.py
@@ -108,7 +108,7 @@ class ZendureInitialSyncRecorder:
         self._seen_devices: set[str] = set()
         self._messages: list[CloudMqttMessage] = []
         self._connection_events: list[dict[str, Any]] = []
-        self._last_state: ConnectionState | None = None
+        self._last_connection_signature: tuple[ConnectionState, str, str] | None = None
         self._expected_devices = tuple(
             sorted(
                 item.candidate.candidate_id
@@ -117,12 +117,24 @@ class ZendureInitialSyncRecorder:
             )
         )
 
-    def observe_connection(self, state: ConnectionState) -> None:
-        if state == self._last_state:
+    def observe_connection(
+        self,
+        state: ConnectionState,
+        *,
+        variant: str = "unknown",
+        phase: str = "unknown",
+    ) -> None:
+        signature = (state, variant, phase)
+        if signature == self._last_connection_signature:
             return
-        self._last_state = state
+        self._last_connection_signature = signature
         self._connection_events.append(
-            {"timestamp": _iso(self._clock()), "state": state.value}
+            {
+                "timestamp": _iso(self._clock()),
+                "state": state.value,
+                "variant": variant,
+                "phase": phase,
+            }
         )
 
     def observe_message(self, message: CloudMqttMessage) -> None:
@@ -189,18 +201,25 @@ async def async_capture_initial_sync(
         monotonic=monotonic,
     )
     cursor = 0
-    recorder.observe_connection(transport.state)
+    def observe_transport() -> None:
+        recorder.observe_connection(
+            transport.state,
+            variant=str(getattr(transport, "connection_variant", "unknown")),
+            phase=str(getattr(transport, "connection_phase", "unknown")),
+        )
+
+    observe_transport()
     try:
         await transport.async_start(timeout=min(15.0, hard_timeout))
     except Exception as error:
-        recorder.observe_connection(transport.state)
+        observe_transport()
         return recorder.finish(
             complete=False,
             reason=_safe_failure_reason(error),
         )
 
     while True:
-        recorder.observe_connection(transport.state)
+        observe_transport()
         messages = transport.messages
         for message in messages[cursor:]:
             recorder.observe_message(message)

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -13,7 +13,7 @@ COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
 
 
 class DebugIntegrationContractTests(unittest.TestCase):
-    def test_manifest_and_runtime_version_match_v5_dev4_release(self) -> None:
+    def test_manifest_and_runtime_version_match_v5_dev5_release(self) -> None:
         manifest_version = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )["version"]
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "5.0.0-dev4")
+        self.assertEqual(manifest_version, "5.0.0-dev5")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_native_zendure_ha_integration.py
+++ b/tests/test_native_zendure_ha_integration.py
@@ -17,7 +17,7 @@ class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
         manifest = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )
-        self.assertEqual(manifest["version"], "5.0.0-dev4")
+        self.assertEqual(manifest["version"], "5.0.0-dev5")
         self.assertIn("paho-mqtt==2.1.0", manifest["requirements"])
 
     def test_options_flow_uses_a_password_field_and_never_suggests_token(self) -> None:

--- a/tests/test_zendure_cloud_mqtt.py
+++ b/tests/test_zendure_cloud_mqtt.py
@@ -164,6 +164,22 @@ class CloudMqttTransportTests(unittest.IsolatedAsyncioTestCase):
             await transport.async_start(timeout=0.01)
         self.assertEqual(transport.state, ConnectionState.STOPPED)
         self.assertTrue(session.disconnected)
+        self.assertEqual(transport.connection_variant, "mqtt5_clean")
+
+    async def test_connection_phase_is_retained_after_timeout_cleanup(self):
+        class PhasedHangingSession(HangingSession):
+            connection_phase = "tcp_connected_waiting_for_mqtt_connack"
+
+        transport = ZendureCloudMqttTransport(
+            self.data,
+            session_factory=lambda _credentials: PhasedHangingSession(None),
+        )
+        with self.assertRaisesRegex(Exception, "connection_timeout"):
+            await transport.async_start(timeout=0.01)
+        self.assertEqual(
+            transport.connection_phase,
+            "tcp_connected_waiting_for_mqtt_connack",
+        )
 
     def test_schema_free_port_1883_is_plain_mqtt(self):
         self.assertEqual(
@@ -181,14 +197,15 @@ class CloudMqttTransportTests(unittest.IsolatedAsyncioTestCase):
             ("broker.example", 1883, False),
         )
 
-    def test_paho_uses_zendure_cloud_mqtt_31_protocol(self):
+    def test_paho_uses_io_broker_compatible_mqtt_5_protocol(self):
         source = (
             Path(__file__).resolve().parents[1]
             / "custom_components"
             / "battery_smartflow_ai"
             / "zendure_cloud_mqtt.py"
         ).read_text(encoding="utf-8")
-        self.assertIn("protocol=mqtt.MQTTv31", source)
+        self.assertIn("protocol=mqtt.MQTTv5", source)
+        self.assertIn("connect_async", source)
 
 
 if __name__ == "__main__":

--- a/tests/test_zendure_initial_sync.py
+++ b/tests/test_zendure_initial_sync.py
@@ -330,6 +330,8 @@ class InitialSyncCaptureTests(unittest.IsolatedAsyncioTestCase):
         class FailedTransport:
             state = ConnectionState.DISCONNECTED
             messages = ()
+            connection_variant = "mqtt5_clean"
+            connection_phase = "dns_or_tcp_connect"
 
             async def async_start(self, *, timeout):
                 raise RuntimeError("mqtt-user-secret")
@@ -343,6 +345,14 @@ class InitialSyncCaptureTests(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(result.complete)
         self.assertEqual(result.completion_reason, "mqtt_connect_failed")
         self.assertNotIn("mqtt-user-secret", json.dumps(result.as_dict()))
+        self.assertEqual(
+            result.connection_events[-1]["phase"],
+            "dns_or_tcp_connect",
+        )
+        self.assertEqual(
+            result.connection_events[-1]["variant"],
+            "mqtt5_clean",
+        )
 
     async def test_orchestrator_completes_after_real_quiet_period(self):
         messages = (


### PR DESCRIPTION
## Summary

- test the MQTT 5 clean-session Cloud dialect used by the production ioBroker Zendure adapter after DEV2/DEV3 both timed out with MQTT 3.1
- use non-blocking Paho connection startup
- record privacy-safe connection variant and phase details in the initial-sync export
- retain the furthest phase after timeout cleanup
- bump the prerelease version to 5.0.0-dev5

## Diagnostic phases

The export can now distinguish:

- DNS or TCP connection pending
- TCP connected while waiting for MQTT CONNACK
- MQTT CONNACK accepted
- MQTT CONNACK rejected

No broker host, credential, client ID, publish method, or command API is exposed.

## Validation

- 467 unit tests pass
- Python compilation passes
- git diff check passes

Closes #379