### PR TITLE
V5.0.0 DEV9: Stabilize pack discovery and Z-HA coexistence

### DIFF
--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -38,7 +38,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "5.0.0-dev8"
+INTEGRATION_VERSION = "5.0.0-dev9"
 
 # V5 native Zendure discovery is observation-only in the first development
 # build. The App Token is account discovery material and must never be copied

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": ["paho-mqtt==2.1.0"],
-  "version": "5.0.0-dev8"
+  "version": "5.0.0-dev9"
 }

--- a/custom_components/battery_smartflow_ai/zendure_cloud_mqtt.py
+++ b/custom_components/battery_smartflow_ai/zendure_cloud_mqtt.py
@@ -12,6 +12,7 @@ from collections import deque
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import StrEnum
+import hashlib
 import ipaddress
 import json
 import logging
@@ -437,7 +438,7 @@ class PahoReadOnlyMqttSession:
         self._connect_packet_sent = False
         self._client = mqtt.Client(
             mqtt.CallbackAPIVersion.VERSION2,
-            client_id=credentials.client_id,
+            client_id=_bsfai_client_id(credentials.client_id),
             clean_session=False,
             protocol=mqtt.MQTTv31,
         )
@@ -567,6 +568,18 @@ def _reason_code_success(reason_code: Any) -> bool:
         return int(value) == 0
     except (TypeError, ValueError):
         return str(reason_code).strip().casefold() == "success"
+
+
+def _bsfai_client_id(cloud_client_id: str) -> str:
+    """Return a stable MQTT 3.1 ID distinct from Zendure-HA's identity.
+
+    MQTT 3.1 brokers may restrict client IDs to 23 characters.  Hashing the
+    account-provided ID keeps the BSFAI identity stable without exposing the
+    original identifier in the broker session name.
+    """
+
+    digest = hashlib.sha256(cloud_client_id.encode("utf-8")).hexdigest()[:16]
+    return f"bsfai-{digest}"
 
 
 def _safe_peer_scope(mqtt_socket: Any) -> str:

--- a/custom_components/battery_smartflow_ai/zendure_initial_sync.py
+++ b/custom_components/battery_smartflow_ai/zendure_initial_sync.py
@@ -311,6 +311,7 @@ def _build_summary(
             seen_devices.add(message.device_candidate_id)
         if message.pack_id:
             packs.add(message.pack_id)
+        packs.update(_payload_pack_ids(message.parsed_payload))
         topic = topics.setdefault(
             message.topic,
             {"updates": 0, "first_seen": _iso(message.received_at), "last_seen": None},
@@ -351,6 +352,28 @@ def _build_summary(
         "topics": topics,
         "properties": properties,
     }
+
+
+def _payload_pack_ids(value: Any) -> set[str]:
+    """Collect every stable pack identity embedded in a main-device report."""
+
+    if not isinstance(value, Mapping):
+        return set()
+    raw_packs = value.get("packData")
+    if not isinstance(raw_packs, list):
+        return set()
+    result: set[str] = set()
+    for raw_pack in raw_packs:
+        if not isinstance(raw_pack, Mapping):
+            continue
+        for key in ("sn", "packId", "packKey", "packSn", "packSN"):
+            raw_id = raw_pack.get(key)
+            if isinstance(raw_id, (str, int)) and not isinstance(raw_id, bool):
+                pack_id = str(raw_id).strip()
+                if pack_id:
+                    result.add(pack_id)
+                    break
+    return result
 
 
 def _property_items(value: Any, prefix: str = "") -> list[tuple[str, Any]]:

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -13,7 +13,7 @@ COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
 
 
 class DebugIntegrationContractTests(unittest.TestCase):
-    def test_manifest_and_runtime_version_match_v5_dev8_release(self) -> None:
+    def test_manifest_and_runtime_version_match_v5_dev9_release(self) -> None:
         manifest_version = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )["version"]
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "5.0.0-dev8")
+        self.assertEqual(manifest_version, "5.0.0-dev9")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_native_zendure_ha_integration.py
+++ b/tests/test_native_zendure_ha_integration.py
@@ -17,7 +17,7 @@ class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
         manifest = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )
-        self.assertEqual(manifest["version"], "5.0.0-dev8")
+        self.assertEqual(manifest["version"], "5.0.0-dev9")
         self.assertIn("paho-mqtt==2.1.0", manifest["requirements"])
 
     def test_options_flow_uses_a_password_field_and_never_suggests_token(self) -> None:

--- a/tests/test_zendure_cloud_mqtt.py
+++ b/tests/test_zendure_cloud_mqtt.py
@@ -15,6 +15,7 @@ from custom_components.battery_smartflow_ai.zendure_cloud import ZendureCloudCli
 from custom_components.battery_smartflow_ai.zendure_cloud_mqtt import (
     ConnectionState,
     ZendureCloudMqttTransport,
+    _bsfai_client_id,
     _parse_broker_url,
     _reason_code_success,
     _safe_peer_scope,
@@ -253,6 +254,20 @@ class CloudMqttTransportTests(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(_reason_code_success(ReasonCode(is_failure=True, value=135)))
         self.assertTrue(_reason_code_success(0))
         self.assertFalse(_reason_code_success(5))
+
+    def test_bsfai_uses_a_stable_private_mqtt31_client_identity(self):
+        first = _bsfai_client_id("zendure-cloud-client-secret")
+        second = _bsfai_client_id("zendure-cloud-client-secret")
+
+        self.assertEqual(first, second)
+        self.assertTrue(first.startswith("bsfai-"))
+        self.assertLessEqual(len(first), 23)
+        self.assertNotIn("zendure-cloud-client-secret", first)
+        self.assertNotEqual(first, "zendure-cloud-client-secret")
+        self.assertNotEqual(
+            first,
+            _bsfai_client_id("another-zendure-cloud-client"),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_zendure_initial_sync.py
+++ b/tests/test_zendure_initial_sync.py
@@ -244,6 +244,34 @@ class InitialSyncCaptureTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("futureUnknown", properties)
         self.assertEqual(properties["futureUnknown"]["types"], ["array"])
 
+    async def test_summary_collects_all_pack_ids_from_main_device_report(self):
+        recorder = self.recorder()
+        recorder.observe_message(
+            message(
+                self.time.clock(),
+                "cloud_mqtt:real-device-1",
+                "real-device-1",
+                {
+                    "properties": {"packNum": 2},
+                    "packData": [
+                        {"sn": "pack-b", "socLevel": 52},
+                        {"sn": "pack-a", "socLevel": 48},
+                    ],
+                },
+            )
+        )
+
+        summary = recorder.finish(complete=True, reason="test").as_dict()[
+            "bsfai_interpretation"
+        ]
+
+        pack_ids = summary["pack_ids"]
+        self.assertEqual(len(pack_ids), 2)
+        self.assertEqual(len(set(pack_ids)), 2)
+        self.assertTrue(all(item.startswith("ZD_SERIAL_A") for item in pack_ids))
+        self.assertNotIn("pack-a", pack_ids)
+        self.assertNotIn("pack-b", pack_ids)
+
     async def test_all_secrets_and_identities_are_consistently_sanitized(self):
         recorder = self.recorder()
         recorder.observe_message(


### PR DESCRIPTION
## Summary

- collect every stable pack identity from `packData[]` in the initial-sync summary
- keep multi-pack discovery independent of array order
- use a stable, pseudonymized BSFAI MQTT 3.1 client ID instead of reusing Zendure-HA's cloud client ID
- keep the client ID within the MQTT 3.1 23-character compatibility limit
- bump the development version to `5.0.0-dev9`

## Field evidence

The successful DEV8 field capture completed in 3.27 seconds and received 35 messages. Zendure reported `packNum: 2` and supplied two complete pack records with stable serial numbers, but the summary still returned an empty `pack_ids` list because it only considered the message-level pack ID.

The Zendure-HA reference implementation also confirms that Z-HA uses the account-provided cloud `clientId` unchanged. BSFAI previously reused the same value, allowing the two integrations to displace each other at the broker. DEV9 derives a separate deterministic BSFAI identity without exposing the original identifier.

## Validation

- 66 Zendure-focused tests
- 472 tests in the complete suite
- Python compilation
- `git diff --check`

The native Zendure connection remains strictly read-only.

Closes #389