### PR TITLE
V5 dev11: add read-only local ZenSDK initial sync

### DIFF
--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -38,7 +38,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "5.0.0.dev10"
+INTEGRATION_VERSION = "5.0.0.dev11"
 
 # V5 native Zendure discovery is observation-only in the first development
 # build. The App Token is account discovery material and must never be copied

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": ["paho-mqtt==2.1.0"],
-  "version": "5.0.0.dev10"
+  "version": "5.0.0.dev11"
 }

--- a/custom_components/battery_smartflow_ai/native_zendure_runtime.py
+++ b/custom_components/battery_smartflow_ai/native_zendure_runtime.py
@@ -21,6 +21,7 @@ from .zendure_initial_sync import (
 )
 from .zendure_normalizer import ZendureCloudNormalizer
 from .zendure_privacy import ZendureDiagnosticSanitizer
+from .zendure_zensdk import async_read_zensdk_reports
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -36,6 +37,7 @@ STATUS_ERROR = "error"
 @dataclass(slots=True)
 class _JsonPayloadResponse:
     payload: Any
+    status: int = 200
 
     async def json(self) -> Any:
         return self.payload
@@ -68,6 +70,7 @@ class NativeZendureRuntime:
         self._normalizer: ZendureCloudNormalizer | None = None
         self._processed_messages = 0
         self._last_processed_message: Any | None = None
+        self._last_received_at: Any | None = None
 
     @property
     def configured(self) -> bool:
@@ -105,7 +108,8 @@ class NativeZendureRuntime:
             "native_zendure_device_count": len(self._inventory.devices),
             "native_zendure_message_count": self._processed_messages,
             "native_zendure_last_message": (
-                self._transport.last_message_at if self._transport else None
+                self._last_received_at
+                or (self._transport.last_message_at if self._transport else None)
             ),
             "native_zendure_last_capture": (
                 Path(self._capture_path).name if self._capture_path else None
@@ -173,10 +177,19 @@ class NativeZendureRuntime:
                     system_id=candidate_id,
                 )
             self._normalizer = ZendureCloudNormalizer(bootstrap)
+            zensdk = await async_read_zensdk_reports(
+                bootstrap,
+                self._get_json,
+            )
             self._transport = ZendureCloudMqttTransport(bootstrap)
             self._set_status(STATUS_CONNECTING)
             self._set_status(STATUS_CAPTURING)
-            capture = await async_capture_initial_sync(bootstrap, self._transport)
+            capture = await async_capture_initial_sync(
+                bootstrap,
+                self._transport,
+                initial_messages=zensdk.messages,
+                zensdk_attempts=zensdk.attempts,
+            )
             self._capture_complete = capture.complete
             self._capture_reason = capture.completion_reason
             exported = await self._hass.async_add_executor_job(
@@ -187,7 +200,7 @@ class NativeZendureRuntime:
                 )
             )
             self._capture_path = str(exported.path)
-            self._consume_messages()
+            self._consume_captured_messages(capture.messages)
             if capture.completion_reason not in {
                 "initial_sync_quiet",
                 "hard_timeout",
@@ -217,6 +230,16 @@ class NativeZendureRuntime:
             payload = await response.json(content_type=None)
         return _JsonPayloadResponse(payload)
 
+    async def _get_json(self, url: str, **kwargs: Any) -> _JsonPayloadResponse:
+        session = async_get_clientsession(self._hass)
+        async with session.get(url, **kwargs) as response:
+            payload = (
+                await response.json(content_type=None)
+                if response.status == 200
+                else None
+            )
+            return _JsonPayloadResponse(payload, response.status)
+
     def _consume_messages(self) -> None:
         if self._transport is None or self._normalizer is None:
             return
@@ -228,7 +251,24 @@ class NativeZendureRuntime:
                     start = index + 1
                     break
         new_messages = messages[start:]
-        for message in new_messages:
+        self._apply_messages(new_messages)
+        if new_messages:
+            self._last_processed_message = new_messages[-1]
+
+    def _consume_captured_messages(self, messages: tuple[Any, ...]) -> None:
+        """Apply ZenSDK seed data and MQTT messages captured during startup."""
+
+        self._apply_messages(messages)
+        cloud_messages = [
+            message for message in messages if message.transport == "cloud_mqtt"
+        ]
+        if cloud_messages:
+            self._last_processed_message = cloud_messages[-1]
+
+    def _apply_messages(self, messages: tuple[Any, ...]) -> None:
+        if self._normalizer is None:
+            return
+        for message in messages:
             result = self._normalizer.apply(message)
             if result is None:
                 continue
@@ -244,9 +284,11 @@ class NativeZendureRuntime:
                 for pack in state.packs
             )
             self._inventory.reconcile_packs(state.system_id, packs)
-        if new_messages:
-            self._last_processed_message = new_messages[-1]
-            self._processed_messages += len(new_messages)
+        if messages:
+            self._last_received_at = max(
+                message.received_at for message in messages
+            )
+            self._processed_messages += len(messages)
 
     def _set_status(self, value: str) -> None:
         self._status = value

--- a/custom_components/battery_smartflow_ai/zendure_cloud_mqtt.py
+++ b/custom_components/battery_smartflow_ai/zendure_cloud_mqtt.py
@@ -63,6 +63,7 @@ class CloudMqttMessage:
     pack_id: str | None
     known_topic: bool
     session_number: int
+    transport: str = "cloud_mqtt"
 
 
 @dataclass(slots=True)

--- a/custom_components/battery_smartflow_ai/zendure_initial_sync.py
+++ b/custom_components/battery_smartflow_ai/zendure_initial_sync.py
@@ -20,6 +20,7 @@ from .zendure_cloud_mqtt import (
     ZendureCloudMqttTransport,
 )
 from .zendure_privacy import ZendureDiagnosticSanitizer
+from .zendure_zensdk import ZenSdkReadAttempt
 
 
 SCHEMA = "battery_smartflow_ai.zendure_initial_sync"
@@ -46,11 +47,21 @@ class InitialSyncCaptureResult:
     connection_events: tuple[Mapping[str, Any], ...]
     messages: tuple[CloudMqttMessage, ...]
     expected_devices: tuple[str, ...]
+    zensdk_attempts: tuple[ZenSdkReadAttempt, ...] = ()
 
     def as_dict(self) -> dict[str, Any]:
         """Build one detached package and sanitize it with one alias namespace."""
 
-        raw_messages = [_raw_message(item) for item in self.messages]
+        mqtt_messages = [
+            _raw_message(item)
+            for item in self.messages
+            if item.transport == "cloud_mqtt"
+        ]
+        zensdk_responses = [
+            _raw_message(item)
+            for item in self.messages
+            if item.transport == "zensdk"
+        ]
         package = {
             "meta": {
                 "schema": SCHEMA,
@@ -64,7 +75,18 @@ class InitialSyncCaptureResult:
             "raw_communication": {
                 "device_list": [dict(item) for item in self.discovery],
                 "connection_events": [dict(item) for item in self.connection_events],
-                "mqtt_messages": raw_messages,
+                "mqtt_messages": mqtt_messages,
+                "zensdk_requests": [
+                    {
+                        "device_id": item.device_candidate_id,
+                        "path": "/properties/report",
+                        "address_source": item.address_source,
+                        "result": item.result,
+                        "http_status": item.http_status,
+                    }
+                    for item in self.zensdk_attempts
+                ],
+                "zensdk_responses": zensdk_responses,
             },
             "bsfai_interpretation": _build_summary(
                 self.discovery,
@@ -92,6 +114,8 @@ class ZendureInitialSyncRecorder:
         hard_timeout: float = DEFAULT_HARD_TIMEOUT,
         clock: Callable[[], datetime] | None = None,
         monotonic: Callable[[], float] = time.monotonic,
+        initial_messages: tuple[CloudMqttMessage, ...] = (),
+        zensdk_attempts: tuple[ZenSdkReadAttempt, ...] = (),
     ) -> None:
         if quiet_period <= 0 or hard_timeout <= quiet_period:
             raise ValueError("hard_timeout must be greater than quiet_period")
@@ -107,6 +131,7 @@ class ZendureInitialSyncRecorder:
         self._seen_properties: set[str] = set()
         self._seen_devices: set[str] = set()
         self._messages: list[CloudMqttMessage] = []
+        self._zensdk_attempts = zensdk_attempts
         self._connection_events: list[dict[str, Any]] = []
         self._last_connection_signature: tuple[Any, ...] | None = None
         self._expected_devices = tuple(
@@ -116,6 +141,8 @@ class ZendureInitialSyncRecorder:
                 if item.candidate.identity.device_id is not None
             )
         )
+        for message in initial_messages:
+            self.observe_message(message)
 
     def observe_connection(
         self,
@@ -179,6 +206,7 @@ class ZendureInitialSyncRecorder:
             connection_events=tuple(self._connection_events),
             messages=tuple(self._messages),
             expected_devices=self._expected_devices,
+            zensdk_attempts=self._zensdk_attempts,
         )
 
 
@@ -191,6 +219,8 @@ async def async_capture_initial_sync(
     poll_interval: float = 0.1,
     clock: Callable[[], datetime] | None = None,
     monotonic: Callable[[], float] = time.monotonic,
+    initial_messages: tuple[CloudMqttMessage, ...] = (),
+    zensdk_attempts: tuple[ZenSdkReadAttempt, ...] = (),
 ) -> InitialSyncCaptureResult:
     """Capture discovery and MQTT startup until structural traffic is quiet."""
 
@@ -200,6 +230,8 @@ async def async_capture_initial_sync(
         hard_timeout=hard_timeout,
         clock=clock,
         monotonic=monotonic,
+        initial_messages=initial_messages,
+        zensdk_attempts=zensdk_attempts,
     )
     cursor = 0
     def observe_transport() -> None:
@@ -286,7 +318,7 @@ def _raw_message(message: CloudMqttMessage) -> dict[str, Any]:
         payload = message.parsed_payload
     return {
         "timestamp": _iso(message.received_at),
-        "transport": "cloud_mqtt",
+        "transport": message.transport,
         "device_id": message.device_candidate_id,
         "pack_id": message.pack_id,
         "topic": message.topic,

--- a/custom_components/battery_smartflow_ai/zendure_normalizer.py
+++ b/custom_components/battery_smartflow_ai/zendure_normalizer.py
@@ -270,6 +270,10 @@ class ZendureCloudNormalizer:
         self._last_message: dict[str, datetime | None] = {
             candidate_id: None for candidate_id in self._models
         }
+        self._observed_transport: dict[str, ZendureTransport] = {
+            candidate_id: ZendureTransport.CLOUD_MQTT
+            for candidate_id in self._models
+        }
         self._unknown_main = {
             candidate_id: set() for candidate_id in self._models
         }
@@ -308,6 +312,11 @@ class ZendureCloudNormalizer:
             return None
         observed_at = message.received_at
         self._last_message[system_id] = observed_at
+        self._observed_transport[system_id] = (
+            ZendureTransport.ZENSDK
+            if message.transport == "zensdk"
+            else ZendureTransport.CLOUD_MQTT
+        )
         payload = message.parsed_payload
         if isinstance(payload, Mapping):
             properties = payload.get("properties")
@@ -355,7 +364,7 @@ class ZendureCloudNormalizer:
         )
         state = NeutralDeviceState(
             system_id=system_id,
-            observed_transport=ZendureTransport.CLOUD_MQTT,
+            observed_transport=self._observed_transport[system_id],
             model=self._models[system_id],
             firmware=device_value("firmware"),
             online=MeasuredValue(

--- a/custom_components/battery_smartflow_ai/zendure_zensdk.py
+++ b/custom_components/battery_smartflow_ai/zendure_zensdk.py
@@ -1,0 +1,189 @@
+"""Strictly read-only local ZenSDK report collection for V5 field tests."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import ipaddress
+import json
+import re
+from typing import Any, Awaitable, Callable, Mapping, Protocol
+from urllib.parse import urlsplit
+
+from .core.models import ZendureTransport
+from .zendure_cloud import ZendureCloudBootstrap
+from .zendure_cloud_mqtt import CloudMqttMessage
+from .zendure_device_matrix import VerificationLevel, resolve_zendure_device
+
+
+ZENSDK_REPORT_PATH = "/properties/report"
+DEFAULT_ZENSDK_TIMEOUT = 4.0
+
+
+class ZenSdkResponse(Protocol):
+    status: int
+
+    async def json(self) -> Any: ...
+
+
+GetJson = Callable[..., Awaitable[ZenSdkResponse]]
+
+
+@dataclass(frozen=True, slots=True)
+class ZenSdkReadAttempt:
+    """Privacy-safe outcome; the LAN endpoint is deliberately not retained."""
+
+    device_candidate_id: str
+    address_source: str
+    result: str
+    http_status: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ZenSdkReadResult:
+    messages: tuple[CloudMqttMessage, ...]
+    attempts: tuple[ZenSdkReadAttempt, ...]
+
+
+async def async_read_zensdk_reports(
+    bootstrap: ZendureCloudBootstrap,
+    get_json: GetJson,
+    *,
+    timeout: float = DEFAULT_ZENSDK_TIMEOUT,
+    clock: Callable[[], datetime] | None = None,
+) -> ZenSdkReadResult:
+    """Read one local report per supported device without exposing a write API."""
+
+    if timeout <= 0:
+        raise ValueError("timeout must be positive")
+    now = clock or (lambda: datetime.now(timezone.utc))
+    raw_by_device = {
+        str(item.get("deviceKey")): item
+        for item in bootstrap.raw_device_list
+        if isinstance(item, Mapping) and item.get("deviceKey") is not None
+    }
+    tasks = []
+    for device in bootstrap.devices:
+        identity = device.candidate.identity
+        matrix = resolve_zendure_device(identity)
+        if (
+            matrix is None
+            or matrix.transport(ZendureTransport.ZENSDK).read
+            is VerificationLevel.UNSUPPORTED
+            or identity.device_id is None
+        ):
+            continue
+        raw = raw_by_device.get(identity.device_id, {})
+        addresses = _candidate_addresses(
+            raw, identity.product_model, identity.serial_number
+        )
+        tasks.append(
+            _read_device(
+                device.candidate.candidate_id,
+                addresses,
+                get_json,
+                timeout,
+                now,
+            )
+        )
+    if not tasks:
+        return ZenSdkReadResult((), ())
+    results = await asyncio.gather(*tasks)
+    return ZenSdkReadResult(
+        tuple(message for messages, _attempts in results for message in messages),
+        tuple(attempt for _messages, attempts in results for attempt in attempts),
+    )
+
+
+async def _read_device(
+    candidate_id: str,
+    addresses: tuple[tuple[str, str], ...],
+    get_json: GetJson,
+    timeout: float,
+    clock: Callable[[], datetime],
+) -> tuple[tuple[CloudMqttMessage, ...], tuple[ZenSdkReadAttempt, ...]]:
+    attempts: list[ZenSdkReadAttempt] = []
+    if not addresses:
+        return (), (ZenSdkReadAttempt(candidate_id, "none", "no_local_address"),)
+    for source, host in addresses:
+        try:
+            response = await asyncio.wait_for(
+                get_json(f"http://{host}{ZENSDK_REPORT_PATH}"), timeout=timeout
+            )
+            status = int(response.status)
+            if status != 200:
+                attempts.append(
+                    ZenSdkReadAttempt(candidate_id, source, "http_error", status)
+                )
+                continue
+            payload = await asyncio.wait_for(response.json(), timeout=timeout)
+            if not isinstance(payload, Mapping):
+                attempts.append(
+                    ZenSdkReadAttempt(candidate_id, source, "invalid_response", status)
+                )
+                continue
+            encoded = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+            attempts.append(ZenSdkReadAttempt(candidate_id, source, "success", status))
+            return (
+                (
+                    CloudMqttMessage(
+                        received_at=clock(),
+                        topic="zensdk/properties/report",
+                        payload=encoded,
+                        parsed_payload=dict(payload),
+                        payload_format="json",
+                        device_candidate_id=candidate_id,
+                        pack_id=None,
+                        known_topic=True,
+                        session_number=0,
+                        transport="zensdk",
+                    ),
+                ),
+                tuple(attempts),
+            )
+        except TimeoutError:
+            attempts.append(ZenSdkReadAttempt(candidate_id, source, "timeout"))
+        except Exception:
+            attempts.append(ZenSdkReadAttempt(candidate_id, source, "cannot_connect"))
+    return (), tuple(attempts)
+
+
+def _candidate_addresses(
+    raw: Mapping[str, Any], model: str | None, serial: str | None
+) -> tuple[tuple[str, str], ...]:
+    result: list[tuple[str, str]] = []
+    raw_ip = raw.get("ip")
+    if isinstance(raw_ip, str) and _safe_lan_ip(raw_ip.strip()):
+        result.append(("device_list_ip", raw_ip.strip()))
+    hostname = _derived_hostname(model, serial)
+    if hostname and all(host != hostname for _source, host in result):
+        result.append(("derived_local_hostname", hostname))
+    return tuple(result)
+
+
+def _safe_lan_ip(value: str) -> bool:
+    try:
+        address = ipaddress.ip_address(value)
+    except ValueError:
+        return False
+    return bool(
+        (address.is_private or address.is_link_local)
+        and not address.is_loopback
+        and not address.is_multicast
+        and not address.is_unspecified
+        and not address.is_reserved
+    )
+
+
+def _derived_hostname(model: str | None, serial: str | None) -> str | None:
+    if not model or not serial:
+        return None
+    compact_model = re.sub(r"\s+", "", model)
+    if not re.fullmatch(r"[A-Za-z0-9+_-]+", compact_model):
+        return None
+    if not re.fullmatch(r"[A-Za-z0-9_-]+", serial):
+        return None
+    hostname = f"zendure-{compact_model}-{serial}.local"
+    parsed = urlsplit(f"http://{hostname}")
+    return hostname if parsed.hostname == hostname.casefold() else None

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -13,7 +13,7 @@ COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
 
 
 class DebugIntegrationContractTests(unittest.TestCase):
-    def test_manifest_and_runtime_version_match_v5_dev10_release(self) -> None:
+    def test_manifest_and_runtime_version_match_v5_dev11_release(self) -> None:
         manifest_version = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )["version"]
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "5.0.0.dev10")
+        self.assertEqual(manifest_version, "5.0.0.dev11")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_native_zendure_ha_integration.py
+++ b/tests/test_native_zendure_ha_integration.py
@@ -17,7 +17,7 @@ class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
         manifest = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )
-        self.assertEqual(manifest["version"], "5.0.0.dev10")
+        self.assertEqual(manifest["version"], "5.0.0.dev11")
         self.assertIn("paho-mqtt==2.1.0", manifest["requirements"])
 
     def test_options_flow_uses_a_password_field_and_never_suggests_token(self) -> None:
@@ -46,6 +46,7 @@ class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
         self.assertNotIn("properties/write", runtime)
         self.assertNotIn("DeviceCommand", runtime)
         self.assertNotIn("def publish", mqtt)
+        self.assertIn("self._consume_captured_messages(capture.messages)", runtime)
 
     def test_secret_is_not_exposed_by_sensor_or_diagnostic_surfaces(self) -> None:
         runtime = (COMPONENT / "native_zendure_runtime.py").read_text(

--- a/tests/test_zendure_initial_sync.py
+++ b/tests/test_zendure_initial_sync.py
@@ -27,6 +27,9 @@ from custom_components.battery_smartflow_ai.zendure_initial_sync import (  # noq
     async_capture_initial_sync,
     export_initial_sync_capture,
 )
+from custom_components.battery_smartflow_ai.zendure_zensdk import (  # noqa: E402
+    ZenSdkReadAttempt,
+)
 
 
 class Response:
@@ -341,6 +344,58 @@ class InitialSyncCaptureTests(unittest.IsolatedAsyncioTestCase):
             )
             self.assertFalse(data["meta"]["complete"])
             self.assertFalse(list(exported.path.parent.glob("*.tmp")))
+
+    async def test_zensdk_report_and_attempt_are_exported_without_lan_identity(self):
+        local_report = message(
+            self.time.clock(),
+            "cloud_mqtt:real-device-1",
+            "real-device-1",
+            {
+                "properties": {"electricLevel": 75},
+                "packData": [{"sn": "real-pack-1", "socLevel": 74}],
+            },
+        )
+        local_report = CloudMqttMessage(
+            received_at=local_report.received_at,
+            topic="zensdk/properties/report",
+            payload=local_report.payload,
+            parsed_payload=local_report.parsed_payload,
+            payload_format="json",
+            device_candidate_id=local_report.device_candidate_id,
+            pack_id=None,
+            known_topic=True,
+            session_number=0,
+            transport="zensdk",
+        )
+        recorder = ZendureInitialSyncRecorder(
+            self.bootstrap,
+            clock=self.time.clock,
+            monotonic=self.time.monotonic,
+            initial_messages=(local_report,),
+            zensdk_attempts=(
+                ZenSdkReadAttempt(
+                    "cloud_mqtt:real-device-1",
+                    "device_list_ip",
+                    "success",
+                    200,
+                ),
+            ),
+        )
+        package = recorder.finish(complete=True, reason="initial_sync_quiet").as_dict()
+
+        self.assertEqual(
+            package["raw_communication"]["zensdk_responses"][0]["transport"],
+            "zensdk",
+        )
+        self.assertEqual(package["raw_communication"]["mqtt_messages"], [])
+        self.assertEqual(
+            package["raw_communication"]["zensdk_requests"][0]["path"],
+            "/properties/report",
+        )
+        self.assertEqual(len(package["bsfai_interpretation"]["pack_ids"]), 1)
+        self.assertTrue(
+            package["bsfai_interpretation"]["pack_ids"][0].startswith("ZD_SERIAL_A")
+        )
 
     async def test_export_size_limit_is_enforced(self):
         result = self.recorder().finish(complete=False, reason="test")

--- a/tests/test_zendure_zensdk.py
+++ b/tests/test_zendure_zensdk.py
@@ -1,0 +1,151 @@
+"""Read-only local ZenSDK report tests."""
+
+from __future__ import annotations
+
+from base64 import b64encode
+from datetime import datetime, timezone
+import unittest
+
+from support import bootstrap as bootstrap_test_environment
+
+
+bootstrap_test_environment()
+
+from custom_components.battery_smartflow_ai.zendure_cloud import (  # noqa: E402
+    ZendureCloudClient,
+)
+from custom_components.battery_smartflow_ai.zendure_zensdk import (  # noqa: E402
+    _candidate_addresses,
+    async_read_zensdk_reports,
+)
+from custom_components.battery_smartflow_ai.zendure_normalizer import (  # noqa: E402
+    ZendureCloudNormalizer,
+)
+from custom_components.battery_smartflow_ai.core.models import (  # noqa: E402
+    ZendureTransport,
+)
+
+
+class Response:
+    def __init__(self, data, status=200):
+        self.data = data
+        self.status = status
+
+    async def json(self):
+        return self.data
+
+
+async def make_bootstrap(*, ip="192.168.1.44"):
+    token = b64encode(b"https://api.example.com.app-key").decode()
+
+    async def post(*_args, **_kwargs):
+        return Response(
+            {
+                "code": 200,
+                "success": True,
+                "data": {
+                    "deviceList": [
+                        {
+                            "deviceKey": "device-real-1",
+                            "snNumber": "serial-real-1",
+                            "productKey": "BC8B7F",
+                            "productModel": "SolarFlow 2400 AC",
+                            "deviceName": "Garage",
+                            "online": True,
+                            "ip": ip,
+                        }
+                    ],
+                    "mqtt": {
+                        "clientId": "client-secret",
+                        "url": "mqtt://broker.example:1883",
+                        "username": "user-secret",
+                        "password": "password-secret",
+                    },
+                },
+            }
+        )
+
+    return await ZendureCloudClient(post).async_discover(token)
+
+
+class ZenSdkReadTests(unittest.IsolatedAsyncioTestCase):
+    async def test_reads_private_ip_and_returns_transport_tagged_report(self):
+        data = await make_bootstrap()
+        requested = []
+        payload = {
+            "properties": {"electricLevel": 73},
+            "packData": [{"sn": "pack-real-1", "socLevel": 72}],
+        }
+
+        async def get(url, **_kwargs):
+            requested.append(url)
+            return Response(payload)
+
+        result = await async_read_zensdk_reports(
+            data,
+            get,
+            clock=lambda: datetime(2026, 9, 3, 16, 0, tzinfo=timezone.utc),
+        )
+
+        self.assertEqual(requested, ["http://192.168.1.44/properties/report"])
+        self.assertEqual(result.attempts[0].result, "success")
+        self.assertEqual(result.attempts[0].address_source, "device_list_ip")
+        self.assertEqual(result.messages[0].transport, "zensdk")
+        self.assertEqual(result.messages[0].parsed_payload, payload)
+        normalized = ZendureCloudNormalizer(data).apply(result.messages[0])
+        self.assertIsNotNone(normalized)
+        self.assertEqual(
+            normalized.state.observed_transport,
+            ZendureTransport.ZENSDK,
+        )
+        self.assertEqual(len(normalized.state.packs), 1)
+
+    async def test_falls_back_to_derived_local_hostname(self):
+        data = await make_bootstrap()
+        requested = []
+
+        async def get(url, **_kwargs):
+            requested.append(url)
+            if "192.168.1.44" in url:
+                raise OSError("unreachable")
+            return Response({"properties": {"electricLevel": 50}})
+
+        result = await async_read_zensdk_reports(data, get)
+
+        self.assertEqual(len(requested), 2)
+        self.assertEqual(
+            requested[1],
+            "http://zendure-SolarFlow2400AC-serial-real-1.local/properties/report",
+        )
+        self.assertEqual(
+            [attempt.result for attempt in result.attempts],
+            ["cannot_connect", "success"],
+        )
+
+    async def test_rejects_public_or_malformed_device_list_address(self):
+        data = await make_bootstrap(ip="8.8.8.8")
+        requested = []
+
+        async def get(url, **_kwargs):
+            requested.append(url)
+            return Response({"properties": {}})
+
+        await async_read_zensdk_reports(data, get)
+
+        self.assertEqual(len(requested), 1)
+        self.assertIn(".local/properties/report", requested[0])
+        self.assertNotIn("8.8.8.8", requested[0])
+
+    def test_address_candidates_reject_untrusted_hostname_components(self):
+        self.assertEqual(
+            _candidate_addresses(
+                {"ip": "https://example.com"},
+                "Bad/model",
+                "serial?query=1",
+            ),
+            (),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- read /properties/report locally for recognized ZenSDK-capable Zendure devices after cloud discovery
- restrict requests to private/link-local device-list IPs and strictly derived .local hostnames
- keep the path read-only and preserve the existing Cloud MQTT observer
- export privacy-safe ZenSDK request outcomes and responses separately from MQTT messages
- normalize successful ZenSDK reports, including pack data, with the observed transport marked as zensdk
- bump the prerelease version to 5.0.0.dev11

## Safety

- no native write or control API is introduced
- public, loopback, multicast, unspecified, reserved, and malformed addresses are rejected
- local addresses and device identities remain behind the existing diagnostic sanitizer
- failures are bounded and do not block the legacy BSFAI startup path

## Validation

- 479 unit tests passed
- Python compilation passed
- git diff --check passed