### PR TITLE
Add privacy-safe Cloud wire diagnostics for V5 dev7

### DIFF
--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -38,7 +38,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "5.0.0-dev6"
+INTEGRATION_VERSION = "5.0.0-dev7"
 
 # V5 native Zendure discovery is observation-only in the first development
 # build. The App Token is account discovery material and must never be copied

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": ["paho-mqtt==2.1.0"],
-  "version": "5.0.0-dev6"
+  "version": "5.0.0-dev7"
 }

--- a/custom_components/battery_smartflow_ai/zendure_cloud_mqtt.py
+++ b/custom_components/battery_smartflow_ai/zendure_cloud_mqtt.py
@@ -12,9 +12,11 @@ from collections import deque
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import StrEnum
+import ipaddress
 import json
 import logging
 import random
+import socket
 import ssl
 from typing import Any, Callable, Mapping, Protocol
 from urllib.parse import urlsplit
@@ -93,6 +95,9 @@ class ReadOnlyMqttSession(Protocol):
     @property
     def connection_phase(self) -> str: ...
 
+    @property
+    def connection_diagnostics(self) -> Mapping[str, str | bool]: ...
+
 
 SessionFactory = Callable[[CloudMqttCredentials], ReadOnlyMqttSession]
 
@@ -123,6 +128,13 @@ class ZendureCloudMqttTransport:
         self._session_number = 0
         self._last_message_at: datetime | None = None
         self._last_connection_phase = "not_started"
+        self._last_connection_diagnostics: dict[str, str | bool] = {
+            "credential_source": "cloud_mqtt_block",
+            "transport_security": "unknown",
+            "endpoint_scope": "unknown",
+            "socket_family": "unknown",
+            "connect_packet_sent": False,
+        }
         self._devices = {
             item.candidate.candidate_id: CloudMqttDeviceState(
                 online=item.online
@@ -168,6 +180,16 @@ class ZendureCloudMqttTransport:
                 getattr(self._session, "connection_phase", self._last_connection_phase)
             )
         return self._last_connection_phase
+
+    @property
+    def connection_diagnostics(self) -> Mapping[str, str | bool]:
+        """Return only allow-listed, non-identifying connection facts."""
+
+        if self._session is not None:
+            value = getattr(self._session, "connection_diagnostics", None)
+            if isinstance(value, Mapping):
+                return dict(value)
+        return dict(self._last_connection_diagnostics)
 
     @property
     def topics(self) -> tuple[str, ...]:
@@ -218,6 +240,9 @@ class ZendureCloudMqttTransport:
             self._last_connection_phase = str(
                 getattr(session, "connection_phase", self._last_connection_phase)
             )
+            value = getattr(session, "connection_diagnostics", None)
+            if isinstance(value, Mapping):
+                self._last_connection_diagnostics = dict(value)
             try:
                 await asyncio.to_thread(session.disconnect)
             except Exception:
@@ -230,8 +255,9 @@ class ZendureCloudMqttTransport:
         session = self._session_factory(self._bootstrap.mqtt)
         session.set_callbacks(self._on_connect, self._on_disconnect, self._on_message)
         self._session = session
-        # Zendure-HA establishes its Cloud connection with paho's synchronous
-        # connect call. Run that DNS/TCP operation outside HA's event loop.
+        # The production backend starts Paho's non-blocking network loop here.
+        # A custom backend may still perform blocking setup, so retain the
+        # thread boundary to protect Home Assistant's event loop.
         await asyncio.to_thread(session.connect)
 
     def _threadsafe(self, callback: Callable[..., None], *args: Any) -> None:
@@ -406,6 +432,9 @@ class PahoReadOnlyMqttSession:
 
         self._host, self._port, self._tls = _parse_broker_url(credentials.url)
         self._connection_phase = "created"
+        self._endpoint_scope = "unknown"
+        self._socket_family = "unknown"
+        self._connect_packet_sent = False
         self._client = mqtt.Client(
             mqtt.CallbackAPIVersion.VERSION2,
             client_id=credentials.client_id,
@@ -423,6 +452,16 @@ class PahoReadOnlyMqttSession:
     def connection_phase(self) -> str:
         return self._connection_phase
 
+    @property
+    def connection_diagnostics(self) -> Mapping[str, str | bool]:
+        return {
+            "credential_source": "cloud_mqtt_block",
+            "transport_security": "tls" if self._tls else "plain",
+            "endpoint_scope": self._endpoint_scope,
+            "socket_family": self._socket_family,
+            "connect_packet_sent": self._connect_packet_sent,
+        }
+
     def set_callbacks(
         self,
         on_connect: ConnectCallback,
@@ -436,6 +475,8 @@ class PahoReadOnlyMqttSession:
         self._client.on_disconnect = self._paho_disconnect
         self._client.on_message = self._paho_message
         self._client.on_socket_open = self._paho_socket_open
+        self._client.on_socket_register_write = self._paho_register_write
+        self._client.on_socket_unregister_write = self._paho_unregister_write
 
     def connect(self) -> None:
         self._connection_phase = "dns_or_tcp_connect"
@@ -469,8 +510,22 @@ class PahoReadOnlyMqttSession:
             successful = int(reason_code) == 0
             self._on_connect(successful, None if successful else str(reason_code))
 
-    def _paho_socket_open(self, _client: Any, _userdata: Any, _socket: Any) -> None:
+    def _paho_socket_open(self, _client: Any, _userdata: Any, mqtt_socket: Any) -> None:
+        self._socket_family = _safe_socket_family(mqtt_socket)
+        self._endpoint_scope = _safe_peer_scope(mqtt_socket)
         self._connection_phase = "tcp_connected_waiting_for_mqtt_connack"
+
+    def _paho_register_write(self, _client: Any, _userdata: Any, _socket: Any) -> None:
+        if self._connection_phase.startswith("tcp_connected"):
+            self._connection_phase = "mqtt_connect_queued"
+
+    def _paho_unregister_write(self, _client: Any, _userdata: Any, _socket: Any) -> None:
+        if self._connection_phase in {
+            "tcp_connected_waiting_for_mqtt_connack",
+            "mqtt_connect_queued",
+        }:
+            self._connect_packet_sent = True
+            self._connection_phase = "mqtt_connect_sent_waiting_for_connack"
 
     def _paho_disconnect(
         self,
@@ -486,6 +541,35 @@ class PahoReadOnlyMqttSession:
     def _paho_message(self, _client: Any, _userdata: Any, message: Any) -> None:
         if self._on_message is not None:
             self._on_message(str(message.topic), bytes(message.payload))
+
+
+def _safe_socket_family(mqtt_socket: Any) -> str:
+    """Classify a socket family without exporting an address."""
+
+    family = getattr(mqtt_socket, "family", None)
+    if family == socket.AF_INET:
+        return "ipv4"
+    if family == socket.AF_INET6:
+        return "ipv6"
+    return "other"
+
+
+def _safe_peer_scope(mqtt_socket: Any) -> str:
+    """Classify the connected peer without retaining its address."""
+
+    try:
+        peer = mqtt_socket.getpeername()
+        raw_address = peer[0] if isinstance(peer, tuple) and peer else peer
+        address = ipaddress.ip_address(str(raw_address).split("%", 1)[0])
+    except (OSError, TypeError, ValueError):
+        return "unknown"
+    if address.is_loopback:
+        return "loopback"
+    if address.is_private or address.is_link_local:
+        return "private"
+    if address.is_global:
+        return "public"
+    return "other"
 
 
 def _parse_broker_url(value: str) -> tuple[str, int, bool]:

--- a/custom_components/battery_smartflow_ai/zendure_initial_sync.py
+++ b/custom_components/battery_smartflow_ai/zendure_initial_sync.py
@@ -108,7 +108,7 @@ class ZendureInitialSyncRecorder:
         self._seen_devices: set[str] = set()
         self._messages: list[CloudMqttMessage] = []
         self._connection_events: list[dict[str, Any]] = []
-        self._last_connection_signature: tuple[ConnectionState, str, str] | None = None
+        self._last_connection_signature: tuple[Any, ...] | None = None
         self._expected_devices = tuple(
             sorted(
                 item.candidate.candidate_id
@@ -123,19 +123,20 @@ class ZendureInitialSyncRecorder:
         *,
         variant: str = "unknown",
         phase: str = "unknown",
+        diagnostics: Mapping[str, str | bool] | None = None,
     ) -> None:
-        signature = (state, variant, phase)
+        safe_diagnostics = dict(diagnostics or {})
+        signature = (state, variant, phase, tuple(sorted(safe_diagnostics.items())))
         if signature == self._last_connection_signature:
             return
         self._last_connection_signature = signature
-        self._connection_events.append(
-            {
-                "timestamp": _iso(self._clock()),
-                "state": state.value,
-                "variant": variant,
-                "phase": phase,
-            }
-        )
+        self._connection_events.append({
+            "timestamp": _iso(self._clock()),
+            "state": state.value,
+            "variant": variant,
+            "phase": phase,
+            **safe_diagnostics,
+        })
 
     def observe_message(self, message: CloudMqttMessage) -> None:
         """Record every message; only novel structure extends the quiet phase."""
@@ -206,6 +207,7 @@ async def async_capture_initial_sync(
             transport.state,
             variant=str(getattr(transport, "connection_variant", "unknown")),
             phase=str(getattr(transport, "connection_phase", "unknown")),
+            diagnostics=getattr(transport, "connection_diagnostics", None),
         )
 
     observe_transport()

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -13,7 +13,7 @@ COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
 
 
 class DebugIntegrationContractTests(unittest.TestCase):
-    def test_manifest_and_runtime_version_match_v5_dev6_release(self) -> None:
+    def test_manifest_and_runtime_version_match_v5_dev7_release(self) -> None:
         manifest_version = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )["version"]
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "5.0.0-dev6")
+        self.assertEqual(manifest_version, "5.0.0-dev7")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_native_zendure_ha_integration.py
+++ b/tests/test_native_zendure_ha_integration.py
@@ -17,7 +17,7 @@ class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
         manifest = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )
-        self.assertEqual(manifest["version"], "5.0.0-dev6")
+        self.assertEqual(manifest["version"], "5.0.0-dev7")
         self.assertIn("paho-mqtt==2.1.0", manifest["requirements"])
 
     def test_options_flow_uses_a_password_field_and_never_suggests_token(self) -> None:

--- a/tests/test_zendure_cloud_mqtt.py
+++ b/tests/test_zendure_cloud_mqtt.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 import inspect
 import json
 from pathlib import Path
+import socket
 import unittest
 
 from custom_components.battery_smartflow_ai.zendure_cloud import ZendureCloudClient
@@ -15,6 +16,8 @@ from custom_components.battery_smartflow_ai.zendure_cloud_mqtt import (
     ConnectionState,
     ZendureCloudMqttTransport,
     _parse_broker_url,
+    _safe_peer_scope,
+    _safe_socket_family,
 )
 
 
@@ -207,6 +210,31 @@ class CloudMqttTransportTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("protocol=mqtt.MQTTv31", source)
         self.assertIn("clean_session=False", source)
         self.assertIn("connect_async", source)
+
+    def test_socket_metadata_is_classified_without_retaining_addresses(self):
+        class FakeSocket:
+            family = socket.AF_INET
+
+            def getpeername(self):
+                return ("192.168.10.20", 1883)
+
+        mqtt_socket = FakeSocket()
+        self.assertEqual(_safe_socket_family(mqtt_socket), "ipv4")
+        self.assertEqual(_safe_peer_scope(mqtt_socket), "private")
+        self.assertNotIn("192.168.10.20", repr(_safe_peer_scope(mqtt_socket)))
+
+    def test_public_and_loopback_peers_are_distinguished(self):
+        class FakeSocket:
+            family = socket.AF_INET6
+
+            def __init__(self, address):
+                self.address = address
+
+            def getpeername(self):
+                return (self.address, 1883, 0, 0)
+
+        self.assertEqual(_safe_peer_scope(FakeSocket("2606:4700:4700::1111")), "public")
+        self.assertEqual(_safe_peer_scope(FakeSocket("::1")), "loopback")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- classify the connected MQTT peer without exporting its hostname or address
- report public/private/loopback scope, IPv4/IPv6, and plain/TLS transport
- distinguish socket-open, MQTT CONNECT queued, MQTT CONNECT sent, and CONNACK phases
- explicitly report that credentials originate from the global Cloud MQTT block
- retain the furthest diagnostic facts after timeout cleanup
- bump the prerelease version to 5.0.0-dev7

## Evidence

Real DEV5 and DEV6 captures both established TCP but received no MQTT CONNACK. The user's local Mosquitto log independently confirms that the SF2400AC Local-MQTT stream is a separate, working transport and does not contain BSFAI's Cloud attempt.

## Privacy and safety

The export contains categories only. It retains no hostname, IP address, client ID, username, password, publish surface, or command API. Native operation remains strictly read-only.

## Validation

- 469 unit tests pass
- Python compilation passes
- git diff check passes

Closes #385