### PR TITLE
V5 dev12: continuously observe local ZenSDK state

### DIFF
--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -38,7 +38,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "5.0.0.dev11"
+INTEGRATION_VERSION = "5.0.0.dev12"
 
 # V5 native Zendure discovery is observation-only in the first development
 # build. The App Token is account discovery material and must never be copied

--- a/custom_components/battery_smartflow_ai/core/models/inventory.py
+++ b/custom_components/battery_smartflow_ai/core/models/inventory.py
@@ -440,6 +440,25 @@ class DeviceInventory:
             control_state=DeviceControlState.OFFLINE,
         )
 
+    def mark_available(self, system_id: str) -> None:
+        """Restore observation after fresh data without re-enabling control."""
+
+        device = self._devices[system_id]
+        if device.online:
+            return
+        state = (
+            DeviceControlState.HEMS_BLOCKED
+            if device.hems_active
+            else DeviceControlState.OBSERVATION
+            if device.supported
+            else DeviceControlState.UNSUPPORTED
+        )
+        self._devices[system_id] = replace(
+            device,
+            online=True,
+            control_state=state,
+        )
+
     def as_dict(self) -> dict[str, Any]:
         return {
             "schema_version": 1,

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": ["paho-mqtt==2.1.0"],
-  "version": "5.0.0.dev11"
+  "version": "5.0.0.dev12"
 }

--- a/custom_components/battery_smartflow_ai/native_zendure_runtime.py
+++ b/custom_components/battery_smartflow_ai/native_zendure_runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from functools import partial
 import logging
 from pathlib import Path
@@ -21,7 +22,7 @@ from .zendure_initial_sync import (
 )
 from .zendure_normalizer import ZendureCloudNormalizer
 from .zendure_privacy import ZendureDiagnosticSanitizer
-from .zendure_zensdk import async_read_zensdk_reports
+from .zendure_zensdk import ZenSdkReadResult, async_read_zensdk_reports
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -32,6 +33,8 @@ STATUS_CONNECTING = "connecting"
 STATUS_CAPTURING = "capturing"
 STATUS_OBSERVING = "observing"
 STATUS_ERROR = "error"
+ZENSDK_POLL_INTERVAL = 5.0
+ZENSDK_OFFLINE_AFTER_FAILURES = 3
 
 
 @dataclass(slots=True)
@@ -71,6 +74,10 @@ class NativeZendureRuntime:
         self._processed_messages = 0
         self._last_processed_message: Any | None = None
         self._last_received_at: Any | None = None
+        self._bootstrap: Any | None = None
+        self._zensdk_failures: dict[str, int] = {}
+        self._zensdk_last_result: dict[str, str] = {}
+        self._zensdk_last_success: dict[str, datetime] = {}
 
     @property
     def configured(self) -> bool:
@@ -120,7 +127,10 @@ class NativeZendureRuntime:
     def overview_attributes(self) -> dict[str, Any]:
         systems = []
         overview = build_native_device_overview(self._inventory, self._states)
+        now = datetime.now(timezone.utc)
         for system_id, item in zip(sorted(self._inventory.devices), overview):
+            state = self._states.get(system_id)
+            last_data = item.last_message_at
             systems.append(
                 {
                     "id": item.public_id,
@@ -131,6 +141,15 @@ class NativeZendureRuntime:
                     "online": item.online,
                     "status": item.status_text,
                     "transport": item.selected_transport.value,
+                    "observed_transport": (
+                        state.observed_transport.value if state is not None else None
+                    ),
+                    "last_data_at": last_data,
+                    "data_age_seconds": (
+                        max(0.0, round((now - last_data).total_seconds(), 1))
+                        if last_data is not None
+                        else None
+                    ),
                     "packs": [
                         {
                             "id": pack.public_id,
@@ -161,6 +180,8 @@ class NativeZendureRuntime:
                 "capture_complete": self._capture_complete,
                 "capture_reason": self._capture_reason,
                 "error": self._error,
+                "zensdk_poll_interval_seconds": ZENSDK_POLL_INTERVAL,
+                "zensdk_devices": self._zensdk_diagnostics(),
                 "overview": self.overview_attributes(),
             }
         )
@@ -170,6 +191,7 @@ class NativeZendureRuntime:
             self._set_status(STATUS_DISCOVERING)
             client = ZendureCloudClient(self._post_json)
             bootstrap = await client.async_discover(self._app_token or "")
+            self._bootstrap = bootstrap
             bootstrap.register_candidates(self._inventory)
             for candidate_id in tuple(self._inventory.candidates):
                 self._inventory.add_observed_system(
@@ -181,6 +203,7 @@ class NativeZendureRuntime:
                 bootstrap,
                 self._get_json,
             )
+            self._record_zensdk_cycle(zensdk)
             self._transport = ZendureCloudMqttTransport(bootstrap)
             self._set_status(STATUS_CONNECTING)
             self._set_status(STATUS_CAPTURING)
@@ -209,8 +232,16 @@ class NativeZendureRuntime:
                 self._set_status(STATUS_ERROR)
                 return
             self._set_status(STATUS_OBSERVING)
+            next_zensdk_poll = (
+                asyncio.get_running_loop().time() + ZENSDK_POLL_INTERVAL
+            )
             while True:
                 self._consume_messages()
+                loop = asyncio.get_running_loop()
+                if loop.time() >= next_zensdk_poll:
+                    await self._async_poll_zensdk()
+                    next_zensdk_poll = loop.time() + ZENSDK_POLL_INTERVAL
+                self._refresh_snapshots()
                 self._notify()
                 await asyncio.sleep(1.0)
         except asyncio.CancelledError:
@@ -265,6 +296,71 @@ class NativeZendureRuntime:
         if cloud_messages:
             self._last_processed_message = cloud_messages[-1]
 
+    async def _async_poll_zensdk(self) -> None:
+        if self._bootstrap is None:
+            return
+        result = await async_read_zensdk_reports(
+            self._bootstrap,
+            self._get_json,
+        )
+        self._record_zensdk_cycle(result)
+        self._apply_messages(result.messages)
+
+    def _record_zensdk_cycle(self, result: ZenSdkReadResult) -> None:
+        successful = {
+            message.device_candidate_id
+            for message in result.messages
+            if message.device_candidate_id is not None
+        }
+        attempted = {item.device_candidate_id for item in result.attempts}
+        last_results = {
+            candidate_id: next(
+                item.result
+                for item in reversed(result.attempts)
+                if item.device_candidate_id == candidate_id
+            )
+            for candidate_id in attempted
+        }
+        observed_at = datetime.now(timezone.utc)
+        for candidate_id in attempted:
+            self._zensdk_last_result[candidate_id] = last_results[candidate_id]
+            if candidate_id in successful:
+                self._zensdk_failures[candidate_id] = 0
+                self._zensdk_last_success[candidate_id] = observed_at
+                if self._normalizer is not None:
+                    self._normalizer.set_online(candidate_id, True)
+                if candidate_id in self._inventory.devices:
+                    self._inventory.mark_available(candidate_id)
+                continue
+            failures = self._zensdk_failures.get(candidate_id, 0) + 1
+            self._zensdk_failures[candidate_id] = failures
+            if failures >= ZENSDK_OFFLINE_AFTER_FAILURES:
+                if self._normalizer is not None:
+                    self._normalizer.set_online(candidate_id, False)
+                if candidate_id in self._inventory.devices:
+                    self._inventory.mark_unavailable(candidate_id)
+
+    def _refresh_snapshots(self) -> None:
+        if self._normalizer is None:
+            return
+        for system_id in tuple(self._inventory.devices):
+            result = self._normalizer.snapshot(
+                system_id,
+                now=datetime.now(timezone.utc),
+            )
+            self._apply_state(result.state)
+
+    def _zensdk_diagnostics(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "device_id": candidate_id,
+                "last_result": self._zensdk_last_result.get(candidate_id),
+                "consecutive_failures": self._zensdk_failures.get(candidate_id, 0),
+                "last_success": self._zensdk_last_success.get(candidate_id),
+            }
+            for candidate_id in sorted(self._zensdk_last_result)
+        ]
+
     def _apply_messages(self, messages: tuple[Any, ...]) -> None:
         if self._normalizer is None:
             return
@@ -272,23 +368,25 @@ class NativeZendureRuntime:
             result = self._normalizer.apply(message)
             if result is None:
                 continue
-            state = result.state
-            self._states[state.system_id] = state
-            packs = tuple(
-                BatteryPackIdentity(
-                    pack_id=pack.pack_id,
-                    parent_system_id=state.system_id,
-                    pack_type=_value(pack.pack_type),
-                    firmware=_value(pack.firmware),
-                )
-                for pack in state.packs
-            )
-            self._inventory.reconcile_packs(state.system_id, packs)
+            self._apply_state(result.state)
         if messages:
             self._last_received_at = max(
                 message.received_at for message in messages
             )
             self._processed_messages += len(messages)
+
+    def _apply_state(self, state: Any) -> None:
+        self._states[state.system_id] = state
+        packs = tuple(
+            BatteryPackIdentity(
+                pack_id=pack.pack_id,
+                parent_system_id=state.system_id,
+                pack_type=_value(pack.pack_type),
+                firmware=_value(pack.firmware),
+            )
+            for pack in state.packs
+        )
+        self._inventory.reconcile_packs(state.system_id, packs)
 
     def _set_status(self, value: str) -> None:
         self._status = value

--- a/custom_components/battery_smartflow_ai/zendure_initial_sync.py
+++ b/custom_components/battery_smartflow_ai/zendure_initial_sync.py
@@ -78,7 +78,9 @@ class InitialSyncCaptureResult:
                 "mqtt_messages": mqtt_messages,
                 "zensdk_requests": [
                     {
-                        "device_id": item.device_candidate_id,
+                        "device_id": _diagnostic_device_id(
+                            item.device_candidate_id
+                        ),
                         "path": "/properties/report",
                         "address_source": item.address_source,
                         "result": item.result,
@@ -319,7 +321,7 @@ def _raw_message(message: CloudMqttMessage) -> dict[str, Any]:
     return {
         "timestamp": _iso(message.received_at),
         "transport": message.transport,
-        "device_id": message.device_candidate_id,
+        "device_id": _diagnostic_device_id(message.device_candidate_id),
         "pack_id": message.pack_id,
         "topic": message.topic,
         "payload_format": message.payload_format,
@@ -371,8 +373,13 @@ def _build_summary(
             entry["last_seen"] = _iso(message.received_at)
     return {
         "device_count": len(expected_devices),
-        "devices_with_messages": sorted(seen_devices),
-        "devices_without_messages": sorted(set(expected_devices) - seen_devices),
+        "devices_with_messages": sorted(
+            _diagnostic_device_id(item) for item in seen_devices
+        ),
+        "devices_without_messages": sorted(
+            _diagnostic_device_id(item)
+            for item in set(expected_devices) - seen_devices
+        ),
         "pack_ids": sorted(packs),
         "models": sorted(
             {
@@ -406,6 +413,15 @@ def _payload_pack_ids(value: Any) -> set[str]:
                     result.add(pack_id)
                     break
     return result
+
+
+def _diagnostic_device_id(value: str | None) -> str | None:
+    """Use the source device ID so one device receives one export alias."""
+
+    if value is None:
+        return None
+    prefix = "cloud_mqtt:"
+    return value[len(prefix):] if value.startswith(prefix) else value
 
 
 def _property_items(value: Any, prefix: str = "") -> list[tuple[str, Any]]:

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -13,7 +13,7 @@ COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
 
 
 class DebugIntegrationContractTests(unittest.TestCase):
-    def test_manifest_and_runtime_version_match_v5_dev11_release(self) -> None:
+    def test_manifest_and_runtime_version_match_v5_dev12_release(self) -> None:
         manifest_version = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )["version"]
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "5.0.0.dev11")
+        self.assertEqual(manifest_version, "5.0.0.dev12")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_native_device_overview.py
+++ b/tests/test_native_device_overview.py
@@ -115,6 +115,22 @@ class NativeDeviceOverviewTests(unittest.TestCase):
         self.assertFalse(by_name["Battery SmartFlow AI"].actively_controlled)
         self.assertFalse(by_name["Other"].actively_controlled)
 
+    def test_fresh_data_preserves_online_state_but_offline_recovery_is_passive(self):
+        active = MainDevice.from_v4_config_entry("entry")
+        inventory = DeviceInventory(devices=(active,))
+
+        inventory.mark_available(active.system_id)
+        self.assertEqual(
+            inventory.devices[active.system_id].control_state,
+            DeviceControlState.ACTIVE,
+        )
+
+        inventory.mark_unavailable(active.system_id)
+        inventory.mark_available(active.system_id)
+        recovered = inventory.devices[active.system_id]
+        self.assertTrue(recovered.online)
+        self.assertEqual(recovered.control_state, DeviceControlState.OBSERVATION)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_native_zendure_ha_integration.py
+++ b/tests/test_native_zendure_ha_integration.py
@@ -17,7 +17,7 @@ class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
         manifest = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )
-        self.assertEqual(manifest["version"], "5.0.0.dev11")
+        self.assertEqual(manifest["version"], "5.0.0.dev12")
         self.assertIn("paho-mqtt==2.1.0", manifest["requirements"])
 
     def test_options_flow_uses_a_password_field_and_never_suggests_token(self) -> None:
@@ -47,6 +47,8 @@ class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
         self.assertNotIn("DeviceCommand", runtime)
         self.assertNotIn("def publish", mqtt)
         self.assertIn("self._consume_captured_messages(capture.messages)", runtime)
+        self.assertIn("await self._async_poll_zensdk()", runtime)
+        self.assertIn("ZENSDK_POLL_INTERVAL = 5.0", runtime)
 
     def test_secret_is_not_exposed_by_sensor_or_diagnostic_surfaces(self) -> None:
         runtime = (COMPONENT / "native_zendure_runtime.py").read_text(

--- a/tests/test_zendure_initial_sync.py
+++ b/tests/test_zendure_initial_sync.py
@@ -396,6 +396,14 @@ class InitialSyncCaptureTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(
             package["bsfai_interpretation"]["pack_ids"][0].startswith("ZD_SERIAL_A")
         )
+        self.assertEqual(
+            package["raw_communication"]["device_list"][0]["deviceKey"],
+            package["raw_communication"]["zensdk_responses"][0]["device_id"],
+        )
+        self.assertEqual(
+            package["bsfai_interpretation"]["devices_with_messages"],
+            [package["raw_communication"]["device_list"][0]["deviceKey"]],
+        )
 
     async def test_export_size_limit_is_enforced(self):
         result = self.recorder().finish(complete=False, reason="test")

--- a/tests/test_zendure_zensdk.py
+++ b/tests/test_zendure_zensdk.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from base64 import b64encode
 from datetime import datetime, timezone
+import sys
+from types import SimpleNamespace
+from types import ModuleType
 import unittest
 
 from support import bootstrap as bootstrap_test_environment
@@ -11,10 +14,18 @@ from support import bootstrap as bootstrap_test_environment
 
 bootstrap_test_environment()
 
+helpers_module = ModuleType("homeassistant.helpers")
+aiohttp_module = ModuleType("homeassistant.helpers.aiohttp_client")
+aiohttp_module.async_get_clientsession = lambda _hass: None
+sys.modules.setdefault("homeassistant.helpers", helpers_module)
+sys.modules.setdefault("homeassistant.helpers.aiohttp_client", aiohttp_module)
+
 from custom_components.battery_smartflow_ai.zendure_cloud import (  # noqa: E402
     ZendureCloudClient,
 )
 from custom_components.battery_smartflow_ai.zendure_zensdk import (  # noqa: E402
+    ZenSdkReadAttempt,
+    ZenSdkReadResult,
     _candidate_addresses,
     async_read_zensdk_reports,
 )
@@ -22,7 +33,11 @@ from custom_components.battery_smartflow_ai.zendure_normalizer import (  # noqa:
     ZendureCloudNormalizer,
 )
 from custom_components.battery_smartflow_ai.core.models import (  # noqa: E402
+    DeviceControlState,
     ZendureTransport,
+)
+from custom_components.battery_smartflow_ai.native_zendure_runtime import (  # noqa: E402
+    NativeZendureRuntime,
 )
 
 
@@ -144,6 +159,61 @@ class ZenSdkReadTests(unittest.IsolatedAsyncioTestCase):
                 "serial?query=1",
             ),
             (),
+        )
+
+    async def test_runtime_marks_offline_after_three_failures_and_recovers_read_only(self):
+        data = await make_bootstrap()
+        candidate_id = data.devices[0].candidate.candidate_id
+        runtime = NativeZendureRuntime(
+            SimpleNamespace(),
+            app_token="configured",
+            selected_device=None,
+            notify=lambda: None,
+        )
+        data.register_candidates(runtime._inventory)
+        runtime._inventory.add_observed_system(
+            candidate_id,
+            system_id=candidate_id,
+        )
+        runtime._normalizer = ZendureCloudNormalizer(data)
+        failure = ZenSdkReadResult(
+            (),
+            (
+                ZenSdkReadAttempt(
+                    candidate_id,
+                    "device_list_ip",
+                    "timeout",
+                ),
+            ),
+        )
+
+        runtime._record_zensdk_cycle(failure)
+        runtime._record_zensdk_cycle(failure)
+        self.assertTrue(runtime._inventory.devices[candidate_id].online)
+        runtime._record_zensdk_cycle(failure)
+        self.assertFalse(runtime._inventory.devices[candidate_id].online)
+        self.assertEqual(
+            runtime._inventory.devices[candidate_id].control_state,
+            DeviceControlState.OFFLINE,
+        )
+
+        async def get(_url, **_kwargs):
+            return Response({"properties": {"electricLevel": 81}})
+
+        success = await async_read_zensdk_reports(data, get)
+        runtime._record_zensdk_cycle(success)
+        runtime._apply_messages(success.messages)
+
+        self.assertTrue(runtime._inventory.devices[candidate_id].online)
+        self.assertEqual(
+            runtime._inventory.devices[candidate_id].control_state,
+            DeviceControlState.OBSERVATION,
+        )
+        self.assertEqual(runtime._zensdk_failures[candidate_id], 0)
+        self.assertEqual(runtime._processed_messages, 1)
+        self.assertEqual(
+            runtime._states[candidate_id].observed_transport,
+            ZendureTransport.ZENSDK,
         )
 
 


### PR DESCRIPTION
## Summary

- poll recognized local ZenSDK devices every five seconds using read-only GET /properties/report
- continuously update normalized main-device and pack states
- expose current observed transport, last-data timestamp, data age, polling result, and consecutive failures in native diagnostics
- mark a device offline only after three consecutive local read failures and recover into observation mode without enabling control
- unify the same main-device alias across discovery, ZenSDK response, and initial-sync summary
- bump the prerelease version to 5.0.0.dev12

## Safety

- no native write or control path is added
- the existing private/link-local address validation and diagnostic redaction remain enforced
- transient failures do not immediately mark a device offline
- recovery never restores an earlier active-control state automatically
- initial capture remains bounded; continuous polling does not create recurring capture files

## Validation

- 481 unit tests passed
- Python compilation passed
- git diff --check passed