### PR TITLE
V5: add first verified native Zendure write

### DIFF
--- a/custom_components/battery_smartflow_ai/__init__.py
+++ b/custom_components/battery_smartflow_ai/__init__.py
@@ -34,6 +34,7 @@ _LOGGER = logging.getLogger(__name__)
 
 SERVICE_START_DEBUG_RECORDING = "start_debug_recording"
 SERVICE_STOP_DEBUG_RECORDING = "stop_debug_recording"
+SERVICE_VERIFY_NATIVE_WRITE = "verify_native_write"
 
 
 class _DisabledNativeRuntime:
@@ -44,6 +45,9 @@ class _DisabledNativeRuntime:
 
     async def async_stop(self) -> None:
         return None
+
+    async def async_run_first_write_test(self):
+        raise ValueError("native_device_not_ready")
 
 
 def _coordinator_for_call(hass: HomeAssistant, call: ServiceCall) -> ZendureSmartFlowCoordinator:
@@ -98,6 +102,22 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
             SERVICE_STOP_DEBUG_RECORDING,
             async_stop_debug_recording,
             schema=vol.Schema({vol.Optional("entry_id"): str}),
+        )
+    if not hass.services.has_service(DOMAIN, SERVICE_VERIFY_NATIVE_WRITE):
+        async def async_verify_native_write(call: ServiceCall) -> None:
+            coordinator = _coordinator_for_call(hass, call)
+            await coordinator.native_zendure.async_run_first_write_test()
+
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_VERIFY_NATIVE_WRITE,
+            async_verify_native_write,
+            schema=vol.Schema(
+                {
+                    vol.Optional("entry_id"): str,
+                    vol.Required("confirm"): vol.In({True}),
+                }
+            ),
         )
     return True
 

--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -38,7 +38,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "5.0.0.dev13"
+INTEGRATION_VERSION = "5.0.0.dev14"
 
 # V5 native Zendure discovery is observation-only in the first development
 # build. The App Token is account discovery material and must never be copied

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": ["paho-mqtt==2.1.0"],
-  "version": "5.0.0.dev13"
+  "version": "5.0.0.dev14"
 }

--- a/custom_components/battery_smartflow_ai/native_zendure_runtime.py
+++ b/custom_components/battery_smartflow_ai/native_zendure_runtime.py
@@ -1,4 +1,4 @@
-"""Optional read-only Zendure runtime used by the V5.0.0-dev1 field test."""
+"""Native Zendure observation plus one explicit development write test."""
 
 from __future__ import annotations
 
@@ -12,7 +12,21 @@ from typing import Any, Callable
 
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .core.models import BatteryPackIdentity, DeviceInventory, ValueValidity
+from .core.models import (
+    BatteryPackIdentity,
+    DeviceCommand,
+    DeviceControlState,
+    DeviceInventory,
+    MainDevice,
+    NativeDeviceIdentity,
+    ValueValidity,
+    ZendureTransport,
+)
+from .native_device_command_gate import (
+    NativeCommandContext,
+    NativeCommandRequest,
+    NativeDeviceCommandGate,
+)
 from .native_device_overview import build_native_device_overview
 from .zendure_cloud import ZendureCloudClient
 from .zendure_cloud_mqtt import ConnectionState, ZendureCloudMqttTransport
@@ -22,9 +36,19 @@ from .zendure_initial_sync import (
     async_capture_initial_sync,
     export_initial_sync_capture,
 )
+from .zendure_first_write import (
+    NativeWriteVerification,
+    PropertyReadback,
+    TransportWriteResult,
+    async_verify_reversible_write,
+)
 from .zendure_normalizer import ZendureCloudNormalizer
 from .zendure_privacy import ZendureDiagnosticSanitizer
-from .zendure_zensdk import ZenSdkReadResult, async_read_zensdk_reports
+from .zendure_zensdk import (
+    ZenSdkReadResult,
+    async_read_zensdk_reports,
+    async_write_zensdk_property,
+)
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -49,7 +73,7 @@ class _JsonPayloadResponse:
 
 
 class NativeZendureRuntime:
-    """Run discovery, initial sync and normalization without a write surface."""
+    """Observe devices; normal automation retains the Home Assistant backend."""
 
     def __init__(
         self,
@@ -81,6 +105,9 @@ class NativeZendureRuntime:
         self._zensdk_last_result: dict[str, str] = {}
         self._zensdk_last_success: dict[str, datetime] = {}
         self._hems_gate = ZendureHemsCommandGate()
+        self._first_write_result: NativeWriteVerification | None = None
+        self._write_lock = asyncio.Lock()
+        self._write_sequence = 0
 
     @property
     def configured(self) -> bool:
@@ -125,6 +152,10 @@ class NativeZendureRuntime:
                 Path(self._capture_path).name if self._capture_path else None
             ),
             "native_zendure_error": self._error,
+            "native_zendure_first_write": (
+                self._first_write_result.status.value
+                if self._first_write_result is not None else "not_run"
+            ),
         }
 
     def overview_attributes(self) -> dict[str, Any]:
@@ -167,20 +198,24 @@ class NativeZendureRuntime:
                 }
             )
         return {
-            "read_only": True,
-            "native_control": "disabled",
+            "read_only": False,
+            "native_control": "developer_test_only",
             "active_control_path": "Z-HA / Home Assistant entities",
             "capture_complete": self._capture_complete,
             "capture_reason": self._capture_reason,
             "systems": systems,
+            "first_write_test": (
+                self._first_write_result.diagnostics()
+                if self._first_write_result is not None else None
+            ),
         }
 
     def diagnostic_data(self) -> dict[str, Any]:
         return ZendureDiagnosticSanitizer().sanitize(
             {
                 "status": self._status,
-                "read_only": True,
-                "native_control": "disabled",
+                "read_only": False,
+                "native_control": "developer_test_only",
                 "active_control_path": "Z-HA / Home Assistant entities",
                 "selected_device": self._selected_device,
                 "message_count": self._processed_messages,
@@ -197,9 +232,104 @@ class NativeZendureRuntime:
                     }
                     for system_id in sorted(self._inventory.devices)
                 ],
+                "first_write_test": (
+                    self._first_write_result.diagnostics()
+                    if self._first_write_result is not None else None
+                ),
                 "overview": self.overview_attributes(),
             }
         )
+
+    async def async_run_first_write_test(self) -> NativeWriteVerification:
+        """Run the explicit SF2400AC ZenSDK +1 W write and restore test."""
+
+        async with self._write_lock:
+            if self._bootstrap is None or self._selected_device is None:
+                raise ValueError("native_device_not_ready")
+            state = self._states.get(self._selected_device)
+            source_device = self._inventory.devices.get(self._selected_device)
+            if state is None or source_device is None:
+                raise ValueError("native_device_not_ready")
+            current = state.setpoints.output_limit_w
+            now = datetime.now(timezone.utc)
+            if (
+                not current.valid or current.observed_at is None
+                or (now - current.observed_at).total_seconds() > 15
+            ):
+                raise ValueError("output_limit_not_fresh")
+            source_identity = source_device.native_identities[0]
+            local_identity = NativeDeviceIdentity(
+                transport=ZendureTransport.ZENSDK,
+                device_id=source_identity.device_id,
+                serial_number=source_identity.serial_number,
+                product_id=source_identity.product_id,
+                product_model=source_identity.product_model,
+            )
+            test_device = MainDevice(
+                system_id=self._selected_device,
+                display_name=source_device.display_name,
+                model=source_device.model,
+                profile_key=source_device.profile_key,
+                control_state=DeviceControlState.ACTIVE,
+                selected_transport=ZendureTransport.ZENSDK,
+                available_transports=frozenset({ZendureTransport.ZENSDK}),
+                native_identities=(local_identity,),
+                online=True,
+                hems_status=source_device.hems_status,
+                hems_active=source_device.hems_active,
+            )
+            inventory = DeviceInventory(devices=(test_device,))
+            original = float(current.value)
+            profile = resolve_zendure_device(local_identity)
+            maximum = profile.profile.capabilities.max_output_w if profile else original
+            target = original + 1.0 if original < maximum else original - 1.0
+            command = DeviceCommand(
+                "output", output_limit_w=target, reason="native_first_write_test",
+                should_write_mode=False, should_write_input=False,
+                should_write_output=True,
+            )
+            request = NativeCommandRequest(
+                self._selected_device, ZendureTransport.ZENSDK, command
+            )
+            context = NativeCommandContext(
+                inventory=inventory, states={self._selected_device: state},
+                selected_device_id=self._selected_device,
+                native_control_enabled=True,
+                available_transports=frozenset({ZendureTransport.ZENSDK}),
+            )
+
+            async def send(prop: str, value: float, _correlation: str):
+                self._write_sequence += 1
+                outcome = await async_write_zensdk_property(
+                    self._bootstrap, self._selected_device, prop, int(value),
+                    self._write_sequence, self._post_json,
+                )
+                return TransportWriteResult(outcome.accepted, outcome.http_status)
+
+            async def read():
+                result = await async_read_zensdk_reports(
+                    self._bootstrap, self._get_json
+                )
+                self._record_zensdk_cycle(result)
+                self._apply_messages(result.messages)
+                for message in result.messages:
+                    if message.device_candidate_id != self._selected_device:
+                        continue
+                    payload = message.parsed_payload or {}
+                    properties = payload.get("properties", payload)
+                    value = properties.get("outputLimit")
+                    if isinstance(value, (int, float)):
+                        return PropertyReadback(float(value), message.received_at)
+                return None
+
+            self._first_write_result = await async_verify_reversible_write(
+                gate=NativeDeviceCommandGate(self._hems_gate), request=request,
+                context=context, property_name="outputLimit",
+                original_value=original, requested_value=target,
+                send_property=send, read_property=read,
+            )
+            self._notify()
+            return self._first_write_result
 
     async def _async_run(self) -> None:
         try:

--- a/custom_components/battery_smartflow_ai/services.yaml
+++ b/custom_components/battery_smartflow_ai/services.yaml
@@ -28,3 +28,19 @@ stop_debug_recording:
       selector:
         config_entry:
           integration: battery_smartflow_ai
+
+verify_native_write:
+  name: Verify first native Zendure write
+  description: Developer-only SF2400AC ZenSDK test. Changes outputLimit by 1 W, verifies a fresh readback, and restores the original value. Disable competing writers first.
+  fields:
+    entry_id:
+      required: false
+      description: Required only when more than one Battery SmartFlow AI config entry is loaded.
+      selector:
+        config_entry:
+          integration: battery_smartflow_ai
+    confirm:
+      required: true
+      description: Confirms that Zendure HEMS, Z-HA control, and external writers are disabled for this test.
+      selector:
+        boolean:

--- a/custom_components/battery_smartflow_ai/zendure_device_matrix.py
+++ b/custom_components/battery_smartflow_ai/zendure_device_matrix.py
@@ -209,6 +209,18 @@ def _entry(
     *aliases: str,
     product_ids: tuple[str, ...] = (),
 ) -> ZendureDeviceMatrixEntry:
+    first_write_model = profile_key == "SF2400AC"
+    transports = dict(_transport_matrix())
+    writes = dict(_REFERENCE_WRITES)
+    if first_write_model:
+        transports[ZendureTransport.ZENSDK] = TransportCapability(
+            ZendureTransport.ZENSDK,
+            VerificationLevel.VERIFIED,
+            VerificationLevel.VERIFIED,
+            VerificationLevel.REFERENCE_ONLY,
+            ("Only explicit reversible outputLimit verification is approved",),
+        )
+        writes["outputLimit"] = VerificationLevel.VERIFIED
     return ZendureDeviceMatrixEntry(
         profile_key=profile_key,
         canonical_model=canonical_model,
@@ -216,10 +228,10 @@ def _entry(
             _normalize_model(value) for value in (canonical_model, *aliases)
         ),
         confirmed_product_ids=frozenset(product_ids),
-        transports=_transport_matrix(),
+        transports=transports,
         readable_main_properties=_COMMON_MAIN_READS,
         readable_pack_properties=_COMMON_PACK_READS,
-        writable_main_properties=_REFERENCE_WRITES,
+        writable_main_properties=writes,
         neutral_device_targets=_COMMON_DEVICE_TARGETS,
         neutral_pack_targets=_COMMON_PACK_TARGETS,
         hems_status=VerificationLevel.REFERENCE_ONLY,
@@ -231,6 +243,7 @@ def _entry(
                 "Zendure-HA nextCalibration is derived, not a device due date",
             ),
         ),
+        native_control_approved=first_write_model,
     )
 
 

--- a/custom_components/battery_smartflow_ai/zendure_first_write.py
+++ b/custom_components/battery_smartflow_ai/zendure_first_write.py
@@ -1,0 +1,153 @@
+"""One-shot, reversible verification for the first native Zendure write."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import replace
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import StrEnum
+from typing import Awaitable, Callable
+
+from .native_device_command_gate import NativeCommandContext, NativeCommandRequest, NativeDeviceCommandGate
+
+
+class NativeWriteStatus(StrEnum):
+    BLOCKED = "blocked"
+    TRANSPORT_ERROR = "transport_error"
+    READBACK_MISMATCH = "readback_mismatch"
+    TIMEOUT = "timeout"
+    RESTORE_FAILED = "restore_failed"
+    RESTORED = "restored"
+
+
+@dataclass(frozen=True, slots=True)
+class PropertyReadback:
+    value: float
+    observed_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class TransportWriteResult:
+    accepted: bool
+    status: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class NativeWriteVerification:
+    correlation_id: str
+    status: NativeWriteStatus
+    property_name: str
+    original_value: float
+    requested_value: float
+    final_value: float | None
+    readback_value: float | None
+    readback_latency_seconds: float | None
+    restore_status: str
+    gate_status: str
+    gate_reasons: tuple[str, ...]
+    transport_status: int | None = None
+
+    def diagnostics(self) -> dict[str, object]:
+        return {
+            "correlation_id": self.correlation_id, "status": self.status.value,
+            "property": self.property_name, "original_value": self.original_value,
+            "requested_value": self.requested_value, "final_value": self.final_value,
+            "readback_value": self.readback_value,
+            "readback_latency_seconds": self.readback_latency_seconds,
+            "restore_status": self.restore_status, "gate_status": self.gate_status,
+            "gate_reasons": list(self.gate_reasons),
+            "transport_status": self.transport_status,
+        }
+
+
+SendProperty = Callable[[str, float, str], Awaitable[TransportWriteResult]]
+ReadProperty = Callable[[], Awaitable[PropertyReadback | None]]
+
+
+async def async_verify_reversible_write(
+    *, gate: NativeDeviceCommandGate, request: NativeCommandRequest,
+    context: NativeCommandContext, property_name: str, original_value: float,
+    requested_value: float, send_property: SendProperty,
+    read_property: ReadProperty, timeout: float = 10.0,
+    poll_interval: float = 0.5,
+) -> NativeWriteVerification:
+    """Perform exactly one test write and one verified restoration."""
+    gate_result = gate.evaluate(request, context)
+    correlation_id = gate_result.correlation_id
+    final_value = (
+        float(gate_result.command.output_limit_w)
+        if gate_result.command is not None else None
+    )
+
+    def result(status: NativeWriteStatus, *, readback=None, latency=None,
+               restore="not_started", transport_status=None):
+        return NativeWriteVerification(
+            correlation_id, status, property_name, original_value,
+            requested_value, final_value, readback, latency, restore,
+            gate_result.status.value, gate_result.reasons, transport_status,
+        )
+
+    if not gate_result.accepted or final_value is None:
+        return result(NativeWriteStatus.BLOCKED)
+    sent_at = datetime.now(timezone.utc)
+    try:
+        transport = await send_property(property_name, final_value, correlation_id)
+    except Exception:
+        return result(NativeWriteStatus.TRANSPORT_ERROR)
+    if not transport.accepted:
+        return result(NativeWriteStatus.TRANSPORT_ERROR, transport_status=transport.status)
+    readback, mismatch = await _await_readback(
+        read_property, final_value, sent_at, timeout, poll_interval
+    )
+    write_status = (
+        NativeWriteStatus.READBACK_MISMATCH if mismatch
+        else NativeWriteStatus.TIMEOUT
+    ) if readback is None else NativeWriteStatus.RESTORED
+    latency = (
+        max(0.0, (readback.observed_at - sent_at).total_seconds())
+        if readback is not None else None
+    )
+    restore_command = replace(
+        request.command, output_limit_w=original_value,
+        reason="native_first_write_restore",
+    )
+    restore_gate = gate.evaluate(replace(request, command=restore_command), context)
+    restore_sent_at = datetime.now(timezone.utc)
+    try:
+        restore_transport = (
+            await send_property(
+                property_name, original_value, f"{correlation_id}-restore"
+            )
+            if restore_gate.accepted else TransportWriteResult(False)
+        )
+        restored, _ = await _await_readback(
+            read_property, original_value, restore_sent_at, timeout, poll_interval
+        ) if restore_transport.accepted else (None, None)
+    except Exception:
+        restored = None
+    return result(
+        (
+            NativeWriteStatus.RESTORE_FAILED
+            if readback is not None and not restored
+            else write_status
+        ),
+        readback=(readback.value if readback else mismatch.value if mismatch else None),
+        latency=round(latency, 3) if latency is not None else None,
+        restore="readback_confirmed" if restored else "failed",
+        transport_status=transport.status,
+    )
+
+
+async def _await_readback(read_property: ReadProperty, expected: float,
+                          sent_at: datetime, timeout: float, poll_interval: float):
+    deadline = asyncio.get_running_loop().time() + timeout
+    mismatch = None
+    while asyncio.get_running_loop().time() < deadline:
+        value = await read_property()
+        if value is not None and value.observed_at > sent_at:
+            if value.value == expected:
+                return value, mismatch
+            mismatch = value
+        await asyncio.sleep(poll_interval)
+    return None, mismatch

--- a/custom_components/battery_smartflow_ai/zendure_zensdk.py
+++ b/custom_components/battery_smartflow_ai/zendure_zensdk.py
@@ -18,6 +18,7 @@ from .zendure_device_matrix import VerificationLevel, resolve_zendure_device
 
 
 ZENSDK_REPORT_PATH = "/properties/report"
+ZENSDK_WRITE_PATH = "/properties/write"
 DEFAULT_ZENSDK_TIMEOUT = 4.0
 
 
@@ -44,6 +45,69 @@ class ZenSdkReadAttempt:
 class ZenSdkReadResult:
     messages: tuple[CloudMqttMessage, ...]
     attempts: tuple[ZenSdkReadAttempt, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ZenSdkWriteResult:
+    """HTTP acceptance only; this is deliberately not device confirmation."""
+
+    accepted: bool
+    http_status: int | None
+    result: str
+
+
+async def async_write_zensdk_property(
+    bootstrap: ZendureCloudBootstrap,
+    device_candidate_id: str,
+    property_name: str,
+    value: int,
+    request_id: int,
+    post_json: GetJson,
+    *,
+    timeout: float = DEFAULT_ZENSDK_TIMEOUT,
+) -> ZenSdkWriteResult:
+    """Write one allow-listed property to one exact local main device."""
+
+    if property_name != "outputLimit":
+        return ZenSdkWriteResult(False, None, "property_not_allowed")
+    device = next(
+        (item for item in bootstrap.devices
+         if item.candidate.candidate_id == device_candidate_id), None
+    )
+    if device is None:
+        return ZenSdkWriteResult(False, None, "device_not_found")
+    identity = device.candidate.identity
+    if identity.product_model != "SolarFlow 2400 AC" or not identity.serial_number:
+        return ZenSdkWriteResult(False, None, "model_not_allowed")
+    raw = next(
+        (item for item in bootstrap.raw_device_list
+         if str(item.get("deviceKey")) == str(identity.device_id)), {}
+    )
+    addresses = _candidate_addresses(raw, identity.product_model, identity.serial_number)
+    if not addresses:
+        return ZenSdkWriteResult(False, None, "no_local_address")
+    # A read may try another address, but a write is sent exactly once.  A
+    # timeout is ambiguous and must never cause an automatic duplicate POST.
+    _source, host = addresses[0]
+    try:
+        response = await asyncio.wait_for(
+            post_json(
+                f"http://{host}{ZENSDK_WRITE_PATH}",
+                json={
+                    "sn": identity.serial_number,
+                    "properties": {property_name: int(value)},
+                    "id": int(request_id),
+                },
+            ),
+            timeout=timeout,
+        )
+        status = int(response.status)
+        return ZenSdkWriteResult(
+            200 <= status < 300, status,
+            "transport_ok" if 200 <= status < 300 else "http_error",
+        )
+    except Exception:
+        return ZenSdkWriteResult(False, None, "transport_error")
 
 
 async def async_read_zensdk_reports(

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -13,7 +13,7 @@ COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
 
 
 class DebugIntegrationContractTests(unittest.TestCase):
-    def test_manifest_and_runtime_version_match_v5_dev13_release(self) -> None:
+    def test_manifest_and_runtime_version_match_v5_dev14_release(self) -> None:
         manifest_version = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )["version"]
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "5.0.0.dev13")
+        self.assertEqual(manifest_version, "5.0.0.dev14")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_native_device_command_gate.py
+++ b/tests/test_native_device_command_gate.py
@@ -181,8 +181,8 @@ class NativeDeviceCommandGateTests(unittest.IsolatedAsyncioTestCase):
             NativeCommandRequest(DEVICE_ID, TRANSPORT, command()), context()
         )
         self.assertFalse(result.accepted)
-        self.assertIn("device_profile_not_approved", result.reasons)
-        self.assertIn("transport_write_not_verified", result.reasons)
+        self.assertIn("command_capability_unsupported:acMode", result.reasons)
+        self.assertIn("command_capability_unsupported:inputLimit", result.reasons)
 
     async def test_control_selection_and_active_state_are_independent_blockers(self):
         result = ready_gate().evaluate(

--- a/tests/test_native_zendure_ha_integration.py
+++ b/tests/test_native_zendure_ha_integration.py
@@ -1,4 +1,4 @@
-"""Contracts for the first installable native Zendure read-only test."""
+"""Contracts for the installable native Zendure development test."""
 
 from __future__ import annotations
 
@@ -17,7 +17,7 @@ class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
         manifest = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )
-        self.assertEqual(manifest["version"], "5.0.0.dev13")
+        self.assertEqual(manifest["version"], "5.0.0.dev14")
         self.assertIn("paho-mqtt==2.1.0", manifest["requirements"])
 
     def test_options_flow_uses_a_password_field_and_never_suggests_token(self) -> None:
@@ -34,7 +34,7 @@ class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
         self.assertNotIn("add_suggested_values_to_schema", text)
         self.assertIn("disable_native_zendure_test", text)
 
-    def test_runtime_is_background_only_and_has_no_native_write_surface(self) -> None:
+    def test_runtime_keeps_normal_control_read_only_and_write_test_explicit(self) -> None:
         setup = (COMPONENT / "__init__.py").read_text(encoding="utf-8")
         runtime = (COMPONENT / "native_zendure_runtime.py").read_text(
             encoding="utf-8"
@@ -43,8 +43,9 @@ class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
         self.assertIn("coordinator.native_zendure.start()", setup)
         self.assertNotIn("await coordinator.native_zendure.start()", setup)
         self.assertNotIn("publish(", runtime)
-        self.assertNotIn("properties/write", runtime)
-        self.assertNotIn("DeviceCommand", runtime)
+        self.assertIn("SERVICE_VERIFY_NATIVE_WRITE", setup)
+        self.assertIn("async_run_first_write_test", runtime)
+        self.assertIn("NativeDeviceCommandGate", runtime)
         self.assertNotIn("def publish", mqtt)
         self.assertIn("self._consume_captured_messages(capture.messages)", runtime)
         self.assertIn("await self._async_poll_zensdk()", runtime)

--- a/tests/test_zendure_device_matrix.py
+++ b/tests/test_zendure_device_matrix.py
@@ -89,17 +89,29 @@ class ZendureDeviceMatrixTests(unittest.TestCase):
         )
         self.assertNotEqual(runtime_report["inputLimit"], hardware_limit)
 
-    def test_no_model_or_transport_is_approved_for_native_control(self):
-        for entry in ZENDURE_DEVICE_MATRIX.values():
-            with self.subTest(profile=entry.profile_key):
+    def test_only_sf2400ac_zensdk_output_limit_is_approved(self):
+        approved = ZENDURE_DEVICE_MATRIX["SF2400AC"]
+        self.assertTrue(approved.native_control_approved)
+        self.assertIs(
+            approved.transport(ZendureTransport.ZENSDK).write,
+            VerificationLevel.VERIFIED,
+        )
+        self.assertIs(
+            approved.writable_main_properties["outputLimit"],
+            VerificationLevel.VERIFIED,
+        )
+        self.assertIs(
+            approved.transport(ZendureTransport.CLOUD_MQTT).write,
+            VerificationLevel.REFERENCE_ONLY,
+        )
+        for key, entry in ZENDURE_DEVICE_MATRIX.items():
+            if key == "SF2400AC":
+                continue
+            with self.subTest(profile=key):
                 self.assertFalse(entry.native_control_approved)
                 self.assertNotIn(
                     VerificationLevel.VERIFIED,
                     entry.writable_main_properties.values(),
-                )
-                self.assertIs(
-                    entry.transport(ZendureTransport.CLOUD_MQTT).write,
-                    VerificationLevel.REFERENCE_ONLY,
                 )
 
     def test_transports_remain_separate_evidence_domains(self):

--- a/tests/test_zendure_first_write.py
+++ b/tests/test_zendure_first_write.py
@@ -1,0 +1,106 @@
+"""Verification-state contracts for the first native write."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+import unittest
+
+from support import bootstrap
+
+bootstrap()
+
+from custom_components.battery_smartflow_ai.zendure_first_write import (  # noqa: E402
+    NativeWriteStatus,
+    PropertyReadback,
+    TransportWriteResult,
+    async_verify_reversible_write,
+)
+from custom_components.battery_smartflow_ai.core.models import DeviceCommand, ZendureTransport  # noqa: E402
+from custom_components.battery_smartflow_ai.native_device_command_gate import NativeCommandRequest  # noqa: E402
+
+
+def request(value: float) -> NativeCommandRequest:
+    return NativeCommandRequest(
+        "device", ZendureTransport.ZENSDK,
+        DeviceCommand(
+            "output", output_limit_w=value, should_write_mode=False,
+            should_write_input=False, should_write_output=True,
+        ),
+    )
+
+
+class Gate:
+    def __init__(self, *, accepted=True):
+        self.accepted = accepted
+
+    def evaluate(self, request, _context):
+        return SimpleNamespace(
+            correlation_id="safe-correlation",
+            accepted=self.accepted,
+            command=request.command if self.accepted else None,
+            status=SimpleNamespace(value="accepted" if self.accepted else "blocked"),
+            reasons=() if self.accepted else ("hems_active",),
+        )
+
+
+class FirstWriteTests(unittest.IsolatedAsyncioTestCase):
+    async def test_write_and_restore_both_require_fresh_readback(self):
+        writes = []
+
+        async def send(prop, value, correlation):
+            writes.append((prop, value, correlation))
+            return TransportWriteResult(True, 200)
+
+        async def read():
+            value = 101.0 if len(writes) == 1 else 100.0
+            return PropertyReadback(value, datetime.now(timezone.utc))
+
+        result = await async_verify_reversible_write(
+            gate=Gate(), request=request(101.0), context=None,
+            property_name="outputLimit", original_value=100.0,
+            requested_value=101.0, send_property=send, read_property=read,
+            timeout=0.1, poll_interval=0,
+        )
+        self.assertEqual(result.status, NativeWriteStatus.RESTORED)
+        self.assertEqual([item[1] for item in writes], [101.0, 100.0])
+        self.assertEqual(writes[1][2], "safe-correlation-restore")
+
+    async def test_transport_ok_without_readback_is_timeout_and_not_retried(self):
+        writes = []
+
+        async def send(prop, value, correlation):
+            writes.append((prop, value, correlation))
+            return TransportWriteResult(True, 200)
+
+        async def read():
+            return None
+
+        result = await async_verify_reversible_write(
+            gate=Gate(), request=request(1),
+            context=None, property_name="outputLimit", original_value=0,
+            requested_value=1, send_property=send, read_property=read,
+            timeout=0.01, poll_interval=0,
+        )
+        self.assertEqual(result.status, NativeWriteStatus.TIMEOUT)
+        self.assertEqual(result.restore_status, "failed")
+        self.assertEqual(len(writes), 2)
+
+    async def test_blocked_gate_never_calls_transport(self):
+        called = False
+
+        async def send(*_args):
+            nonlocal called
+            called = True
+
+        result = await async_verify_reversible_write(
+            gate=Gate(accepted=False), request=request(1),
+            context=None, property_name="outputLimit", original_value=0,
+            requested_value=1, send_property=send, read_property=lambda: None,
+        )
+        self.assertEqual(result.status, NativeWriteStatus.BLOCKED)
+        self.assertFalse(called)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_zendure_zensdk.py
+++ b/tests/test_zendure_zensdk.py
@@ -28,6 +28,7 @@ from custom_components.battery_smartflow_ai.zendure_zensdk import (  # noqa: E40
     ZenSdkReadResult,
     _candidate_addresses,
     async_read_zensdk_reports,
+    async_write_zensdk_property,
 )
 from custom_components.battery_smartflow_ai.zendure_normalizer import (  # noqa: E402
     ZendureCloudNormalizer,
@@ -84,6 +85,55 @@ async def make_bootstrap(*, ip="192.168.1.44"):
 
 
 class ZenSdkReadTests(unittest.IsolatedAsyncioTestCase):
+    async def test_first_write_posts_one_allowlisted_property_to_exact_device(self):
+        data = await make_bootstrap()
+        calls = []
+
+        async def post(url, **kwargs):
+            calls.append((url, kwargs))
+            return Response({"success": True}, 200)
+
+        result = await async_write_zensdk_property(
+            data, "cloud_mqtt:device-real-1", "outputLimit", 301, 7, post
+        )
+
+        self.assertTrue(result.accepted)
+        self.assertEqual(calls[0][0], "http://192.168.1.44/properties/write")
+        self.assertEqual(
+            calls[0][1]["json"],
+            {"sn": "serial-real-1", "properties": {"outputLimit": 301}, "id": 7},
+        )
+
+    async def test_first_write_rejects_every_other_property_without_network(self):
+        data = await make_bootstrap()
+        called = False
+
+        async def post(*_args, **_kwargs):
+            nonlocal called
+            called = True
+            return Response({})
+
+        result = await async_write_zensdk_property(
+            data, "cloud_mqtt:device-real-1", "inputLimit", 1, 1, post
+        )
+        self.assertFalse(result.accepted)
+        self.assertEqual(result.result, "property_not_allowed")
+        self.assertFalse(called)
+
+    async def test_first_write_never_retries_an_ambiguous_timeout(self):
+        data = await make_bootstrap()
+        calls = []
+
+        async def post(url, **_kwargs):
+            calls.append(url)
+            raise TimeoutError
+
+        result = await async_write_zensdk_property(
+            data, "cloud_mqtt:device-real-1", "outputLimit", 1, 1, post
+        )
+        self.assertFalse(result.accepted)
+        self.assertEqual(calls, ["http://192.168.1.44/properties/write"])
+
     async def test_reads_private_ip_and_returns_transport_tagged_report(self):
         data = await make_bootstrap()
         requested = []


### PR DESCRIPTION
## Summary

- add the first explicit native write path for SolarFlow 2400 AC over ZenSDK only
- allow only outputLimit and change it by exactly 1 W from a fresh observed value
- route both the test write and restoration through the central DeviceCommand gate
- require fresh online/protection state, selected device, exact model/transport capability, and a non-blocking HEMS state
- distinguish HTTP transport acceptance from fresh device readback
- restore the original value and verify that restoration through a second fresh readback
- never retry an ambiguous write timeout, never fall back to another transport, and never activate the normal PowerController native path
- expose a deliberately confirmed developer service and privacy-sanitized diagnostics
- bump the development version to 5.0.0.dev14

## Field-test safety

The service never runs automatically. Before it is called, Zendure HEMS, Z-HA control, BSFAI automatic control, and external writers for the device must be disabled. The first real invocation will be performed as a supervised Dev14 field test after merge/release.

## Validation

- full suite: 519 tests passed
- Python compilation passed
- manifest JSON validation passed
- diff/whitespace validation passed

Closes #333