### PR TITLE
Fix DEV10 version ordering for HACS

### DIFF
--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -38,7 +38,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "5.0.0-dev10"
+INTEGRATION_VERSION = "5.0.0.dev10"
 
 # V5 native Zendure discovery is observation-only in the first development
 # build. The App Token is account discovery material and must never be copied

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": ["paho-mqtt==2.1.0"],
-  "version": "5.0.0-dev10"
+  "version": "5.0.0.dev10"
 }

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "5.0.0-dev10")
+        self.assertEqual(manifest_version, "5.0.0.dev10")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_native_zendure_ha_integration.py
+++ b/tests/test_native_zendure_ha_integration.py
@@ -17,7 +17,7 @@ class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
         manifest = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )
-        self.assertEqual(manifest["version"], "5.0.0-dev10")
+        self.assertEqual(manifest["version"], "5.0.0.dev10")
         self.assertIn("paho-mqtt==2.1.0", manifest["requirements"])
 
     def test_options_flow_uses_a_password_field_and_never_suggests_token(self) -> None:


### PR DESCRIPTION
## Summary

- change the DEV10 version notation from `5.0.0-dev10` to `5.0.0.dev10`
- keep runtime and manifest versions aligned
- preserve all DEV10 code unchanged

## Reason

GitHub's releases API currently orders the existing tags as `dev9`, `dev8`, ..., `dev2`, `dev10`, `dev1`. HACS therefore continues to expose DEV9 as the newest pre-release. The dotted development modifier is explicitly supported by AwesomeVersion and sorts numerically while remaining older than the final `5.0.0` release.

## Validation

- 474 tests in the complete suite
- Python compilation
- `git diff --check`