### PR TITLE
V5.0.0 DEV8: Handle Paho ReasonCode callbacks

### DIFF
--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -38,7 +38,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "5.0.0-dev7"
+INTEGRATION_VERSION = "5.0.0-dev8"
 
 # V5 native Zendure discovery is observation-only in the first development
 # build. The App Token is account discovery material and must never be copied

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": ["paho-mqtt==2.1.0"],
-  "version": "5.0.0-dev7"
+  "version": "5.0.0-dev8"
 }

--- a/custom_components/battery_smartflow_ai/zendure_cloud_mqtt.py
+++ b/custom_components/battery_smartflow_ai/zendure_cloud_mqtt.py
@@ -503,11 +503,11 @@ class PahoReadOnlyMqttSession:
         reason_code: Any,
         _properties: Any,
     ) -> None:
+        successful = _reason_code_success(reason_code)
         self._connection_phase = (
-            "mqtt_connack_accepted" if int(reason_code) == 0 else "mqtt_connack_rejected"
+            "mqtt_connack_accepted" if successful else "mqtt_connack_rejected"
         )
         if self._on_connect is not None:
-            successful = int(reason_code) == 0
             self._on_connect(successful, None if successful else str(reason_code))
 
     def _paho_socket_open(self, _client: Any, _userdata: Any, mqtt_socket: Any) -> None:
@@ -536,7 +536,9 @@ class PahoReadOnlyMqttSession:
         _properties: Any,
     ) -> None:
         if self._on_disconnect is not None:
-            self._on_disconnect(None if int(reason_code) == 0 else str(reason_code))
+            self._on_disconnect(
+                None if _reason_code_success(reason_code) else str(reason_code)
+            )
 
     def _paho_message(self, _client: Any, _userdata: Any, message: Any) -> None:
         if self._on_message is not None:
@@ -552,6 +554,19 @@ def _safe_socket_family(mqtt_socket: Any) -> str:
     if family == socket.AF_INET6:
         return "ipv6"
     return "other"
+
+
+def _reason_code_success(reason_code: Any) -> bool:
+    """Handle Paho 2.x ReasonCode objects and legacy integer codes."""
+
+    is_failure = getattr(reason_code, "is_failure", None)
+    if isinstance(is_failure, bool):
+        return not is_failure
+    value = getattr(reason_code, "value", reason_code)
+    try:
+        return int(value) == 0
+    except (TypeError, ValueError):
+        return str(reason_code).strip().casefold() == "success"
 
 
 def _safe_peer_scope(mqtt_socket: Any) -> str:

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -13,7 +13,7 @@ COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
 
 
 class DebugIntegrationContractTests(unittest.TestCase):
-    def test_manifest_and_runtime_version_match_v5_dev7_release(self) -> None:
+    def test_manifest_and_runtime_version_match_v5_dev8_release(self) -> None:
         manifest_version = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )["version"]
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "5.0.0-dev7")
+        self.assertEqual(manifest_version, "5.0.0-dev8")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_native_zendure_ha_integration.py
+++ b/tests/test_native_zendure_ha_integration.py
@@ -17,7 +17,7 @@ class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
         manifest = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )
-        self.assertEqual(manifest["version"], "5.0.0-dev7")
+        self.assertEqual(manifest["version"], "5.0.0-dev8")
         self.assertIn("paho-mqtt==2.1.0", manifest["requirements"])
 
     def test_options_flow_uses_a_password_field_and_never_suggests_token(self) -> None:

--- a/tests/test_zendure_cloud_mqtt.py
+++ b/tests/test_zendure_cloud_mqtt.py
@@ -16,6 +16,7 @@ from custom_components.battery_smartflow_ai.zendure_cloud_mqtt import (
     ConnectionState,
     ZendureCloudMqttTransport,
     _parse_broker_url,
+    _reason_code_success,
     _safe_peer_scope,
     _safe_socket_family,
 )
@@ -235,6 +236,23 @@ class CloudMqttTransportTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(_safe_peer_scope(FakeSocket("2606:4700:4700::1111")), "public")
         self.assertEqual(_safe_peer_scope(FakeSocket("::1")), "loopback")
+
+    def test_paho_reason_code_objects_do_not_require_integer_conversion(self):
+        class ReasonCode:
+            def __init__(self, *, is_failure, value):
+                self.is_failure = is_failure
+                self.value = value
+
+            def __int__(self):
+                raise TypeError("ReasonCode is not directly integer-convertible")
+
+            def __str__(self):
+                return "Success" if not self.is_failure else "Not authorized"
+
+        self.assertTrue(_reason_code_success(ReasonCode(is_failure=False, value=0)))
+        self.assertFalse(_reason_code_success(ReasonCode(is_failure=True, value=135)))
+        self.assertTrue(_reason_code_success(0))
+        self.assertFalse(_reason_code_success(5))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- handle Paho 2.x ReasonCode objects without direct integer conversion
- apply the compatible success check to connect and disconnect callbacks
- add regression coverage for Paho-shaped reason codes and legacy integer codes
- bump the development version to 5.0.0-dev8

## Field evidence
Home Assistant's error log showed that the Zendure broker returned CONNACK successfully, but the Paho network thread crashed in _paho_connect while evaluating int(reason_code). This left the initial synchronization waiting until its timeout and could temporarily displace Z-HA when both clients used the same broker identity.

## Validation
- 15 focused Zendure Cloud MQTT tests
- 470 tests in the complete suite
- Python compilation
- git diff --check

The native connection remains strictly read-only.

Closes #387