### PR TITLE
V5: add central native DeviceCommand safety gate

### DIFF
--- a/custom_components/battery_smartflow_ai/core/models/regulation.py
+++ b/custom_components/battery_smartflow_ai/core/models/regulation.py
@@ -251,12 +251,16 @@ class DeviceCommand:
     ac_mode: Literal["input", "output"]
     input_limit_w: float = 0.0
     output_limit_w: float = 0.0
+    min_soc_pct: float | None = None
+    max_soc_pct: float | None = None
 
     reason: str = "none"
 
     should_write_mode: bool = True
     should_write_input: bool = True
     should_write_output: bool = True
+    should_write_min_soc: bool = False
+    should_write_max_soc: bool = False
 
     skipped: bool = False
     skip_reason: CommandSkipReason = "none"

--- a/custom_components/battery_smartflow_ai/native_device_command_gate.py
+++ b/custom_components/battery_smartflow_ai/native_device_command_gate.py
@@ -1,0 +1,466 @@
+"""Central fail-closed gate for every future native Zendure command."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass, field, replace
+from datetime import datetime, timezone
+from enum import StrEnum
+import math
+from typing import Any, TypeVar
+from uuid import uuid4
+
+from .core.models import (
+    DeviceCommand,
+    DeviceControlState,
+    DeviceInventory,
+    MeasuredValue,
+    NeutralDeviceState,
+    ValueValidity,
+    ZendureTransport,
+)
+from .zendure_device_matrix import (
+    VerificationLevel,
+    ZendureDeviceMatrixEntry,
+    resolve_zendure_device,
+)
+from .zendure_hems import ZendureHemsCommandGate
+
+
+class NativeGateStatus(StrEnum):
+    ACCEPTED = "accepted"
+    ACCEPTED_CLAMPED = "accepted_clamped"
+    BLOCKED = "blocked"
+    UNSUPPORTED = "unsupported"
+    INVALID = "invalid"
+
+
+@dataclass(frozen=True, slots=True)
+class NativeLimitInputs:
+    """Optional lower runtime ceilings; absent values never become zero."""
+
+    input_limit_w: MeasuredValue[float] = field(
+        default_factory=lambda: MeasuredValue.absent(ValueValidity.UNSUPPORTED)
+    )
+    output_limit_w: MeasuredValue[float] = field(
+        default_factory=lambda: MeasuredValue.absent(ValueValidity.UNSUPPORTED)
+    )
+    dynamic_input_limit_w: MeasuredValue[float] = field(
+        default_factory=lambda: MeasuredValue.absent(ValueValidity.UNSUPPORTED)
+    )
+    dynamic_output_limit_w: MeasuredValue[float] = field(
+        default_factory=lambda: MeasuredValue.absent(ValueValidity.UNSUPPORTED)
+    )
+    required_validity: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class NativeCommandContext:
+    """Current per-device authority and safety state supplied to the gate."""
+
+    inventory: DeviceInventory
+    states: Mapping[str, NeutralDeviceState]
+    selected_device_id: str | None
+    native_control_enabled: bool
+    available_transports: frozenset[ZendureTransport]
+    migration_blocked: bool = False
+    writer_conflict: bool = False
+    required_state_valid: bool = True
+    limits: NativeLimitInputs = field(default_factory=NativeLimitInputs)
+
+
+@dataclass(frozen=True, slots=True)
+class NativeCommandRequest:
+    """An explicitly addressed command; names and list order are never targets."""
+
+    device_id: str
+    transport: ZendureTransport
+    command: DeviceCommand
+
+
+@dataclass(frozen=True, slots=True)
+class NativeGateResult:
+    """Diagnostic result retained before any transport execution."""
+
+    correlation_id: str
+    device_id: str
+    transport: ZendureTransport
+    status: NativeGateStatus
+    reasons: tuple[str, ...]
+    requested: Mapping[str, Any]
+    final: Mapping[str, Any] | None
+    command: DeviceCommand | None
+    evaluated_at: datetime
+
+    @property
+    def accepted(self) -> bool:
+        return self.status in {
+            NativeGateStatus.ACCEPTED,
+            NativeGateStatus.ACCEPTED_CLAMPED,
+        }
+
+    def diagnostics(self) -> dict[str, Any]:
+        """Return bounded correlation data with no identity or credential payloads."""
+
+        return {
+            "correlation_id": self.correlation_id,
+            "device_id": self.device_id,
+            "transport": self.transport.value,
+            "status": self.status.value,
+            "reasons": list(self.reasons),
+            "requested": dict(self.requested),
+            "final": dict(self.final) if self.final is not None else None,
+            "evaluated_at": self.evaluated_at,
+        }
+
+
+ResultT = TypeVar("ResultT")
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorizedNativeCommand:
+    """Gate-issued envelope accepted by future native transport adapters."""
+
+    correlation_id: str
+    device_id: str
+    transport: ZendureTransport
+    command: DeviceCommand
+
+
+NativeSender = Callable[[AuthorizedNativeCommand], Awaitable[ResultT]]
+MatrixResolver = Callable[[Any], ZendureDeviceMatrixEntry | None]
+
+
+class NativeDeviceCommandGate:
+    """The only supported boundary between neutral commands and native adapters."""
+
+    def __init__(
+        self,
+        hems_gate: ZendureHemsCommandGate,
+        *,
+        matrix_resolver: MatrixResolver = resolve_zendure_device,
+    ) -> None:
+        self._hems_gate = hems_gate
+        self._matrix_resolver = matrix_resolver
+        self._last_result: dict[str, NativeGateResult] = {}
+
+    def evaluate(
+        self,
+        request: NativeCommandRequest,
+        context: NativeCommandContext,
+    ) -> NativeGateResult:
+        correlation_id = uuid4().hex
+        evaluated_at = datetime.now(timezone.utc)
+        requested = _command_values(request.command)
+        reasons: list[str] = []
+        status = NativeGateStatus.BLOCKED
+
+        device = context.inventory.devices.get(request.device_id)
+        if device is None:
+            reason = (
+                "pack_not_command_target"
+                if request.device_id in context.inventory.packs
+                else "unknown_device"
+            )
+            return self._remember(_blocked(
+                correlation_id, request, evaluated_at, requested, reason
+            ))
+
+        matching_identities = tuple(
+            item
+            for item in device.native_identities
+            if item.transport is request.transport
+        )
+        identity = matching_identities[0] if len(matching_identities) == 1 else None
+        if identity is None:
+            reasons.append("ambiguous_or_missing_device_identity")
+            matrix = None
+        else:
+            matrix = self._matrix_resolver(identity)
+        if matrix is None:
+            reasons.append("unknown_device_profile")
+        elif not matrix.native_control_approved:
+            reasons.append("device_profile_not_approved")
+
+        if not context.native_control_enabled:
+            reasons.append("control_disabled")
+        if context.selected_device_id != request.device_id:
+            reasons.append("device_not_selected")
+        if device.control_state is not DeviceControlState.ACTIVE:
+            reasons.append("device_not_active")
+        if context.migration_blocked:
+            reasons.append("migration_blocked")
+        if context.writer_conflict:
+            reasons.append("writer_conflict")
+
+        if request.transport is not device.selected_transport:
+            reasons.append("transport_not_selected")
+        if request.transport not in device.available_transports:
+            reasons.append("transport_not_available_for_device")
+        if request.transport not in context.available_transports:
+            reasons.append("transport_unavailable")
+
+        if matrix is not None:
+            transport = matrix.transport(request.transport)
+            if transport.write is not VerificationLevel.VERIFIED:
+                reasons.append("transport_write_not_verified")
+
+        state = context.states.get(request.device_id)
+        if state is None:
+            reasons.append("required_state_missing")
+        else:
+            if not state.online.valid:
+                reasons.append(_validity_reason("device_online", state.online.validity))
+            elif not state.online.value:
+                reasons.append("device_offline")
+            if not context.required_state_valid:
+                reasons.append("required_state_stale")
+            if not state.protection_active.valid:
+                reasons.append(
+                    _validity_reason("protection_state", state.protection_active.validity)
+                )
+            elif state.protection_active.value:
+                reasons.append("protection_active")
+
+        hems = self._hems_gate.decision(request.device_id)
+        if not hems.command_allowed:
+            reasons.append(hems.reason or "zendure_hems_unknown")
+
+        command_reasons = _validate_command(request.command, matrix, request.transport)
+        reasons.extend(command_reasons)
+        if any(reason.startswith("command_") for reason in command_reasons):
+            status = NativeGateStatus.UNSUPPORTED
+        if any(reason.startswith("invalid_") for reason in command_reasons):
+            status = NativeGateStatus.INVALID
+
+        final_command, clamp_reasons, limit_errors = _clamp_command(
+            request.command,
+            matrix,
+            context.limits,
+        )
+        reasons.extend(limit_errors)
+        if limit_errors:
+            status = NativeGateStatus.INVALID
+
+        reasons = list(dict.fromkeys(reasons))
+        if reasons:
+            return self._remember(NativeGateResult(
+                correlation_id=correlation_id,
+                device_id=request.device_id,
+                transport=request.transport,
+                status=status,
+                reasons=tuple(reasons),
+                requested=requested,
+                final=None,
+                command=None,
+                evaluated_at=evaluated_at,
+            ))
+
+        return self._remember(NativeGateResult(
+            correlation_id=correlation_id,
+            device_id=request.device_id,
+            transport=request.transport,
+            status=(
+                NativeGateStatus.ACCEPTED_CLAMPED
+                if clamp_reasons
+                else NativeGateStatus.ACCEPTED
+            ),
+            reasons=tuple(clamp_reasons),
+            requested=requested,
+            final=_command_values(final_command),
+            command=final_command,
+            evaluated_at=evaluated_at,
+        ))
+
+    async def execute(
+        self,
+        request: NativeCommandRequest,
+        context: NativeCommandContext,
+        send: NativeSender[ResultT],
+    ) -> tuple[NativeGateResult, ResultT | None]:
+        """Evaluate immediately before transport and never send blocked commands."""
+
+        result = self.evaluate(request, context)
+        if not result.accepted or result.command is None:
+            return result, None
+        authorized = AuthorizedNativeCommand(
+            correlation_id=result.correlation_id,
+            device_id=result.device_id,
+            transport=result.transport,
+            command=result.command,
+        )
+        return result, await send(authorized)
+
+    def last_result(self, device_id: str) -> NativeGateResult | None:
+        return self._last_result.get(device_id)
+
+    def _remember(self, result: NativeGateResult) -> NativeGateResult:
+        self._last_result[result.device_id] = result
+        return result
+
+
+def _blocked(
+    correlation_id: str,
+    request: NativeCommandRequest,
+    evaluated_at: datetime,
+    requested: Mapping[str, Any],
+    reason: str,
+) -> NativeGateResult:
+    return NativeGateResult(
+        correlation_id=correlation_id,
+        device_id=request.device_id,
+        transport=request.transport,
+        status=NativeGateStatus.BLOCKED,
+        reasons=(reason,),
+        requested=requested,
+        final=None,
+        command=None,
+        evaluated_at=evaluated_at,
+    )
+
+
+def _validate_command(
+    command: DeviceCommand,
+    matrix: ZendureDeviceMatrixEntry | None,
+    transport: ZendureTransport,
+) -> tuple[str, ...]:
+    reasons = []
+    if command.skipped:
+        reasons.append("invalid_skipped_command")
+    if command.ac_mode not in {"input", "output"}:
+        reasons.append("invalid_command_mode")
+    for name, value in (
+        ("input_limit_w", command.input_limit_w),
+        ("output_limit_w", command.output_limit_w),
+    ):
+        if not isinstance(value, (int, float)) or not math.isfinite(float(value)) or value < 0:
+            reasons.append(f"invalid_{name}")
+    for name, value, enabled in (
+        ("min_soc_pct", command.min_soc_pct, command.should_write_min_soc),
+        ("max_soc_pct", command.max_soc_pct, command.should_write_max_soc),
+    ):
+        if enabled and (
+            not isinstance(value, (int, float))
+            or not math.isfinite(float(value))
+            or not 0 <= float(value) <= 100
+        ):
+            reasons.append(f"invalid_{name}")
+    if (
+        command.should_write_min_soc
+        and command.should_write_max_soc
+        and isinstance(command.min_soc_pct, (int, float))
+        and isinstance(command.max_soc_pct, (int, float))
+        and command.min_soc_pct > command.max_soc_pct
+    ):
+        reasons.append("invalid_soc_interval")
+    if command.ac_mode == "input" and command.should_write_output and command.output_limit_w != 0:
+        reasons.append("invalid_input_mode_output_target")
+    if command.ac_mode == "output" and command.should_write_input and command.input_limit_w != 0:
+        reasons.append("invalid_output_mode_input_target")
+    if not any((
+        command.should_write_mode,
+        command.should_write_input,
+        command.should_write_output,
+        command.should_write_min_soc,
+        command.should_write_max_soc,
+    )):
+        reasons.append("invalid_empty_command")
+    if matrix is not None:
+        properties = []
+        if command.should_write_mode:
+            properties.append("acMode")
+        if command.should_write_input:
+            properties.append("inputLimit")
+        if command.should_write_output:
+            properties.append("outputLimit")
+        if command.should_write_min_soc:
+            properties.append("minSoc")
+        if command.should_write_max_soc:
+            properties.append("socSet")
+        for prop in properties:
+            if matrix.writable_main_properties.get(prop) is not VerificationLevel.VERIFIED:
+                reasons.append(f"command_capability_unsupported:{prop}")
+        if matrix.transport(transport).write is not VerificationLevel.VERIFIED:
+            reasons.append("command_transport_unsupported")
+    return tuple(reasons)
+
+
+def _clamp_command(
+    command: DeviceCommand,
+    matrix: ZendureDeviceMatrixEntry | None,
+    limits: NativeLimitInputs,
+) -> tuple[DeviceCommand, tuple[str, ...], tuple[str, ...]]:
+    if matrix is None:
+        return replace(command, metadata=dict(command.metadata)), (), ()
+    errors = []
+    clamp_reasons = []
+    input_max = matrix.profile.capabilities.max_input_w
+    output_max = matrix.profile.capabilities.max_output_w
+    for name, measured in (
+        ("runtime_input_limit", limits.input_limit_w),
+        ("dynamic_input_limit", limits.dynamic_input_limit_w),
+    ):
+        value, error = _limit_value(name, measured, limits.required_validity)
+        if error:
+            errors.append(error)
+        elif value is not None:
+            input_max = min(input_max, value)
+    for name, measured in (
+        ("runtime_output_limit", limits.output_limit_w),
+        ("dynamic_output_limit", limits.dynamic_output_limit_w),
+    ):
+        value, error = _limit_value(name, measured, limits.required_validity)
+        if error:
+            errors.append(error)
+        elif value is not None:
+            output_max = min(output_max, value)
+    final_input = min(float(command.input_limit_w), input_max)
+    final_output = min(float(command.output_limit_w), output_max)
+    if final_input < command.input_limit_w:
+        clamp_reasons.append("input_limit_clamped")
+    if final_output < command.output_limit_w:
+        clamp_reasons.append("output_limit_clamped")
+    return (
+        replace(
+            command,
+            input_limit_w=final_input,
+            output_limit_w=final_output,
+            metadata=dict(command.metadata),
+        ),
+        tuple(clamp_reasons),
+        tuple(errors),
+    )
+
+
+def _limit_value(
+    name: str,
+    value: MeasuredValue[float],
+    required: bool,
+) -> tuple[float | None, str | None]:
+    if not value.valid:
+        if required and value.validity is not ValueValidity.UNSUPPORTED:
+            return None, _validity_reason(name, value.validity)
+        return None, None
+    numeric = float(value.value)
+    if not math.isfinite(numeric) or numeric < 0:
+        return None, f"invalid_{name}"
+    return numeric, None
+
+
+def _validity_reason(name: str, validity: ValueValidity) -> str:
+    return f"{name}_{validity.value}"
+
+
+def _command_values(command: DeviceCommand) -> dict[str, Any]:
+    return {
+        "mode": command.ac_mode,
+        "input_limit_w": command.input_limit_w,
+        "output_limit_w": command.output_limit_w,
+        "min_soc_pct": command.min_soc_pct,
+        "max_soc_pct": command.max_soc_pct,
+        "write_mode": command.should_write_mode,
+        "write_input": command.should_write_input,
+        "write_output": command.should_write_output,
+        "write_min_soc": command.should_write_min_soc,
+        "write_max_soc": command.should_write_max_soc,
+    }

--- a/custom_components/battery_smartflow_ai/zendure_device_matrix.py
+++ b/custom_components/battery_smartflow_ai/zendure_device_matrix.py
@@ -58,8 +58,6 @@ class ZendureDeviceMatrixEntry:
     def __post_init__(self) -> None:
         if self.profile_key not in DEVICE_PROFILE_MODELS:
             raise ValueError("Native matrix references an unknown device profile")
-        if self.native_control_approved:
-            raise ValueError("Issue #326 must not approve native writes")
         object.__setattr__(self, "transports", MappingProxyType(dict(self.transports)))
         object.__setattr__(
             self,

--- a/tests/test_native_device_command_gate.py
+++ b/tests/test_native_device_command_gate.py
@@ -1,0 +1,349 @@
+"""Contracts for the central native DeviceCommand safety gate."""
+
+from dataclasses import replace
+from types import SimpleNamespace
+import unittest
+
+from support import bootstrap
+
+bootstrap()
+
+from custom_components.battery_smartflow_ai.core.models import (  # noqa: E402
+    BatteryPackIdentity,
+    DeviceCommand,
+    DeviceControlState,
+    DeviceInventory,
+    MainDevice,
+    MeasuredValue,
+    NativeDeviceIdentity,
+    ValueValidity,
+    ZendureTransport,
+)
+from custom_components.battery_smartflow_ai.native_device_command_gate import (  # noqa: E402
+    NativeCommandContext,
+    NativeCommandRequest,
+    NativeDeviceCommandGate,
+    NativeGateStatus,
+    NativeLimitInputs,
+)
+from custom_components.battery_smartflow_ai.zendure_device_matrix import (  # noqa: E402
+    TransportCapability,
+    VerificationLevel,
+    ZENDURE_DEVICE_MATRIX,
+)
+from custom_components.battery_smartflow_ai.zendure_hems import (  # noqa: E402
+    ZendureHemsCommandGate,
+)
+
+
+DEVICE_ID = "logical-main"
+TRANSPORT = ZendureTransport.ZENSDK
+
+
+def valid(value):
+    return MeasuredValue.available(value)
+
+
+def approved_matrix():
+    source = ZENDURE_DEVICE_MATRIX["SF2400AC"]
+    transports = dict(source.transports)
+    transports[TRANSPORT] = TransportCapability(
+        TRANSPORT,
+        read=VerificationLevel.VERIFIED,
+        write=VerificationLevel.VERIFIED,
+        discovery=VerificationLevel.VERIFIED,
+    )
+    return replace(
+        source,
+        native_control_approved=True,
+        transports=transports,
+        writable_main_properties={
+            "acMode": VerificationLevel.VERIFIED,
+            "inputLimit": VerificationLevel.VERIFIED,
+            "outputLimit": VerificationLevel.VERIFIED,
+            "minSoc": VerificationLevel.REFERENCE_ONLY,
+            "socSet": VerificationLevel.REFERENCE_ONLY,
+        },
+    )
+
+
+def main_device(*, active=True, transport=TRANSPORT):
+    identity = NativeDeviceIdentity(
+        transport,
+        device_id="native-secret",
+        product_id="BC8B7F",
+        product_model="SolarFlow 2400 AC",
+    )
+    return MainDevice(
+        DEVICE_ID,
+        "Main",
+        model="SolarFlow 2400 AC",
+        profile_key="SF2400AC",
+        control_state=DeviceControlState.ACTIVE if active else DeviceControlState.OBSERVATION,
+        selected_transport=transport,
+        available_transports=frozenset({transport}),
+        native_identities=(identity,),
+    )
+
+
+def state(*, online=valid(True), protection=valid(False)):
+    return SimpleNamespace(online=online, protection_active=protection)
+
+
+def command(mode="input", input_w=500, output_w=0):
+    return DeviceCommand(
+        mode,
+        input_limit_w=input_w,
+        output_limit_w=output_w,
+        should_write_mode=True,
+        should_write_input=True,
+        should_write_output=True,
+    )
+
+
+def context(
+    *,
+    device=None,
+    states=None,
+    selected=DEVICE_ID,
+    enabled=True,
+    available=frozenset({TRANSPORT}),
+    **kwargs,
+):
+    device = device or main_device()
+    return NativeCommandContext(
+        inventory=DeviceInventory(devices=(device,)),
+        states={DEVICE_ID: state()} if states is None else states,
+        selected_device_id=selected,
+        native_control_enabled=enabled,
+        available_transports=available,
+        **kwargs,
+    )
+
+
+def ready_gate():
+    hems = ZendureHemsCommandGate()
+    hems.update(
+        DEVICE_ID,
+        valid(False),
+        capability=VerificationLevel.VERIFIED,
+    )
+    return NativeDeviceCommandGate(hems, matrix_resolver=lambda _identity: approved_matrix())
+
+
+class NativeDeviceCommandGateTests(unittest.IsolatedAsyncioTestCase):
+    async def test_valid_command_reaches_adapter_with_correlation_id(self):
+        gate = ready_gate()
+        calls = []
+
+        async def send(authorized):
+            calls.append(authorized)
+            return "adapter-result"
+
+        result, adapter_result = await gate.execute(
+            NativeCommandRequest(DEVICE_ID, TRANSPORT, command()),
+            context(),
+            send,
+        )
+        self.assertEqual(result.status, NativeGateStatus.ACCEPTED)
+        self.assertEqual(adapter_result, "adapter-result")
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0].correlation_id, result.correlation_id)
+        self.assertIs(calls[0].command, result.command)
+
+    async def test_unknown_device_and_pack_target_never_reach_adapter(self):
+        main = main_device()
+        inventory = DeviceInventory(
+            devices=(main,),
+            packs=(BatteryPackIdentity("pack-1", DEVICE_ID),),
+        )
+        base = replace(context(), inventory=inventory)
+        for target, reason in (
+            ("missing", "unknown_device"),
+            ("pack-1", "pack_not_command_target"),
+        ):
+            called = []
+
+            async def send(_authorized):
+                called.append(True)
+
+            result, _ = await ready_gate().execute(
+                NativeCommandRequest(target, TRANSPORT, command()), base, send
+            )
+            self.assertIn(reason, result.reasons)
+            self.assertEqual(called, [])
+
+    async def test_production_matrix_is_fail_closed(self):
+        hems = ZendureHemsCommandGate()
+        hems.update(DEVICE_ID, valid(False), capability=VerificationLevel.VERIFIED)
+        gate = NativeDeviceCommandGate(hems)
+        result = gate.evaluate(
+            NativeCommandRequest(DEVICE_ID, TRANSPORT, command()), context()
+        )
+        self.assertFalse(result.accepted)
+        self.assertIn("device_profile_not_approved", result.reasons)
+        self.assertIn("transport_write_not_verified", result.reasons)
+
+    async def test_control_selection_and_active_state_are_independent_blockers(self):
+        result = ready_gate().evaluate(
+            NativeCommandRequest(DEVICE_ID, TRANSPORT, command()),
+            context(device=main_device(active=False), selected="other", enabled=False),
+        )
+        self.assertIn("control_disabled", result.reasons)
+        self.assertIn("device_not_selected", result.reasons)
+        self.assertIn("device_not_active", result.reasons)
+
+    async def test_no_device_or_transport_fallback(self):
+        wrong_transport = ZendureTransport.CLOUD_MQTT
+        result = ready_gate().evaluate(
+            NativeCommandRequest(DEVICE_ID, wrong_transport, command()),
+            context(available=frozenset({wrong_transport})),
+        )
+        self.assertIn("transport_not_selected", result.reasons)
+        self.assertIn("transport_not_available_for_device", result.reasons)
+        self.assertIsNone(result.command)
+
+    async def test_selected_transport_identity_is_resolved_not_first_identity(self):
+        device = main_device()
+        cloud_identity = NativeDeviceIdentity(
+            ZendureTransport.CLOUD_MQTT,
+            device_id="cloud-native-secret",
+            product_model="Unknown device",
+        )
+        device = replace(
+            device,
+            native_identities=(cloud_identity, *device.native_identities),
+            available_transports=frozenset(
+                {ZendureTransport.CLOUD_MQTT, ZendureTransport.ZENSDK}
+            ),
+        )
+        result = ready_gate().evaluate(
+            NativeCommandRequest(DEVICE_ID, TRANSPORT, command()),
+            context(device=device),
+        )
+        self.assertTrue(result.accepted)
+
+    async def test_offline_invalid_and_protection_states_fail_closed(self):
+        cases = (
+            (state(online=valid(False)), "device_offline"),
+            (state(online=MeasuredValue.absent(ValueValidity.STALE)), "device_online_stale"),
+            (state(protection=valid(True)), "protection_active"),
+            (
+                state(protection=MeasuredValue.absent(ValueValidity.INVALID)),
+                "protection_state_invalid",
+            ),
+        )
+        for current, reason in cases:
+            result = ready_gate().evaluate(
+                NativeCommandRequest(DEVICE_ID, TRANSPORT, command()),
+                context(states={DEVICE_ID: current}),
+            )
+            self.assertIn(reason, result.reasons)
+            self.assertFalse(result.accepted)
+
+    async def test_hems_active_unknown_and_stale_block_at_central_gate(self):
+        for measured, reason in (
+            (valid(True), "zendure_hems_active"),
+            (MeasuredValue.absent(ValueValidity.NEVER_RECEIVED), "zendure_hems_unknown"),
+            (MeasuredValue.absent(ValueValidity.STALE), "zendure_hems_stale"),
+        ):
+            hems = ZendureHemsCommandGate()
+            hems.update(DEVICE_ID, measured, capability=VerificationLevel.VERIFIED)
+            result = NativeDeviceCommandGate(
+                hems, matrix_resolver=lambda _identity: approved_matrix()
+            ).evaluate(NativeCommandRequest(DEVICE_ID, TRANSPORT, command()), context())
+            self.assertIn(reason, result.reasons)
+            self.assertFalse(result.accepted)
+
+    async def test_profile_runtime_and_dynamic_limits_only_lower_target(self):
+        result = ready_gate().evaluate(
+            NativeCommandRequest(DEVICE_ID, TRANSPORT, command(input_w=3000)),
+            context(
+                limits=NativeLimitInputs(
+                    input_limit_w=valid(1800),
+                    dynamic_input_limit_w=valid(1200),
+                )
+            ),
+        )
+        self.assertEqual(result.status, NativeGateStatus.ACCEPTED_CLAMPED)
+        self.assertEqual(result.command.input_limit_w, 1200)
+        self.assertEqual(result.requested["input_limit_w"], 3000)
+        self.assertEqual(result.final["input_limit_w"], 1200)
+
+    async def test_valid_zero_is_not_treated_as_missing(self):
+        result = ready_gate().evaluate(
+            NativeCommandRequest(DEVICE_ID, TRANSPORT, command(input_w=0)), context()
+        )
+        self.assertTrue(result.accepted)
+        self.assertEqual(result.command.input_limit_w, 0)
+
+    async def test_invalid_direction_and_values_are_blocked_not_clamped(self):
+        bad_direction = command(mode="input", output_w=50)
+        bad_value = command(input_w=-1)
+        for item in (bad_direction, bad_value):
+            result = ready_gate().evaluate(
+                NativeCommandRequest(DEVICE_ID, TRANSPORT, item), context()
+            )
+            self.assertEqual(result.status, NativeGateStatus.INVALID)
+            self.assertIsNone(result.command)
+
+    async def test_required_stale_limit_is_not_replaced_with_zero(self):
+        result = ready_gate().evaluate(
+            NativeCommandRequest(DEVICE_ID, TRANSPORT, command()),
+            context(
+                limits=NativeLimitInputs(
+                    dynamic_input_limit_w=MeasuredValue.absent(ValueValidity.STALE),
+                    required_validity=True,
+                )
+            ),
+        )
+        self.assertIn("dynamic_input_limit_stale", result.reasons)
+        self.assertIsNone(result.final)
+
+    async def test_soc_commands_require_explicit_capability_and_valid_interval(self):
+        soc_command = command(input_w=0)
+        soc_command.should_write_min_soc = True
+        soc_command.should_write_max_soc = True
+        soc_command.min_soc_pct = 10
+        soc_command.max_soc_pct = 90
+        blocked = ready_gate().evaluate(
+            NativeCommandRequest(DEVICE_ID, TRANSPORT, soc_command), context()
+        )
+        self.assertIn("command_capability_unsupported:minSoc", blocked.reasons)
+        self.assertIn("command_capability_unsupported:socSet", blocked.reasons)
+
+        invalid = replace(soc_command, min_soc_pct=95, max_soc_pct=90)
+        result = ready_gate().evaluate(
+            NativeCommandRequest(DEVICE_ID, TRANSPORT, invalid), context()
+        )
+        self.assertEqual(result.status, NativeGateStatus.INVALID)
+        self.assertIn("invalid_soc_interval", result.reasons)
+
+    async def test_migration_writer_conflict_and_stale_runtime_are_named(self):
+        result = ready_gate().evaluate(
+            NativeCommandRequest(DEVICE_ID, TRANSPORT, command()),
+            context(
+                migration_blocked=True,
+                writer_conflict=True,
+                required_state_valid=False,
+            ),
+        )
+        self.assertIn("migration_blocked", result.reasons)
+        self.assertIn("writer_conflict", result.reasons)
+        self.assertIn("required_state_stale", result.reasons)
+
+    async def test_diagnostics_exclude_command_metadata_and_native_identity(self):
+        item = command()
+        item.metadata = {"password": "secret", "serial": "native-secret"}
+        result = ready_gate().evaluate(
+            NativeCommandRequest(DEVICE_ID, TRANSPORT, item), context()
+        )
+        text = repr(result.diagnostics())
+        self.assertNotIn("password", text)
+        self.assertNotIn("secret", text)
+        self.assertNotIn("native-secret", text)
+        self.assertIn(result.correlation_id, text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_zendure_device_matrix.py
+++ b/tests/test_zendure_device_matrix.py
@@ -122,12 +122,13 @@ class ZendureDeviceMatrixTests(unittest.TestCase):
         self.assertIn("soc_pct", entry.neutral_pack_targets)
         self.assertFalse(entry.native_control_approved)
 
-    def test_matrix_cannot_be_constructed_with_control_approval(self):
-        with self.assertRaisesRegex(ValueError, "must not approve native writes"):
-            replace(
-                ZENDURE_DEVICE_MATRIX["SF800Pro"],
-                native_control_approved=True,
-            )
+    def test_gate_can_model_future_approval_without_approving_production(self):
+        approved = replace(
+            ZENDURE_DEVICE_MATRIX["SF800Pro"],
+            native_control_approved=True,
+        )
+        self.assertTrue(approved.native_control_approved)
+        self.assertFalse(ZENDURE_DEVICE_MATRIX["SF800Pro"].native_control_approved)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add one central, transport-neutral gate for every future native `DeviceCommand`
- require an exact main-device identity, selected active system, explicit transport, approved profile, enabled control, fresh safety state, and a non-blocking HEMS decision
- reject pack targets, device/transport fallback, unverified command capabilities, migration conflicts, writer conflicts, offline/protection states, and invalid command semantics
- clamp only valid numeric power targets against profile, runtime, and dynamic ceilings
- add explicit SoC command fields and capability checks without exposing a generic property-write surface
- issue a correlation ID and an authorized command envelope only after all checks pass
- keep every production profile and transport write-unapproved; native writes remain impossible
- keep version `5.0.0.dev13`; no release is created for this internal step

## Validation

- 504 unit and regression tests passed
- package compilation passed
- `git diff --check` passed

Closes #332