### PR TITLE
V5 DEV13: add per-device Zendure HEMS hard blocker

### DIFF
--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -38,7 +38,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "5.0.0.dev12"
+INTEGRATION_VERSION = "5.0.0.dev13"
 
 # V5 native Zendure discovery is observation-only in the first development
 # build. The App Token is account discovery material and must never be copied

--- a/custom_components/battery_smartflow_ai/core/models/__init__.py
+++ b/custom_components/battery_smartflow_ai/core/models/__init__.py
@@ -17,6 +17,7 @@ from .inventory import (
     NativeDeviceIdentity,
     ZendureTransport,
 )
+from .hems import HemsStatus
 from .limits import (
     ControlBlocker,
     DirectionLimitRequest,
@@ -97,6 +98,7 @@ __all__ = [
     "DecisionContext",
     "GridHistoryState",
     "GridState",
+    "HemsStatus",
     "DiscoveryCandidate",
     "EffectivePowerLimit",
     "EffectiveSocLimits",

--- a/custom_components/battery_smartflow_ai/core/models/hems.py
+++ b/custom_components/battery_smartflow_ai/core/models/hems.py
@@ -1,0 +1,14 @@
+"""Neutral Zendure HEMS safety states."""
+
+from enum import StrEnum
+
+
+class HemsStatus(StrEnum):
+    """Safety-relevant interpretation of one device's HEMS telemetry."""
+
+    ACTIVE = "active"
+    INACTIVE = "inactive"
+    UNKNOWN = "unknown"
+    STALE = "stale"
+    INVALID = "invalid"
+    UNSUPPORTED = "unsupported"

--- a/custom_components/battery_smartflow_ai/core/models/inventory.py
+++ b/custom_components/battery_smartflow_ai/core/models/inventory.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field, replace
+from datetime import datetime
 from enum import StrEnum
 from types import MappingProxyType
 from typing import Any, Iterable, Mapping
+
+from .hems import HemsStatus
 
 
 class ZendureTransport(StrEnum):
@@ -147,6 +150,8 @@ class MainDevice:
     native_identities: tuple[NativeDeviceIdentity, ...] = ()
     online: bool = True
     hems_active: bool = False
+    hems_status: HemsStatus = HemsStatus.UNSUPPORTED
+    hems_observed_at: datetime | None = None
     supported: bool = True
 
     def __post_init__(self) -> None:
@@ -157,6 +162,9 @@ class MainDevice:
         identity_keys = [identity.key for identity in self.native_identities]
         if len(identity_keys) != len(set(identity_keys)):
             raise ValueError("Native identities must be unique per main system")
+        # Preserve the pre-DEV13 construction contract while storing richer state.
+        if self.hems_active and self.hems_status is HemsStatus.UNSUPPORTED:
+            object.__setattr__(self, "hems_status", HemsStatus.ACTIVE)
 
     @classmethod
     def from_v4_config_entry(
@@ -206,6 +214,10 @@ class MainDevice:
             "native_identities": [item.as_dict() for item in self.native_identities],
             "online": self.online,
             "hems_active": self.hems_active,
+            "hems_status": self.hems_status.value,
+            "hems_observed_at": (
+                self.hems_observed_at.isoformat() if self.hems_observed_at else None
+            ),
             "supported": self.supported,
         }
 
@@ -228,6 +240,19 @@ class MainDevice:
             ),
             online=bool(value.get("online", True)),
             hems_active=bool(value.get("hems_active", False)),
+            hems_status=HemsStatus(
+                str(
+                    value.get(
+                        "hems_status",
+                        "active" if value.get("hems_active", False) else "unsupported",
+                    )
+                )
+            ),
+            hems_observed_at=(
+                datetime.fromisoformat(str(value["hems_observed_at"]))
+                if value.get("hems_observed_at")
+                else None
+            ),
             supported=bool(value.get("supported", True)),
         )
 
@@ -402,7 +427,7 @@ class DeviceInventory:
                 raise ValueError("Unsupported device cannot be enabled")
             if not device.online:
                 raise ValueError("Offline device cannot be enabled")
-            if device.hems_active:
+            if device.control_state is DeviceControlState.HEMS_BLOCKED:
                 raise ValueError("HEMS-blocked device cannot be enabled")
         if state is DeviceControlState.ACTIVE and any(
             other_id != system_id
@@ -417,16 +442,39 @@ class DeviceInventory:
     def set_hems_active(self, system_id: str, active: bool) -> MainDevice:
         """Treat Zendure HEMS solely as a control blocker."""
 
+        return self.set_hems_status(
+            system_id,
+            HemsStatus.ACTIVE if active else HemsStatus.INACTIVE,
+        )
+
+    def set_hems_status(
+        self,
+        system_id: str,
+        status: HemsStatus,
+        *,
+        observed_at: datetime | None = None,
+    ) -> MainDevice:
+        """Apply the evaluated per-device HEMS state without auto-reactivation."""
+
         device = self._devices[system_id]
-        if active:
+        blocks = status not in {HemsStatus.INACTIVE, HemsStatus.UNSUPPORTED}
+        if blocks:
             state = DeviceControlState.HEMS_BLOCKED
+        elif device.control_state is not DeviceControlState.HEMS_BLOCKED:
+            state = device.control_state
         elif not device.supported:
             state = DeviceControlState.UNSUPPORTED
         elif not device.online:
             state = DeviceControlState.OFFLINE
         else:
             state = DeviceControlState.OBSERVATION
-        updated = replace(device, hems_active=active, control_state=state)
+        updated = replace(
+            device,
+            hems_active=status is HemsStatus.ACTIVE,
+            hems_status=status,
+            hems_observed_at=observed_at,
+            control_state=state,
+        )
         self._devices[system_id] = updated
         return updated
 
@@ -448,7 +496,10 @@ class DeviceInventory:
             return
         state = (
             DeviceControlState.HEMS_BLOCKED
-            if device.hems_active
+            if device.hems_status not in {
+                HemsStatus.INACTIVE,
+                HemsStatus.UNSUPPORTED,
+            }
             else DeviceControlState.OBSERVATION
             if device.supported
             else DeviceControlState.UNSUPPORTED

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": ["paho-mqtt==2.1.0"],
-  "version": "5.0.0.dev12"
+  "version": "5.0.0.dev13"
 }

--- a/custom_components/battery_smartflow_ai/native_device_overview.py
+++ b/custom_components/battery_smartflow_ai/native_device_overview.py
@@ -11,6 +11,7 @@ from typing import Mapping
 from .core.models import (
     DeviceControlState,
     DeviceInventory,
+    HemsStatus,
     MeasuredValue,
     NeutralDeviceState,
     ZendureTransport,
@@ -47,6 +48,9 @@ class MainSystemOverview:
     available_transports: tuple[ZendureTransport, ...]
     online: bool
     hems_active: bool
+    hems_status: HemsStatus
+    hems_observed_at: datetime | None
+    control_block_reason: str | None
     last_message_at: datetime | None
     packs: tuple[PackOverview, ...]
 
@@ -109,13 +113,20 @@ def build_native_device_overview(
                 actively_controlled=(
                     device.control_state is DeviceControlState.ACTIVE
                 ),
-                status_text=_status_text(device.control_state),
+                status_text=_status_text(device.control_state, device.hems_status),
                 selected_transport=device.selected_transport,
                 available_transports=tuple(
                     sorted(device.available_transports, key=lambda item: item.value)
                 ),
                 online=device.online,
                 hems_active=device.hems_active,
+                hems_status=device.hems_status,
+                hems_observed_at=device.hems_observed_at,
+                control_block_reason=(
+                    f"zendure_hems_{device.hems_status.value}"
+                    if device.control_state is DeviceControlState.HEMS_BLOCKED
+                    else None
+                ),
                 last_message_at=state.last_message_at if state else None,
                 packs=tuple(packs),
             )
@@ -128,13 +139,19 @@ def _public_id(kind: str, value: str) -> str:
     return f"ZD_{kind}_{digest}"
 
 
-def _status_text(state: DeviceControlState) -> str:
+def _status_text(state: DeviceControlState, hems_status: HemsStatus) -> str:
+    if state is DeviceControlState.HEMS_BLOCKED:
+        return {
+            HemsStatus.ACTIVE: "Observation mode - Zendure HEMS active",
+            HemsStatus.STALE: "Observation mode - Zendure HEMS status stale",
+            HemsStatus.INVALID: "Observation mode - Zendure HEMS status invalid",
+            HemsStatus.UNKNOWN: "Observation mode - Zendure HEMS status unknown",
+        }.get(hems_status, "Observation mode - Zendure HEMS blocks control")
     return {
         DeviceControlState.OBSERVATION: "Observation mode",
         DeviceControlState.ELIGIBLE: "Eligible for control",
         DeviceControlState.ENABLED: "Control enabled",
         DeviceControlState.ACTIVE: "Actively controlled",
-        DeviceControlState.HEMS_BLOCKED: "Observation mode - Zendure HEMS active",
         DeviceControlState.UNSUPPORTED: (
             "Observation mode - device profile not supported"
         ),

--- a/custom_components/battery_smartflow_ai/native_zendure_runtime.py
+++ b/custom_components/battery_smartflow_ai/native_zendure_runtime.py
@@ -16,6 +16,8 @@ from .core.models import BatteryPackIdentity, DeviceInventory, ValueValidity
 from .native_device_overview import build_native_device_overview
 from .zendure_cloud import ZendureCloudClient
 from .zendure_cloud_mqtt import ZendureCloudMqttTransport
+from .zendure_device_matrix import VerificationLevel, resolve_zendure_device
+from .zendure_hems import ZendureHemsCommandGate
 from .zendure_initial_sync import (
     async_capture_initial_sync,
     export_initial_sync_capture,
@@ -78,6 +80,7 @@ class NativeZendureRuntime:
         self._zensdk_failures: dict[str, int] = {}
         self._zensdk_last_result: dict[str, str] = {}
         self._zensdk_last_success: dict[str, datetime] = {}
+        self._hems_gate = ZendureHemsCommandGate()
 
     @property
     def configured(self) -> bool:
@@ -145,6 +148,10 @@ class NativeZendureRuntime:
                         state.observed_transport.value if state is not None else None
                     ),
                     "last_data_at": last_data,
+                    "hems_status": item.hems_status.value,
+                    "hems_last_updated": item.hems_observed_at,
+                    "hems_blocks_control": item.control_block_reason is not None,
+                    "control_block_reason": item.control_block_reason,
                     "data_age_seconds": (
                         max(0.0, round((now - last_data).total_seconds(), 1))
                         if last_data is not None
@@ -182,6 +189,13 @@ class NativeZendureRuntime:
                 "error": self._error,
                 "zensdk_poll_interval_seconds": ZENSDK_POLL_INTERVAL,
                 "zensdk_devices": self._zensdk_diagnostics(),
+                "hems_devices": [
+                    {
+                        "device_id": system_id,
+                        **self._hems_gate.diagnostics(system_id),
+                    }
+                    for system_id in sorted(self._inventory.devices)
+                ],
                 "overview": self.overview_attributes(),
             }
         )
@@ -377,6 +391,22 @@ class NativeZendureRuntime:
 
     def _apply_state(self, state: Any) -> None:
         self._states[state.system_id] = state
+        device = self._inventory.devices[state.system_id]
+        identity = device.native_identities[0] if device.native_identities else None
+        profile = resolve_zendure_device(identity) if identity is not None else None
+        capability = (
+            profile.hems_status if profile is not None else VerificationLevel.UNKNOWN
+        )
+        decision = self._hems_gate.update(
+            state.system_id,
+            state.hems_active,
+            capability=capability,
+        )
+        self._inventory.set_hems_status(
+            state.system_id,
+            decision.status,
+            observed_at=decision.observed_at,
+        )
         packs = tuple(
             BatteryPackIdentity(
                 pack_id=pack.pack_id,

--- a/custom_components/battery_smartflow_ai/zendure_hems.py
+++ b/custom_components/battery_smartflow_ai/zendure_hems.py
@@ -1,0 +1,140 @@
+"""Fail-closed, per-device Zendure HEMS command protection."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TypeVar
+
+from .core.models import HemsStatus, MeasuredValue, ValueValidity, ZendureTransport
+from .zendure_device_matrix import VerificationLevel
+
+
+@dataclass(frozen=True, slots=True)
+class HemsControlDecision:
+    """One explicit HEMS decision; absence never means permission."""
+
+    device_id: str
+    status: HemsStatus
+    command_allowed: bool
+    reason: str | None
+    observed_at: datetime | None
+
+
+@dataclass(frozen=True, slots=True)
+class HemsCommandResult:
+    """Result of the last safety gate immediately before a transport."""
+
+    sent: bool
+    decision: HemsControlDecision
+    command_type: str
+    transport: ZendureTransport
+
+
+def evaluate_hems_status(
+    value: MeasuredValue[bool],
+    *,
+    capability: VerificationLevel,
+) -> HemsStatus:
+    """Interpret HEMS without conflating unsupported and unavailable."""
+
+    if capability is VerificationLevel.UNSUPPORTED:
+        return HemsStatus.UNSUPPORTED
+    if value.valid:
+        return HemsStatus.ACTIVE if value.value else HemsStatus.INACTIVE
+    if value.validity is ValueValidity.STALE:
+        return HemsStatus.STALE
+    if value.validity is ValueValidity.INVALID:
+        return HemsStatus.INVALID
+    return HemsStatus.UNKNOWN
+
+
+ResultT = TypeVar("ResultT")
+TransportSender = Callable[[], Awaitable[ResultT]]
+
+
+class ZendureHemsCommandGate:
+    """Per-device guard which every future native transport can share."""
+
+    def __init__(self) -> None:
+        self._decisions: dict[str, HemsControlDecision] = {}
+        self._last_rejected: dict[str, HemsCommandResult] = {}
+
+    def update(
+        self,
+        device_id: str,
+        value: MeasuredValue[bool],
+        *,
+        capability: VerificationLevel,
+    ) -> HemsControlDecision:
+        status = evaluate_hems_status(value, capability=capability)
+        allowed = status in {HemsStatus.INACTIVE, HemsStatus.UNSUPPORTED}
+        reason = None if allowed else f"zendure_hems_{status.value}"
+        decision = HemsControlDecision(
+            device_id=device_id,
+            status=status,
+            command_allowed=allowed,
+            reason=reason,
+            observed_at=value.observed_at,
+        )
+        self._decisions[device_id] = decision
+        return decision
+
+    def decision(self, device_id: str) -> HemsControlDecision:
+        """Fail closed until this exact device has a usable observation."""
+
+        return self._decisions.get(
+            device_id,
+            HemsControlDecision(
+                device_id=device_id,
+                status=HemsStatus.UNKNOWN,
+                command_allowed=False,
+                reason="zendure_hems_unknown",
+                observed_at=None,
+            ),
+        )
+
+    async def execute(
+        self,
+        *,
+        device_id: str,
+        transport: ZendureTransport,
+        command_type: str,
+        send: TransportSender[ResultT],
+    ) -> ResultT | HemsCommandResult:
+        """Recheck HEMS at the last boundary before a real device write."""
+
+        decision = self.decision(device_id)
+        if command_type in {"hems", "hems_enable", "hems_disable"}:
+            decision = HemsControlDecision(
+                device_id=device_id,
+                status=decision.status,
+                command_allowed=False,
+                reason="zendure_hems_write_forbidden",
+                observed_at=decision.observed_at,
+            )
+        if decision.command_allowed:
+            return await send()
+        result = HemsCommandResult(
+            sent=False,
+            decision=decision,
+            command_type=command_type,
+            transport=transport,
+        )
+        self._last_rejected[device_id] = result
+        return result
+
+    def diagnostics(self, device_id: str) -> dict[str, object]:
+        decision = self.decision(device_id)
+        rejected = self._last_rejected.get(device_id)
+        return {
+            "status": decision.status.value,
+            "blocks_control": not decision.command_allowed,
+            "reason": decision.reason,
+            "last_updated": decision.observed_at,
+            "last_rejected_command": rejected.command_type if rejected else None,
+            "last_rejected_transport": (
+                rejected.transport.value if rejected else None
+            ),
+        }

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -13,7 +13,7 @@ COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
 
 
 class DebugIntegrationContractTests(unittest.TestCase):
-    def test_manifest_and_runtime_version_match_v5_dev12_release(self) -> None:
+    def test_manifest_and_runtime_version_match_v5_dev13_release(self) -> None:
         manifest_version = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )["version"]
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "5.0.0.dev12")
+        self.assertEqual(manifest_version, "5.0.0.dev13")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_native_device_overview.py
+++ b/tests/test_native_device_overview.py
@@ -9,7 +9,7 @@ from support import bootstrap
 bootstrap()
 
 from custom_components.battery_smartflow_ai.core.models import (  # noqa: E402
-    BatteryPackIdentity, DeviceControlState, DeviceInventory, MainDevice,
+    BatteryPackIdentity, DeviceControlState, DeviceInventory, HemsStatus, MainDevice,
     MeasuredValue, NativeDeviceIdentity, ZendureTransport,
 )
 from custom_components.battery_smartflow_ai.native_device_overview import (  # noqa: E402
@@ -114,6 +114,21 @@ class NativeDeviceOverviewTests(unittest.TestCase):
         by_name = {item.display_name: item for item in overview}
         self.assertFalse(by_name["Battery SmartFlow AI"].actively_controlled)
         self.assertFalse(by_name["Other"].actively_controlled)
+
+    def test_hems_quality_and_block_reason_are_visible_per_device(self):
+        main = MainDevice("main", "Main")
+        inventory = DeviceInventory(devices=(main,))
+        observed_at = datetime(2026, 9, 4, tzinfo=timezone.utc)
+        inventory.set_hems_status(
+            main.system_id,
+            HemsStatus.STALE,
+            observed_at=observed_at,
+        )
+        item = build_native_device_overview(inventory, {})[0]
+        self.assertEqual(item.hems_status, HemsStatus.STALE)
+        self.assertEqual(item.hems_observed_at, observed_at)
+        self.assertEqual(item.control_block_reason, "zendure_hems_stale")
+        self.assertIn("status stale", item.status_text)
 
     def test_fresh_data_preserves_online_state_but_offline_recovery_is_passive(self):
         active = MainDevice.from_v4_config_entry("entry")

--- a/tests/test_native_zendure_ha_integration.py
+++ b/tests/test_native_zendure_ha_integration.py
@@ -17,7 +17,7 @@ class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
         manifest = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )
-        self.assertEqual(manifest["version"], "5.0.0.dev12")
+        self.assertEqual(manifest["version"], "5.0.0.dev13")
         self.assertIn("paho-mqtt==2.1.0", manifest["requirements"])
 
     def test_options_flow_uses_a_password_field_and_never_suggests_token(self) -> None:

--- a/tests/test_zendure_hems.py
+++ b/tests/test_zendure_hems.py
@@ -1,0 +1,185 @@
+"""Contracts for the per-device Zendure HEMS hard blocker."""
+
+from datetime import datetime, timezone
+import unittest
+
+from support import bootstrap
+
+bootstrap()
+
+from custom_components.battery_smartflow_ai.core.models import (  # noqa: E402
+    MeasuredValue,
+    HemsStatus,
+    ValueValidity,
+    ZendureTransport,
+)
+from custom_components.battery_smartflow_ai.zendure_device_matrix import (  # noqa: E402
+    VerificationLevel,
+)
+from custom_components.battery_smartflow_ai.zendure_hems import (  # noqa: E402
+    HemsCommandResult,
+    ZendureHemsCommandGate,
+)
+
+
+NOW = datetime(2026, 9, 4, tzinfo=timezone.utc)
+
+
+class ZendureHemsCommandGateTests(unittest.IsolatedAsyncioTestCase):
+    async def test_active_hems_blocks_every_transport_and_command_type(self):
+        gate = ZendureHemsCommandGate()
+        gate.update(
+            "device-a",
+            MeasuredValue.available(True, observed_at=NOW),
+            capability=VerificationLevel.VERIFIED,
+        )
+        writes = []
+
+        async def send():
+            writes.append("sent")
+
+        for transport in (
+            ZendureTransport.CLOUD_MQTT,
+            ZendureTransport.LOCAL_MQTT,
+            ZendureTransport.ZENSDK,
+        ):
+            for command_type in (
+                "mode",
+                "input_limit",
+                "output_limit",
+                "soc_limits",
+                "manual",
+            ):
+                result = await gate.execute(
+                    device_id="device-a",
+                    transport=transport,
+                    command_type=command_type,
+                    send=send,
+                )
+                self.assertIsInstance(result, HemsCommandResult)
+                self.assertEqual(result.decision.reason, "zendure_hems_active")
+        self.assertEqual(writes, [])
+        self.assertEqual(
+            gate.diagnostics("device-a")["last_rejected_command"], "manual"
+        )
+
+    async def test_unknown_stale_and_invalid_capable_status_fail_closed(self):
+        for validity, expected in (
+            (ValueValidity.NEVER_RECEIVED, HemsStatus.UNKNOWN),
+            (ValueValidity.STALE, HemsStatus.STALE),
+            (ValueValidity.INVALID, HemsStatus.INVALID),
+        ):
+            gate = ZendureHemsCommandGate()
+            decision = gate.update(
+                "device-a",
+                MeasuredValue.absent(validity, observed_at=NOW),
+                capability=VerificationLevel.REFERENCE_ONLY,
+            )
+            self.assertEqual(decision.status, expected)
+            self.assertFalse(decision.command_allowed)
+
+    async def test_inactive_hems_does_not_bypass_other_future_gates(self):
+        gate = ZendureHemsCommandGate()
+        decision = gate.update(
+            "device-a",
+            MeasuredValue.available(False, observed_at=NOW),
+            capability=VerificationLevel.VERIFIED,
+        )
+        self.assertTrue(decision.command_allowed)
+        self.assertIsNone(decision.reason)
+
+        async def send():
+            return "next-gate-result"
+
+        result = await gate.execute(
+            device_id="device-a",
+            transport=ZendureTransport.ZENSDK,
+            command_type="mode",
+            send=send,
+        )
+        self.assertEqual(result, "next-gate-result")
+
+    async def test_unsupported_is_not_treated_as_unknown(self):
+        gate = ZendureHemsCommandGate()
+        decision = gate.update(
+            "legacy-device",
+            MeasuredValue.absent(ValueValidity.UNSUPPORTED),
+            capability=VerificationLevel.UNSUPPORTED,
+        )
+        self.assertEqual(decision.status, HemsStatus.UNSUPPORTED)
+        self.assertTrue(decision.command_allowed)
+
+    async def test_devices_are_isolated_and_deactivation_needs_readback(self):
+        gate = ZendureHemsCommandGate()
+        gate.update(
+            "blocked",
+            MeasuredValue.available(True, observed_at=NOW),
+            capability=VerificationLevel.VERIFIED,
+        )
+        gate.update(
+            "free",
+            MeasuredValue.available(False, observed_at=NOW),
+            capability=VerificationLevel.VERIFIED,
+        )
+        calls = []
+
+        async def send():
+            calls.append("sent")
+            return "sent"
+
+        blocked = await gate.execute(
+            device_id="blocked",
+            transport=ZendureTransport.CLOUD_MQTT,
+            command_type="mode",
+            send=send,
+        )
+        allowed = await gate.execute(
+            device_id="free",
+            transport=ZendureTransport.CLOUD_MQTT,
+            command_type="mode",
+            send=send,
+        )
+        self.assertIsInstance(blocked, HemsCommandResult)
+        self.assertEqual(allowed, "sent")
+        self.assertEqual(calls, ["sent"])
+
+        # A UI action cannot clear the blocker. Only fresh telemetry can update it.
+        self.assertFalse(gate.decision("blocked").command_allowed)
+        gate.update(
+            "blocked",
+            MeasuredValue.available(False, observed_at=NOW),
+            capability=VerificationLevel.VERIFIED,
+        )
+        self.assertTrue(gate.decision("blocked").command_allowed)
+
+    async def test_missing_device_state_fails_closed(self):
+        gate = ZendureHemsCommandGate()
+        decision = gate.decision("never-observed")
+        self.assertEqual(decision.status, HemsStatus.UNKNOWN)
+        self.assertFalse(decision.command_allowed)
+
+    async def test_bsfai_can_never_disable_hems(self):
+        gate = ZendureHemsCommandGate()
+        gate.update(
+            "device-a",
+            MeasuredValue.available(False, observed_at=NOW),
+            capability=VerificationLevel.VERIFIED,
+        )
+        calls = []
+
+        async def send():
+            calls.append("sent")
+
+        result = await gate.execute(
+            device_id="device-a",
+            transport=ZendureTransport.ZENSDK,
+            command_type="hems_disable",
+            send=send,
+        )
+        self.assertIsInstance(result, HemsCommandResult)
+        self.assertEqual(result.decision.reason, "zendure_hems_write_forbidden")
+        self.assertEqual(calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_zendure_zensdk.py
+++ b/tests/test_zendure_zensdk.py
@@ -207,7 +207,11 @@ class ZenSdkReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(runtime._inventory.devices[candidate_id].online)
         self.assertEqual(
             runtime._inventory.devices[candidate_id].control_state,
-            DeviceControlState.OBSERVATION,
+            DeviceControlState.HEMS_BLOCKED,
+        )
+        self.assertEqual(
+            runtime._inventory.devices[candidate_id].hems_status.value,
+            "unknown",
         )
         self.assertEqual(runtime._zensdk_failures[candidate_id], 0)
         self.assertEqual(runtime._processed_messages, 1)


### PR DESCRIPTION
## Summary

- add a fail-closed per-device Zendure HEMS state model for active, inactive, unknown, stale, invalid, and unsupported telemetry
- expose HEMS status, freshness, blocking reason, and diagnostics in the native device overview
- add a transport-neutral final command gate for Cloud MQTT, Local MQTT, and ZenSDK
- permanently reject any attempt by BSFAI to enable or disable Zendure HEMS
- keep native hardware access read-only and the existing Z-HA control path active
- bump the prerelease version to `5.0.0.dev13`

## Validation

- 489 unit and regression tests passed
- package compilation passed
- manifest JSON validation passed
- `git diff --check` passed

Closes #331