### PR TITLE
Match Zendure HA Cloud MQTT session in V5 dev6

### DIFF
--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -38,7 +38,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "5.0.0-dev5"
+INTEGRATION_VERSION = "5.0.0-dev6"
 
 # V5 native Zendure discovery is observation-only in the first development
 # build. The App Token is account discovery material and must never be copied

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": ["paho-mqtt==2.1.0"],
-  "version": "5.0.0-dev5"
+  "version": "5.0.0-dev6"
 }

--- a/custom_components/battery_smartflow_ai/zendure_cloud_mqtt.py
+++ b/custom_components/battery_smartflow_ai/zendure_cloud_mqtt.py
@@ -157,7 +157,7 @@ class ZendureCloudMqttTransport:
     def connection_variant(self) -> str:
         """Return a safe identifier for the currently tested Cloud dialect."""
 
-        return "mqtt5_clean"
+        return "mqtt31_persistent"
 
     @property
     def connection_phase(self) -> str:
@@ -409,7 +409,8 @@ class PahoReadOnlyMqttSession:
         self._client = mqtt.Client(
             mqtt.CallbackAPIVersion.VERSION2,
             client_id=credentials.client_id,
-            protocol=mqtt.MQTTv5,
+            clean_session=False,
+            protocol=mqtt.MQTTv31,
         )
         self._client.username_pw_set(credentials.username, credentials.password)
         if self._tls:

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -13,7 +13,7 @@ COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
 
 
 class DebugIntegrationContractTests(unittest.TestCase):
-    def test_manifest_and_runtime_version_match_v5_dev5_release(self) -> None:
+    def test_manifest_and_runtime_version_match_v5_dev6_release(self) -> None:
         manifest_version = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )["version"]
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "5.0.0-dev5")
+        self.assertEqual(manifest_version, "5.0.0-dev6")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_native_zendure_ha_integration.py
+++ b/tests/test_native_zendure_ha_integration.py
@@ -17,7 +17,7 @@ class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
         manifest = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )
-        self.assertEqual(manifest["version"], "5.0.0-dev5")
+        self.assertEqual(manifest["version"], "5.0.0-dev6")
         self.assertIn("paho-mqtt==2.1.0", manifest["requirements"])
 
     def test_options_flow_uses_a_password_field_and_never_suggests_token(self) -> None:

--- a/tests/test_zendure_cloud_mqtt.py
+++ b/tests/test_zendure_cloud_mqtt.py
@@ -164,7 +164,7 @@ class CloudMqttTransportTests(unittest.IsolatedAsyncioTestCase):
             await transport.async_start(timeout=0.01)
         self.assertEqual(transport.state, ConnectionState.STOPPED)
         self.assertTrue(session.disconnected)
-        self.assertEqual(transport.connection_variant, "mqtt5_clean")
+        self.assertEqual(transport.connection_variant, "mqtt31_persistent")
 
     async def test_connection_phase_is_retained_after_timeout_cleanup(self):
         class PhasedHangingSession(HangingSession):
@@ -197,14 +197,15 @@ class CloudMqttTransportTests(unittest.IsolatedAsyncioTestCase):
             ("broker.example", 1883, False),
         )
 
-    def test_paho_uses_io_broker_compatible_mqtt_5_protocol(self):
+    def test_paho_uses_zendure_ha_mqtt_31_persistent_session(self):
         source = (
             Path(__file__).resolve().parents[1]
             / "custom_components"
             / "battery_smartflow_ai"
             / "zendure_cloud_mqtt.py"
         ).read_text(encoding="utf-8")
-        self.assertIn("protocol=mqtt.MQTTv5", source)
+        self.assertIn("protocol=mqtt.MQTTv31", source)
+        self.assertIn("clean_session=False", source)
         self.assertIn("connect_async", source)
 
 

--- a/tests/test_zendure_initial_sync.py
+++ b/tests/test_zendure_initial_sync.py
@@ -330,7 +330,7 @@ class InitialSyncCaptureTests(unittest.IsolatedAsyncioTestCase):
         class FailedTransport:
             state = ConnectionState.DISCONNECTED
             messages = ()
-            connection_variant = "mqtt5_clean"
+            connection_variant = "mqtt31_persistent"
             connection_phase = "dns_or_tcp_connect"
 
             async def async_start(self, *, timeout):
@@ -351,7 +351,7 @@ class InitialSyncCaptureTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(
             result.connection_events[-1]["variant"],
-            "mqtt5_clean",
+            "mqtt31_persistent",
         )
 
     async def test_orchestrator_completes_after_real_quiet_period(self):


### PR DESCRIPTION
## Summary

- reproduce the official Zendure-HA Cloud MQTT client parameters exactly: MQTT 3.1 with a persistent session
- retain DEV5's asynchronous connection startup and privacy-safe phase diagnostics
- retain the original Zendure-provided client ID for the isolated compatibility test
- bump the prerelease version to 5.0.0-dev6

## Evidence

The real DEV5 capture reached TCP successfully but received no MQTT CONNACK for MQTT 5 with a clean session. Earlier MQTT 3.1 builds did not set Zendure-HA's explicit persistent-session flag, so this exact combination has not yet been field-tested.

## Safety

The transport remains strictly read-only and exposes neither publish nor command APIs.

## Validation

- 467 unit tests pass
- Python compilation passes
- git diff check passes

Closes #383