### PR TITLE
V5.0.0 DEV10: Request current Zendure state with getAll

### DIFF
--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -38,7 +38,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "5.0.0-dev9"
+INTEGRATION_VERSION = "5.0.0-dev10"
 
 # V5 native Zendure discovery is observation-only in the first development
 # build. The App Token is account discovery material and must never be copied

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": ["paho-mqtt==2.1.0"],
-  "version": "5.0.0-dev9"
+  "version": "5.0.0-dev10"
 }

--- a/custom_components/battery_smartflow_ai/native_zendure_runtime.py
+++ b/custom_components/battery_smartflow_ai/native_zendure_runtime.py
@@ -259,6 +259,7 @@ def _safe_reason(error: Exception) -> str:
         "invalid_response", "no_devices", "no_mqtt_credentials",
         "connection_timeout", "invalid_broker_url", "mqtt_dependency_missing",
         "no_routable_devices", "subscribe_failed", "capture_write_failed",
+        "state_request_failed",
     }
     return str(reason) if reason in allowed else "native_test_failed"
 

--- a/custom_components/battery_smartflow_ai/zendure_cloud_mqtt.py
+++ b/custom_components/battery_smartflow_ai/zendure_cloud_mqtt.py
@@ -1,8 +1,10 @@
-"""Strictly read-only Zendure Cloud MQTT transport.
+"""State-reading Zendure Cloud MQTT transport.
 
-The public transport surface deliberately contains no publish or command API.
-Raw inbound messages are retained for the V5 initial-sync capture while
-credentials remain inside the transport boundary.
+The public transport surface deliberately contains no arbitrary publish or
+command API.  Its sole outbound operation is an internally constructed
+``properties/read`` request for ``getAll``.  Raw inbound messages are retained
+for the V5 initial-sync capture while credentials remain inside the transport
+boundary.
 """
 
 from __future__ import annotations
@@ -78,7 +80,7 @@ DisconnectCallback = Callable[[str | None], None]
 
 
 class ReadOnlyMqttSession(Protocol):
-    """Minimal subscriber-only backend contract (intentionally no publish)."""
+    """Minimal state-reader contract without an arbitrary publish surface."""
 
     def set_callbacks(
         self,
@@ -90,6 +92,14 @@ class ReadOnlyMqttSession(Protocol):
     def connect(self) -> None: ...
 
     def subscribe(self, topics: tuple[str, ...]) -> None: ...
+
+    def request_all(
+        self,
+        product_id: str,
+        device_id: str,
+        message_id: int,
+        timestamp: int,
+    ) -> None: ...
 
     def disconnect(self) -> None: ...
 
@@ -124,9 +134,11 @@ class ZendureCloudMqttTransport:
         self._session: ReadOnlyMqttSession | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
         self._connected = asyncio.Event()
+        self._connect_failure: str | None = None
         self._stopping = False
         self._reconnect_task: asyncio.Task[None] | None = None
         self._session_number = 0
+        self._request_message_id = 0
         self._last_message_at: datetime | None = None
         self._last_connection_phase = "not_started"
         self._last_connection_diagnostics: dict[str, str | bool] = {
@@ -216,6 +228,7 @@ class ZendureCloudMqttTransport:
         self._loop = asyncio.get_running_loop()
         self._stopping = False
         self._connected.clear()
+        self._connect_failure = None
         self._state = ConnectionState.CONNECTING
         await self._open_session()
         try:
@@ -223,6 +236,10 @@ class ZendureCloudMqttTransport:
         except TimeoutError:
             await self.async_stop()
             raise CloudMqttError("connection_timeout") from None
+        if self._connect_failure is not None:
+            reason = self._connect_failure
+            await self.async_stop()
+            raise CloudMqttError(reason)
 
     async def async_stop(self) -> None:
         """Stop reconnects and disconnect the read-only subscriber."""
@@ -280,11 +297,29 @@ class ZendureCloudMqttTransport:
             return
         if self._session is None:
             return
-        self._session.subscribe(self.topics)
+        try:
+            self._session.subscribe(self.topics)
+            for device_id, _candidate_id, product_id in self._routes:
+                if product_id is None:
+                    continue
+                self._request_message_id += 1
+                self._session.request_all(
+                    product_id,
+                    device_id,
+                    self._request_message_id,
+                    int(self._clock().timestamp()),
+                )
+        except CloudMqttError as error:
+            _LOGGER.warning(
+                "Zendure Cloud MQTT state request failed: %s", error.reason
+            )
+            self._connect_failure = error.reason
+            self._connected.set()
+            return
         self._state = ConnectionState.CONNECTED
         self._connected.set()
         _LOGGER.info(
-            "Zendure Cloud MQTT connected; subscribed to %d read-only topics",
+            "Zendure Cloud MQTT connected; subscribed to %d state topics",
             len(self.topics),
         )
 
@@ -314,6 +349,7 @@ class ZendureCloudMqttTransport:
                 return
             await asyncio.sleep(delay + random.uniform(0, min(0.25, delay / 4)))
             self._connected.clear()
+            self._connect_failure = None
             old, self._session = self._session, None
             if old is not None:
                 try:
@@ -323,6 +359,8 @@ class ZendureCloudMqttTransport:
             try:
                 await self._open_session()
                 await asyncio.wait_for(self._connected.wait(), timeout=15.0)
+                if self._connect_failure is not None:
+                    raise CloudMqttError(self._connect_failure)
                 return
             except Exception as error:  # backend errors are sanitized before logging
                 safe = ZendureDiagnosticSanitizer().sanitize_exception(error)
@@ -423,7 +461,7 @@ def _online_value(value: Any) -> bool | None:
 
 
 class PahoReadOnlyMqttSession:
-    """Production paho subscriber wrapper with no exposed publish method."""
+    """Paho state reader with no arbitrary publish or command method."""
 
     def __init__(self, credentials: CloudMqttCredentials) -> None:
         try:
@@ -489,6 +527,26 @@ class PahoReadOnlyMqttSession:
             result, _mid = self._client.subscribe(topic, qos=0)
             if result != 0:
                 raise CloudMqttError("subscribe_failed")
+
+    def request_all(
+        self,
+        product_id: str,
+        device_id: str,
+        message_id: int,
+        timestamp: int,
+    ) -> None:
+        topic, payload = _get_all_request(
+            product_id, device_id, message_id, timestamp
+        )
+        result = self._client.publish(topic, payload)
+        result_code = getattr(result, "rc", None)
+        if result_code is None:
+            try:
+                result_code = result[0]
+            except (IndexError, TypeError):
+                result_code = None
+        if result_code != 0:
+            raise CloudMqttError("state_request_failed")
 
     def disconnect(self) -> None:
         try:
@@ -580,6 +638,28 @@ def _bsfai_client_id(cloud_client_id: str) -> str:
 
     digest = hashlib.sha256(cloud_client_id.encode("utf-8")).hexdigest()[:16]
     return f"bsfai-{digest}"
+
+
+def _get_all_request(
+    product_id: str,
+    device_id: str,
+    message_id: int,
+    timestamp: int,
+) -> tuple[str, str]:
+    """Build the sole allow-listed outbound state request."""
+
+    return (
+        f"iot/{product_id}/{device_id}/properties/read",
+        json.dumps(
+            {
+                "properties": ["getAll"],
+                "messageId": message_id,
+                "deviceId": device_id,
+                "timestamp": timestamp,
+            },
+            separators=(",", ":"),
+        ),
+    )
 
 
 def _safe_peer_scope(mqtt_socket: Any) -> str:

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -13,7 +13,7 @@ COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
 
 
 class DebugIntegrationContractTests(unittest.TestCase):
-    def test_manifest_and_runtime_version_match_v5_dev9_release(self) -> None:
+    def test_manifest_and_runtime_version_match_v5_dev10_release(self) -> None:
         manifest_version = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )["version"]
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "5.0.0-dev9")
+        self.assertEqual(manifest_version, "5.0.0-dev10")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_native_zendure_ha_integration.py
+++ b/tests/test_native_zendure_ha_integration.py
@@ -17,7 +17,7 @@ class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
         manifest = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )
-        self.assertEqual(manifest["version"], "5.0.0-dev9")
+        self.assertEqual(manifest["version"], "5.0.0-dev10")
         self.assertIn("paho-mqtt==2.1.0", manifest["requirements"])
 
     def test_options_flow_uses_a_password_field_and_never_suggests_token(self) -> None:

--- a/tests/test_zendure_cloud_mqtt.py
+++ b/tests/test_zendure_cloud_mqtt.py
@@ -13,9 +13,11 @@ import unittest
 
 from custom_components.battery_smartflow_ai.zendure_cloud import ZendureCloudClient
 from custom_components.battery_smartflow_ai.zendure_cloud_mqtt import (
+    CloudMqttError,
     ConnectionState,
     ZendureCloudMqttTransport,
     _bsfai_client_id,
+    _get_all_request,
     _parse_broker_url,
     _reason_code_success,
     _safe_peer_scope,
@@ -42,6 +44,7 @@ class FakeSession:
     def __init__(self, _credentials, *, connect_ok=True):
         self.connect_ok = connect_ok
         self.subscriptions = ()
+        self.state_requests = []
         self.disconnected = False
 
     def set_callbacks(self, on_connect, on_disconnect, on_message):
@@ -49,6 +52,8 @@ class FakeSession:
 
     def connect(self): self.on_connect(self.connect_ok, None if self.connect_ok else "not authorized")
     def subscribe(self, topics): self.subscriptions = topics
+    def request_all(self, product_id, device_id, message_id, timestamp):
+        self.state_requests.append((product_id, device_id, message_id, timestamp))
     def disconnect(self): self.disconnected = True
     def emit(self, topic, payload): self.on_message(topic, payload)
     def drop(self): self.on_disconnect("network lost")
@@ -61,6 +66,11 @@ class HangingSession(FakeSession):
     def disconnect(self):
         self.disconnected = True
         raise RuntimeError("not connected")
+
+
+class FailedStateRequestSession(FakeSession):
+    def request_all(self, product_id, device_id, message_id, timestamp):
+        raise CloudMqttError("state_request_failed")
 
 
 class CloudMqttTransportTests(unittest.IsolatedAsyncioTestCase):
@@ -78,7 +88,11 @@ class CloudMqttTransportTests(unittest.IsolatedAsyncioTestCase):
         return session
 
     async def test_connects_and_subscribes_all_devices(self):
-        transport = ZendureCloudMqttTransport(self.data, session_factory=self.factory)
+        transport = ZendureCloudMqttTransport(
+            self.data,
+            session_factory=self.factory,
+            clock=lambda: self.now,
+        )
         await transport.async_start()
         self.assertEqual(transport.state, ConnectionState.CONNECTED)
         self.assertEqual(
@@ -89,6 +103,21 @@ class CloudMqttTransportTests(unittest.IsolatedAsyncioTestCase):
                 "iot/product-a/main-1/#",
                 "iot/product-b/main-2/#",
             ),
+        )
+        self.assertEqual(
+            [(product, device) for product, device, _message, _timestamp in self.sessions[0].state_requests],
+            [("product-a", "main-1"), ("product-b", "main-2")],
+        )
+        self.assertEqual(
+            [message for _product, _device, message, _timestamp in self.sessions[0].state_requests],
+            [1, 2],
+        )
+        self.assertTrue(
+            all(
+                timestamp == int(self.now.timestamp())
+                for _product, _device, _message, timestamp
+                in self.sessions[0].state_requests
+            )
         )
         await transport.async_stop()
         self.assertTrue(self.sessions[0].disconnected)
@@ -133,6 +162,8 @@ class CloudMqttTransportTests(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(hasattr(transport, "command"))
         public = {name for name, _ in inspect.getmembers(type(transport), inspect.isfunction) if not name.startswith("_")}
         self.assertEqual(public, {"async_start", "async_stop"})
+        self.assertEqual(len(self.sessions[0].state_requests), 2)
+        self.assertEqual(len(self.sessions[1].state_requests), 2)
 
     async def test_credentials_do_not_appear_in_logs_or_representations(self):
         transport = ZendureCloudMqttTransport(self.data, session_factory=self.factory)
@@ -158,6 +189,19 @@ class CloudMqttTransportTests(unittest.IsolatedAsyncioTestCase):
         transport = ZendureCloudMqttTransport(data, session_factory=self.factory)
         with self.assertRaisesRegex(Exception, "no_routable_devices"):
             await transport.async_start()
+
+    async def test_state_request_failure_is_classified(self):
+        transport = ZendureCloudMqttTransport(
+            self.data,
+            session_factory=lambda credentials: FailedStateRequestSession(
+                credentials
+            ),
+        )
+
+        with self.assertRaisesRegex(CloudMqttError, "state_request_failed"):
+            await transport.async_start()
+
+        self.assertEqual(transport.state, ConnectionState.STOPPED)
 
     async def test_cleanup_failure_does_not_mask_connection_timeout(self):
         session = HangingSession(None)
@@ -268,6 +312,24 @@ class CloudMqttTransportTests(unittest.IsolatedAsyncioTestCase):
             first,
             _bsfai_client_id("another-zendure-cloud-client"),
         )
+
+    def test_get_all_request_has_no_arbitrary_write_surface(self):
+        topic, payload = _get_all_request(
+            "product-a", "main-1", 7, 1788444000
+        )
+
+        self.assertEqual(topic, "iot/product-a/main-1/properties/read")
+        self.assertEqual(
+            json.loads(payload),
+            {
+                "properties": ["getAll"],
+                "messageId": 7,
+                "deviceId": "main-1",
+                "timestamp": 1788444000,
+            },
+        )
+        self.assertNotIn("properties/write", topic)
+        self.assertNotIn("function/invoke", topic)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- issue one allow-listed `getAll` state request after Cloud MQTT subscriptions are established
- construct the device-specific `properties/read` topic and payload internally
- repeat the state request after reconnects so a fresh session does not depend on retained traffic
- classify publish failures as `state_request_failed`
- keep arbitrary publish, command, `properties/write`, and `function/invoke` surfaces unavailable
- bump the development version to `5.0.0-dev10`

## Field evidence

DEV9 proved that Zendure accepts BSFAI's separate MQTT client ID, but a fresh session receives no spontaneous reports. This remained true while the battery was actively discharging. Z-HA also stayed unavailable when BSFAI was completely disabled. The Zendure-HA reference implementation confirms that current state is requested through `iot/<productKey>/<deviceId>/properties/read` with `properties: ["getAll"]`.

DEV10 uses that protocol operation solely to retrieve current state. It does not alter any device setting.

## Validation

- 68 Zendure-focused tests
- 474 tests in the complete suite
- Python compilation
- `git diff --check`

Closes #391