### PR TITLE
V5: track Zendure HEMS activity safely

### DIFF
--- a/custom_components/battery_smartflow_ai/native_zendure_runtime.py
+++ b/custom_components/battery_smartflow_ai/native_zendure_runtime.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from .core.models import BatteryPackIdentity, DeviceInventory, ValueValidity
 from .native_device_overview import build_native_device_overview
 from .zendure_cloud import ZendureCloudClient
-from .zendure_cloud_mqtt import ZendureCloudMqttTransport
+from .zendure_cloud_mqtt import ConnectionState, ZendureCloudMqttTransport
 from .zendure_device_matrix import VerificationLevel, resolve_zendure_device
 from .zendure_hems import ZendureHemsCommandGate
 from .zendure_initial_sync import (
@@ -193,6 +193,7 @@ class NativeZendureRuntime:
                     {
                         "device_id": system_id,
                         **self._hems_gate.diagnostics(system_id),
+                        **self._hems_activity_diagnostics(system_id),
                     }
                     for system_id in sorted(self._inventory.devices)
                 ],
@@ -357,12 +358,37 @@ class NativeZendureRuntime:
     def _refresh_snapshots(self) -> None:
         if self._normalizer is None:
             return
+        now = datetime.now(timezone.utc)
         for system_id in tuple(self._inventory.devices):
+            self._normalizer.set_hems_monitoring(
+                system_id,
+                self._transport is not None
+                and self._transport.state is ConnectionState.CONNECTED,
+                observed_at=now,
+            )
             result = self._normalizer.snapshot(
                 system_id,
-                now=datetime.now(timezone.utc),
+                now=now,
             )
             self._apply_state(result.state)
+
+    def _hems_activity_diagnostics(self, system_id: str) -> dict[str, Any]:
+        if self._normalizer is None:
+            return {}
+        value = self._normalizer.hems_diagnostics(
+            system_id,
+            now=datetime.now(timezone.utc),
+        )
+        return {
+            "activity_source": value.source,
+            "activity_monitoring": value.monitoring,
+            "activity_monitoring_started": value.monitoring_started_at,
+            "last_activity": value.last_activity_at,
+            "activity_quiet_seconds": value.quiet_seconds,
+            "activity_confirmation_window_seconds": (
+                value.confirmation_window_seconds
+            ),
+        }
 
     def _zensdk_diagnostics(self) -> list[dict[str, Any]]:
         return [

--- a/custom_components/battery_smartflow_ai/zendure_cloud_mqtt.py
+++ b/custom_components/battery_smartflow_ai/zendure_cloud_mqtt.py
@@ -375,7 +375,11 @@ class ZendureCloudMqttTransport:
         received_at = self._clock()
         parsed, payload_format = _parse_payload(payload)
         candidate_id, pack_id = self._route_message(topic, parsed)
-        known_topic = topic.endswith("/properties/report") or topic.endswith("/state")
+        known_topic = (
+            topic.endswith("/properties/report")
+            or topic.endswith("/properties/energy")
+            or topic.endswith("/state")
+        )
         message = CloudMqttMessage(
             received_at=received_at,
             topic=topic,

--- a/custom_components/battery_smartflow_ai/zendure_hems_activity.py
+++ b/custom_components/battery_smartflow_ai/zendure_hems_activity.py
@@ -1,0 +1,87 @@
+"""Interpret Zendure Cloud HEMS activity without guessing device properties."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from .core.models import MeasuredValue, ValueValidity
+
+
+HEMS_ACTIVITY_TIMEOUT_SECONDS = 60.0
+HEMS_ACTIVITY_SOURCE = "cloud_mqtt_properties_energy"
+
+
+@dataclass(frozen=True, slots=True)
+class HemsActivityDiagnostic:
+    monitoring: bool
+    source: str
+    monitoring_started_at: datetime | None
+    last_activity_at: datetime | None
+    quiet_seconds: float | None
+    confirmation_window_seconds: float
+
+
+class HemsActivityTracker:
+    """Per-device heartbeat tracker matching the observed Zendure event path."""
+
+    def __init__(self, *, timeout_seconds: float = HEMS_ACTIVITY_TIMEOUT_SECONDS) -> None:
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        self._timeout = float(timeout_seconds)
+        self._monitoring = False
+        self._monitoring_started_at: datetime | None = None
+        self._last_activity_at: datetime | None = None
+
+    def set_monitoring(self, available: bool, *, observed_at: datetime) -> None:
+        """Start a fresh quiet window only for a healthy subscribed transport."""
+
+        if available and not self._monitoring:
+            self._monitoring_started_at = observed_at
+        self._monitoring = available
+
+    def observe_energy(self, *, observed_at: datetime) -> None:
+        """Treat properties/energy solely as positive HEMS activity evidence."""
+
+        self._last_activity_at = observed_at
+
+    def measurement(self, *, now: datetime) -> MeasuredValue[bool]:
+        if self._last_activity_at is not None:
+            age = max(0.0, (now - self._last_activity_at).total_seconds())
+            if not self._monitoring:
+                return MeasuredValue.absent(
+                    ValueValidity.STALE,
+                    observed_at=self._last_activity_at,
+                )
+            if age <= self._timeout:
+                return MeasuredValue.available(
+                    True,
+                    observed_at=self._last_activity_at,
+                )
+            return MeasuredValue.available(
+                False,
+                observed_at=self._last_activity_at,
+            )
+
+        if not self._monitoring or self._monitoring_started_at is None:
+            return MeasuredValue.absent(ValueValidity.NEVER_RECEIVED)
+        quiet = max(0.0, (now - self._monitoring_started_at).total_seconds())
+        if quiet <= self._timeout:
+            return MeasuredValue.absent(
+                ValueValidity.NEVER_RECEIVED,
+                observed_at=self._monitoring_started_at,
+            )
+        return MeasuredValue.available(False, observed_at=self._monitoring_started_at)
+
+    def diagnostics(self, *, now: datetime) -> HemsActivityDiagnostic:
+        anchor = self._last_activity_at or self._monitoring_started_at
+        return HemsActivityDiagnostic(
+            monitoring=self._monitoring,
+            source=HEMS_ACTIVITY_SOURCE,
+            monitoring_started_at=self._monitoring_started_at,
+            last_activity_at=self._last_activity_at,
+            quiet_seconds=(
+                max(0.0, (now - anchor).total_seconds()) if anchor else None
+            ),
+            confirmation_window_seconds=self._timeout,
+        )

--- a/custom_components/battery_smartflow_ai/zendure_normalizer.py
+++ b/custom_components/battery_smartflow_ai/zendure_normalizer.py
@@ -20,6 +20,7 @@ from .core.models import (
 from .zendure_cloud import ZendureCloudBootstrap
 from .zendure_cloud_mqtt import CloudMqttMessage
 from .zendure_device_matrix import resolve_zendure_device
+from .zendure_hems_activity import HemsActivityDiagnostic, HemsActivityTracker
 
 
 DEFAULT_STALE_AFTER_SECONDS = 30.0
@@ -270,6 +271,9 @@ class ZendureCloudNormalizer:
         self._last_message: dict[str, datetime | None] = {
             candidate_id: None for candidate_id in self._models
         }
+        self._hems_activity = {
+            candidate_id: HemsActivityTracker() for candidate_id in self._models
+        }
         self._observed_transport: dict[str, ZendureTransport] = {
             candidate_id: ZendureTransport.CLOUD_MQTT
             for candidate_id in self._models
@@ -330,10 +334,34 @@ class ZendureCloudNormalizer:
                 )
             self._apply_packs(system_id, payload.get("packData"), observed_at)
         if message.topic.endswith("/properties/energy"):
-            self._device_values[system_id]["hems_active"] = _Observed(
-                True, ValueValidity.VALID, observed_at
-            )
+            self._hems_activity[system_id].observe_energy(observed_at=observed_at)
         return self.snapshot(system_id, now=now or observed_at)
+
+    def set_hems_monitoring(
+        self,
+        system_id: str,
+        available: bool,
+        *,
+        observed_at: datetime,
+    ) -> None:
+        """Tell the tracker whether Cloud MQTT is currently subscribed."""
+
+        if system_id not in self._models:
+            raise KeyError(system_id)
+        self._hems_activity[system_id].set_monitoring(
+            available,
+            observed_at=observed_at,
+        )
+
+    def hems_diagnostics(
+        self,
+        system_id: str,
+        *,
+        now: datetime,
+    ) -> HemsActivityDiagnostic:
+        if system_id not in self._models:
+            raise KeyError(system_id)
+        return self._hems_activity[system_id].diagnostics(now=now)
 
     def set_online(self, system_id: str, online: bool) -> None:
         if system_id not in self._models:
@@ -355,6 +383,14 @@ class ZendureCloudNormalizer:
 
         def device_value(target: str) -> MeasuredValue[Any]:
             return self._value(values, target, supported, online, current)
+
+        direct_hems = device_value("hems_active")
+        hems_active = (
+            direct_hems
+            if direct_hems.validity
+            not in {ValueValidity.NEVER_RECEIVED, ValueValidity.MISSING}
+            else self._hems_activity[system_id].measurement(now=current)
+        )
 
         packs = tuple(
             self._pack_snapshot(system_id, pack_id, accumulator, current, online)
@@ -395,7 +431,7 @@ class ZendureCloudNormalizer:
                 min_soc_pct=device_value("min_soc_pct"),
                 max_soc_pct=device_value("max_soc_pct"),
             ),
-            hems_active=device_value("hems_active"),
+            hems_active=hems_active,
             fault_code=device_value("fault_code"),
             protection_active=device_value("protection_active"),
             temperature_c=device_value("temperature_c"),

--- a/tests/test_zendure_cloud_mqtt.py
+++ b/tests/test_zendure_cloud_mqtt.py
@@ -148,6 +148,23 @@ class CloudMqttTransportTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(message.device_candidate_id, "cloud_mqtt:main-1")
         self.assertEqual(message.pack_id, "pack-77")
 
+    async def test_properties_energy_is_known_and_routed_per_device(self):
+        transport = ZendureCloudMqttTransport(
+            self.data,
+            session_factory=self.factory,
+            clock=lambda: self.now,
+        )
+        await transport.async_start()
+        self.sessions[0].emit(
+            "/product-a/main-1/properties/energy",
+            json.dumps({"properties": {"gridPower": 120}}).encode(),
+        )
+        await asyncio.sleep(0)
+        message = transport.messages[0]
+        self.assertTrue(message.known_topic)
+        self.assertEqual(message.device_candidate_id, "cloud_mqtt:main-1")
+        self.assertTrue(message.topic.endswith("/properties/energy"))
+
     async def test_disconnect_reconnects_without_commands(self):
         transport = ZendureCloudMqttTransport(self.data, session_factory=self.factory, reconnect_delays=(0.0,))
         await transport.async_start()

--- a/tests/test_zendure_hems_activity.py
+++ b/tests/test_zendure_hems_activity.py
@@ -1,0 +1,79 @@
+"""Contracts for Cloud-MQTT HEMS activity interpretation."""
+
+from datetime import datetime, timedelta, timezone
+import unittest
+
+from support import bootstrap
+
+bootstrap()
+
+from custom_components.battery_smartflow_ai.core.models import ValueValidity  # noqa: E402
+from custom_components.battery_smartflow_ai.zendure_hems_activity import (  # noqa: E402
+    HEMS_ACTIVITY_SOURCE,
+    HemsActivityTracker,
+)
+
+
+NOW = datetime(2026, 9, 4, tzinfo=timezone.utc)
+
+
+class HemsActivityTrackerTests(unittest.TestCase):
+    def test_restart_without_activity_stays_unknown_for_full_window(self):
+        tracker = HemsActivityTracker(timeout_seconds=60)
+        tracker.set_monitoring(True, observed_at=NOW)
+        value = tracker.measurement(now=NOW + timedelta(seconds=60))
+        self.assertIsNone(value.value)
+        self.assertEqual(value.validity, ValueValidity.NEVER_RECEIVED)
+
+    def test_confirmed_quiet_subscription_can_report_inactive_after_window(self):
+        tracker = HemsActivityTracker(timeout_seconds=60)
+        tracker.set_monitoring(True, observed_at=NOW)
+        value = tracker.measurement(now=NOW + timedelta(seconds=61))
+        self.assertFalse(value.value)
+        self.assertTrue(value.valid)
+
+    def test_energy_activity_is_immediately_active_for_only_its_tracker(self):
+        first = HemsActivityTracker(timeout_seconds=60)
+        second = HemsActivityTracker(timeout_seconds=60)
+        for tracker in (first, second):
+            tracker.set_monitoring(True, observed_at=NOW)
+        first.observe_energy(observed_at=NOW + timedelta(seconds=5))
+        self.assertTrue(first.measurement(now=NOW + timedelta(seconds=5)).value)
+        self.assertIsNone(second.measurement(now=NOW + timedelta(seconds=5)).value)
+
+    def test_activity_remains_active_until_complete_timeout(self):
+        tracker = HemsActivityTracker(timeout_seconds=60)
+        tracker.set_monitoring(True, observed_at=NOW)
+        tracker.observe_energy(observed_at=NOW)
+        self.assertTrue(tracker.measurement(now=NOW + timedelta(seconds=60)).value)
+        self.assertFalse(tracker.measurement(now=NOW + timedelta(seconds=61)).value)
+
+    def test_transport_loss_makes_prior_activity_stale_not_inactive(self):
+        tracker = HemsActivityTracker(timeout_seconds=60)
+        tracker.set_monitoring(True, observed_at=NOW)
+        tracker.observe_energy(observed_at=NOW)
+        tracker.set_monitoring(False, observed_at=NOW + timedelta(seconds=10))
+        value = tracker.measurement(now=NOW + timedelta(seconds=90))
+        self.assertIsNone(value.value)
+        self.assertEqual(value.validity, ValueValidity.STALE)
+
+    def test_reconnect_starts_a_new_complete_confirmation_window(self):
+        tracker = HemsActivityTracker(timeout_seconds=60)
+        tracker.set_monitoring(True, observed_at=NOW)
+        tracker.set_monitoring(False, observed_at=NOW + timedelta(seconds=20))
+        reconnected = NOW + timedelta(seconds=100)
+        tracker.set_monitoring(True, observed_at=reconnected)
+        self.assertIsNone(
+            tracker.measurement(now=reconnected + timedelta(seconds=30)).value
+        )
+
+    def test_diagnostics_name_exact_activity_source(self):
+        tracker = HemsActivityTracker(timeout_seconds=60)
+        diagnostic = tracker.diagnostics(now=NOW)
+        self.assertEqual(diagnostic.source, HEMS_ACTIVITY_SOURCE)
+        self.assertFalse(diagnostic.monitoring)
+        self.assertIsNone(diagnostic.last_activity_at)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_zendure_normalizer.py
+++ b/tests/test_zendure_normalizer.py
@@ -271,11 +271,28 @@ class ZendureNormalizerTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_hems_energy_topic_is_observed_as_blocker_input_only(self):
         normalizer = ZendureCloudNormalizer(self.bootstrap)
+        system_id = self.bootstrap.devices[0].candidate.candidate_id
+        normalizer.set_hems_monitoring(system_id, True, observed_at=self.at)
         result = normalizer.apply(
             report(self.at, {}, topic="properties/energy")
         )
         self.assertTrue(result.state.hems_active.value)
         self.assertTrue(result.state.hems_active.valid)
+
+    async def test_zensdk_report_without_hems_does_not_imply_inactive(self):
+        normalizer = ZendureCloudNormalizer(self.bootstrap)
+        result = normalizer.apply(
+            report(
+                self.at,
+                {"properties": {"smartMode": 0, "IOTState": 2, "bindstate": 0}},
+                topic="zensdk/properties/report",
+            )
+        )
+        self.assertIsNone(result.state.hems_active.value)
+        self.assertEqual(
+            result.state.hems_active.validity,
+            ValueValidity.NEVER_RECEIVED,
+        )
 
     async def test_unknown_device_message_is_not_guessed(self):
         normalizer = ZendureCloudNormalizer(self.bootstrap)


### PR DESCRIPTION
## Summary

- recognize and route Zendure properties/energy activity per device
- treat observed activity as immediate positive HEMS evidence
- require a complete 60-second healthy and subscribed quiet window before reporting HEMS inactive
- report stale data after transport loss and restart the confirmation window after reconnect
- never infer HEMS state from smartMode, IOTState, indstate, or a missing ZenSDK field
- expose activity source and freshness details in diagnostics

## Scope

- read-only telemetry only; no native control writes
- integration version remains 5.0.0.dev13
- no development release is created for this intermediate step

## Validation

- full test suite: 513 tests passed
- Python compilation passed
- manifest JSON validation passed
- staged diff and whitespace checks passed

Closes #399