### PR TITLE
V5: generalize native command verification

### DIFF
--- a/custom_components/battery_smartflow_ai/native_command_verification.py
+++ b/custom_components/battery_smartflow_ai/native_command_verification.py
@@ -1,0 +1,347 @@
+"""Transport-neutral lifecycle and correlation for native device commands."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import StrEnum
+from hashlib import sha256
+import math
+from typing import Any
+from uuid import uuid4
+
+from .core.models import ZendureTransport
+
+
+class CommandVerificationStatus(StrEnum):
+    PREPARED = "prepared"
+    GATE_ACCEPTED = "gate_accepted"
+    BLOCKED = "blocked"
+    SENT = "sent"
+    TRANSPORT_OK = "transport_ok"
+    TRANSPORT_ERROR = "transport_error"
+    READBACK_CONFIRMED = "readback_confirmed"
+    READBACK_TIMEOUT = "readback_timeout"
+    READBACK_MISMATCH = "readback_mismatch"
+    CONTRADICTORY_RESPONSE = "contradictory_response"
+    EFFECT_CONFIRMED = "effect_confirmed"
+    EFFECT_TIMEOUT = "effect_timeout"
+    EFFECT_MISMATCH = "effect_mismatch"
+    SUPERSEDED = "superseded"
+    CANCELLED = "cancelled"
+
+
+class EffectStatus(StrEnum):
+    PENDING = "pending"
+    NOT_APPLICABLE = "not_applicable"
+    NOT_OBSERVABLE = "not_observable"
+    CONFIRMED = "confirmed"
+    TIMEOUT = "timeout"
+    MISMATCH = "mismatch"
+
+
+@dataclass(frozen=True, slots=True)
+class ReadbackPolicy:
+    property_name: str
+    expected_value: float
+    tolerance: float = 0.0
+
+    def matches(self, value: float) -> bool:
+        return math.isclose(
+            float(value), float(self.expected_value), rel_tol=0.0,
+            abs_tol=max(0.0, float(self.tolerance)),
+        )
+
+
+@dataclass(slots=True)
+class CommandVerification:
+    command_id: str
+    device_id: str
+    command_type: str
+    target_key: str
+    transport: ZendureTransport
+    requested_value: float
+    final_value: float
+    readback: ReadbackPolicy
+    prepared_at: datetime
+    status: CommandVerificationStatus = CommandVerificationStatus.PREPARED
+    gate_at: datetime | None = None
+    sent_at: datetime | None = None
+    transport_at: datetime | None = None
+    readback_at: datetime | None = None
+    readback_value: float | None = None
+    effect_at: datetime | None = None
+    effect_status: EffectStatus = EffectStatus.PENDING
+    reason: str | None = None
+    superseded_by: str | None = None
+    transport_status: str | None = None
+    attempts: int = 0
+    max_attempts: int = 1
+    readback_values: list[float] = field(default_factory=list)
+    failure_counted: bool = False
+
+    @property
+    def active(self) -> bool:
+        if self.status is CommandVerificationStatus.READBACK_CONFIRMED:
+            return self.effect_status is EffectStatus.PENDING
+        return self.status not in {
+            CommandVerificationStatus.BLOCKED,
+            CommandVerificationStatus.TRANSPORT_ERROR,
+            CommandVerificationStatus.READBACK_TIMEOUT,
+            CommandVerificationStatus.READBACK_MISMATCH,
+            CommandVerificationStatus.CONTRADICTORY_RESPONSE,
+            CommandVerificationStatus.EFFECT_CONFIRMED,
+            CommandVerificationStatus.EFFECT_TIMEOUT,
+            CommandVerificationStatus.EFFECT_MISMATCH,
+            CommandVerificationStatus.SUPERSEDED,
+            CommandVerificationStatus.CANCELLED,
+        }
+
+    def diagnostics(self) -> dict[str, Any]:
+        """Expose no metadata, credentials, serial number or payload content."""
+        return {
+            "command_id": self.command_id,
+            "device_id": _public_device_id(self.device_id),
+            "command_type": self.command_type,
+            "target": self.target_key,
+            "transport": self.transport.value,
+            "requested_value": self.requested_value,
+            "final_value": self.final_value,
+            "expected_property": self.readback.property_name,
+            "readback_tolerance": self.readback.tolerance,
+            "status": self.status.value,
+            "effect_status": self.effect_status.value,
+            "reason": self.reason,
+            "attempts": self.attempts,
+            "max_attempts": self.max_attempts,
+            "transport_status": self.transport_status,
+            "readback_value": self.readback_value,
+            "prepared_at": self.prepared_at,
+            "gate_at": self.gate_at,
+            "sent_at": self.sent_at,
+            "transport_at": self.transport_at,
+            "readback_at": self.readback_at,
+            "effect_at": self.effect_at,
+            "gate_to_send_seconds": _latency(self.gate_at, self.sent_at),
+            "send_to_transport_seconds": _latency(self.sent_at, self.transport_at),
+            "send_to_readback_seconds": _latency(self.sent_at, self.readback_at),
+            "send_to_effect_seconds": _latency(self.sent_at, self.effect_at),
+            "superseded_by": self.superseded_by,
+        }
+
+
+class NativeCommandVerificationManager:
+    """Correlate writes above transports and below neutral regulation."""
+
+    def __init__(self, *, history_limit: int = 50) -> None:
+        if history_limit < 1:
+            raise ValueError("history_limit must be positive")
+        self._history_limit = history_limit
+        self._commands: dict[str, CommandVerification] = {}
+        self._active: dict[tuple[str, str], str] = {}
+        self._failures: dict[str, int] = {}
+
+    def prepare(
+        self, *, device_id: str, command_type: str, target_key: str,
+        transport: ZendureTransport, requested_value: float, final_value: float,
+        readback: ReadbackPolicy, prepared_at: datetime | None = None,
+        max_attempts: int = 1,
+    ) -> CommandVerification:
+        if not device_id or not command_type or not target_key:
+            raise ValueError("command identity must not be empty")
+        if max_attempts < 1:
+            raise ValueError("max_attempts must be positive")
+        key = (device_id, target_key)
+        command_id = uuid4().hex
+        previous_id = self._active.get(key)
+        if previous_id is not None:
+            previous = self._commands[previous_id]
+            if previous.active:
+                previous.status = CommandVerificationStatus.SUPERSEDED
+                previous.superseded_by = command_id
+                previous.reason = "newer_command"
+        command = CommandVerification(
+            command_id=command_id, device_id=device_id,
+            command_type=command_type, target_key=target_key,
+            transport=transport, requested_value=float(requested_value),
+            final_value=float(final_value), readback=readback,
+            prepared_at=_aware(prepared_at), max_attempts=max_attempts,
+        )
+        self._commands[command_id] = command
+        self._active[key] = command_id
+        self._trim()
+        return command
+
+    def gate(self, command_id: str, *, accepted: bool,
+             reasons: tuple[str, ...] = (), at: datetime | None = None) -> None:
+        command = self._mutable(command_id)
+        command.gate_at = _aware(at)
+        command.status = (
+            CommandVerificationStatus.GATE_ACCEPTED
+            if accepted else CommandVerificationStatus.BLOCKED
+        )
+        command.reason = None if accepted else ",".join(reasons) or "blocked"
+        if not accepted:
+            self._finish(command)
+
+    def sent(self, command_id: str, *, at: datetime | None = None) -> None:
+        command = self._mutable(command_id)
+        if command.status is not CommandVerificationStatus.GATE_ACCEPTED:
+            raise ValueError("command was not gate accepted")
+        if command.attempts >= command.max_attempts:
+            raise ValueError("retry_limit_reached")
+        command.attempts += 1
+        command.sent_at = _aware(at)
+        command.status = CommandVerificationStatus.SENT
+
+    def transport_result(self, command_id: str, *, ok: bool,
+                         status: str | None = None,
+                         at: datetime | None = None) -> None:
+        command = self._mutable(command_id)
+        if command.sent_at is None:
+            raise ValueError("command was not sent")
+        command.transport_at = _aware(at)
+        command.transport_status = status
+        command.status = (
+            CommandVerificationStatus.TRANSPORT_OK
+            if ok else CommandVerificationStatus.TRANSPORT_ERROR
+        )
+        command.reason = None if ok else "transport_error"
+        if not ok:
+            self._fail(command)
+
+    def observe_readback(self, command_id: str, *, device_id: str,
+                         property_name: str, value: float,
+                         observed_at: datetime) -> bool:
+        command = self._commands[command_id]
+        if command.status is CommandVerificationStatus.SUPERSEDED:
+            return False
+        if device_id != command.device_id or property_name != command.readback.property_name:
+            return False
+        observed = _aware(observed_at)
+        if command.sent_at is None or observed <= command.sent_at:
+            return False
+        numeric = float(value)
+        command.readback_values.append(numeric)
+        previously_confirmed = command.readback_at is not None
+        if command.readback.matches(numeric):
+            command.readback_at = observed
+            command.readback_value = numeric
+            if command.status is CommandVerificationStatus.TRANSPORT_ERROR:
+                command.status = CommandVerificationStatus.CONTRADICTORY_RESPONSE
+                command.reason = "transport_error_but_readback_confirmed"
+                self._fail(command)
+                return False
+            command.status = CommandVerificationStatus.READBACK_CONFIRMED
+            command.reason = None
+            return True
+        command.readback_value = numeric
+        command.readback_at = observed
+        command.status = (
+            CommandVerificationStatus.CONTRADICTORY_RESPONSE
+            if previously_confirmed or len(set(command.readback_values)) > 1
+            else CommandVerificationStatus.READBACK_MISMATCH
+        )
+        command.reason = "readback_value_mismatch"
+        self._fail(command)
+        return False
+
+    def readback_timeout(self, command_id: str) -> None:
+        command = self._mutable(command_id)
+        command.status = CommandVerificationStatus.READBACK_TIMEOUT
+        command.reason = "readback_timeout"
+        self._fail(command)
+
+    def effect(self, command_id: str, *, status: EffectStatus,
+               at: datetime | None = None, reason: str | None = None) -> None:
+        command = self._mutable(command_id)
+        if command.readback_at is None:
+            raise ValueError("effect cannot precede readback")
+        command.effect_status = status
+        command.effect_at = _aware(at)
+        command.reason = reason
+        if status is EffectStatus.CONFIRMED:
+            command.status = CommandVerificationStatus.EFFECT_CONFIRMED
+            self._finish(command)
+        elif status is EffectStatus.TIMEOUT:
+            command.status = CommandVerificationStatus.EFFECT_TIMEOUT
+            self._fail(command)
+        elif status is EffectStatus.MISMATCH:
+            command.status = CommandVerificationStatus.EFFECT_MISMATCH
+            self._fail(command)
+        elif status in {EffectStatus.NOT_APPLICABLE, EffectStatus.NOT_OBSERVABLE}:
+            command.status = CommandVerificationStatus.READBACK_CONFIRMED
+            self._finish(command)
+
+    def cancel(self, command_id: str) -> None:
+        command = self._commands[command_id]
+        if command.sent_at is not None:
+            raise ValueError("sent command cannot be cancelled")
+        command.status = CommandVerificationStatus.CANCELLED
+        command.reason = "cancelled_before_send"
+        self._finish(command)
+
+    def get(self, command_id: str) -> CommandVerification:
+        return self._commands[command_id]
+
+    def active_for(self, device_id: str, target_key: str) -> CommandVerification | None:
+        command_id = self._active.get((device_id, target_key))
+        return self._commands.get(command_id) if command_id else None
+
+    def diagnostics(self) -> dict[str, Any]:
+        return {
+            "commands": [item.diagnostics() for item in self._commands.values()],
+            "failures_by_device": {
+                _public_device_id(key): value for key, value in self._failures.items()
+            },
+        }
+
+    def _mutable(self, command_id: str) -> CommandVerification:
+        command = self._commands[command_id]
+        if command.status in {
+            CommandVerificationStatus.SUPERSEDED,
+            CommandVerificationStatus.CANCELLED,
+        }:
+            raise ValueError("command is no longer active")
+        return command
+
+    def _fail(self, command: CommandVerification) -> None:
+        if not command.failure_counted:
+            self._failures[command.device_id] = (
+                self._failures.get(command.device_id, 0) + 1
+            )
+            command.failure_counted = True
+        self._finish(command)
+
+    def _finish(self, command: CommandVerification) -> None:
+        key = (command.device_id, command.target_key)
+        if self._active.get(key) == command.command_id:
+            self._active.pop(key, None)
+
+    def _trim(self) -> None:
+        while len(self._commands) > self._history_limit:
+            removable = next(
+                (command_id for command_id, command in self._commands.items()
+                 if not command.active),
+                None,
+            )
+            if removable is None:
+                break
+            self._commands.pop(removable)
+
+
+def _aware(value: datetime | None) -> datetime:
+    result = value or datetime.now(timezone.utc)
+    if result.tzinfo is None or result.utcoffset() is None:
+        raise ValueError("timestamps must be timezone-aware")
+    return result
+
+
+def _latency(start: datetime | None, end: datetime | None) -> float | None:
+    if start is None or end is None:
+        return None
+    return round(max(0.0, (end - start).total_seconds()), 3)
+
+
+def _public_device_id(value: str) -> str:
+    return f"device_{sha256(value.encode('utf-8')).hexdigest()[:12]}"

--- a/custom_components/battery_smartflow_ai/native_zendure_runtime.py
+++ b/custom_components/battery_smartflow_ai/native_zendure_runtime.py
@@ -27,6 +27,7 @@ from .native_device_command_gate import (
     NativeCommandRequest,
     NativeDeviceCommandGate,
 )
+from .native_command_verification import NativeCommandVerificationManager
 from .native_device_overview import build_native_device_overview
 from .zendure_cloud import ZendureCloudClient
 from .zendure_cloud_mqtt import ConnectionState, ZendureCloudMqttTransport
@@ -108,6 +109,7 @@ class NativeZendureRuntime:
         self._first_write_result: NativeWriteVerification | None = None
         self._write_lock = asyncio.Lock()
         self._write_sequence = 0
+        self._command_verification = NativeCommandVerificationManager()
 
     @property
     def configured(self) -> bool:
@@ -236,6 +238,7 @@ class NativeZendureRuntime:
                     self._first_write_result.diagnostics()
                     if self._first_write_result is not None else None
                 ),
+                "command_verification": self._command_verification.diagnostics(),
                 "overview": self.overview_attributes(),
             }
         )
@@ -327,6 +330,7 @@ class NativeZendureRuntime:
                 context=context, property_name="outputLimit",
                 original_value=original, requested_value=target,
                 send_property=send, read_property=read,
+                verification_manager=self._command_verification,
             )
             self._notify()
             return self._first_write_result

--- a/custom_components/battery_smartflow_ai/zendure_first_write.py
+++ b/custom_components/battery_smartflow_ai/zendure_first_write.py
@@ -10,6 +10,11 @@ from enum import StrEnum
 from typing import Awaitable, Callable
 
 from .native_device_command_gate import NativeCommandContext, NativeCommandRequest, NativeDeviceCommandGate
+from .native_command_verification import (
+    EffectStatus,
+    NativeCommandVerificationManager,
+    ReadbackPolicy,
+)
 
 
 class NativeWriteStatus(StrEnum):
@@ -71,6 +76,7 @@ async def async_verify_reversible_write(
     requested_value: float, send_property: SendProperty,
     read_property: ReadProperty, timeout: float = 10.0,
     poll_interval: float = 0.5,
+    verification_manager: NativeCommandVerificationManager | None = None,
 ) -> NativeWriteVerification:
     """Perform exactly one test write and one verified restoration."""
     gate_result = gate.evaluate(request, context)
@@ -79,6 +85,24 @@ async def async_verify_reversible_write(
         float(gate_result.command.output_limit_w)
         if gate_result.command is not None else None
     )
+    tracked = None
+    if verification_manager is not None:
+        tracked = verification_manager.prepare(
+            device_id=request.device_id,
+            command_type="set_output_limit",
+            target_key="output_limit",
+            transport=request.transport,
+            requested_value=requested_value,
+            final_value=final_value if final_value is not None else requested_value,
+            readback=ReadbackPolicy(
+                property_name,
+                final_value if final_value is not None else requested_value,
+            ),
+        )
+        verification_manager.gate(
+            tracked.command_id, accepted=gate_result.accepted,
+            reasons=gate_result.reasons,
+        )
 
     def result(status: NativeWriteStatus, *, readback=None, latency=None,
                restore="not_started", transport_status=None):
@@ -91,10 +115,21 @@ async def async_verify_reversible_write(
     if not gate_result.accepted or final_value is None:
         return result(NativeWriteStatus.BLOCKED)
     sent_at = datetime.now(timezone.utc)
+    if tracked is not None:
+        verification_manager.sent(tracked.command_id, at=sent_at)
     try:
         transport = await send_property(property_name, final_value, correlation_id)
     except Exception:
+        if tracked is not None:
+            verification_manager.transport_result(
+                tracked.command_id, ok=False, status="exception"
+            )
         return result(NativeWriteStatus.TRANSPORT_ERROR)
+    if tracked is not None:
+        verification_manager.transport_result(
+            tracked.command_id, ok=transport.accepted,
+            status=(str(transport.status) if transport.status is not None else None),
+        )
     if not transport.accepted:
         return result(NativeWriteStatus.TRANSPORT_ERROR, transport_status=transport.status)
     readback, mismatch = await _await_readback(
@@ -104,6 +139,25 @@ async def async_verify_reversible_write(
         NativeWriteStatus.READBACK_MISMATCH if mismatch
         else NativeWriteStatus.TIMEOUT
     ) if readback is None else NativeWriteStatus.RESTORED
+    if tracked is not None:
+        if readback is not None:
+            verification_manager.observe_readback(
+                tracked.command_id, device_id=request.device_id,
+                property_name=property_name, value=readback.value,
+                observed_at=readback.observed_at,
+            )
+            verification_manager.effect(
+                tracked.command_id, status=EffectStatus.NOT_APPLICABLE,
+                reason="setpoint_only_test",
+            )
+        elif mismatch is not None:
+            verification_manager.observe_readback(
+                tracked.command_id, device_id=request.device_id,
+                property_name=property_name, value=mismatch.value,
+                observed_at=mismatch.observed_at,
+            )
+        else:
+            verification_manager.readback_timeout(tracked.command_id)
     latency = (
         max(0.0, (readback.observed_at - sent_at).total_seconds())
         if readback is not None else None
@@ -113,11 +167,29 @@ async def async_verify_reversible_write(
         reason="native_first_write_restore",
     )
     restore_gate = gate.evaluate(replace(request, command=restore_command), context)
+    restore_tracked = None
+    if verification_manager is not None:
+        restore_tracked = verification_manager.prepare(
+            device_id=request.device_id,
+            command_type="restore_output_limit",
+            target_key="output_limit",
+            transport=request.transport,
+            requested_value=original_value,
+            final_value=original_value,
+            readback=ReadbackPolicy(property_name, original_value),
+        )
+        verification_manager.gate(
+            restore_tracked.command_id, accepted=restore_gate.accepted,
+            reasons=restore_gate.reasons,
+        )
     restore_sent_at = datetime.now(timezone.utc)
+    restore_transport = TransportWriteResult(False)
     try:
         restore_transport = (
-            await send_property(
-                property_name, original_value, f"{correlation_id}-restore"
+            await _send_tracked_restore(
+                send_property, property_name, original_value,
+                f"{correlation_id}-restore", verification_manager,
+                restore_tracked,
             )
             if restore_gate.accepted else TransportWriteResult(False)
         )
@@ -125,7 +197,25 @@ async def async_verify_reversible_write(
             read_property, original_value, restore_sent_at, timeout, poll_interval
         ) if restore_transport.accepted else (None, None)
     except Exception:
+        if restore_tracked is not None:
+            verification_manager.transport_result(
+                restore_tracked.command_id, ok=False, status="exception"
+            )
         restored = None
+    if restore_tracked is not None and restore_transport.accepted:
+        if restored is not None:
+            verification_manager.observe_readback(
+                restore_tracked.command_id, device_id=request.device_id,
+                property_name=property_name, value=restored.value,
+                observed_at=restored.observed_at,
+            )
+            verification_manager.effect(
+                restore_tracked.command_id,
+                status=EffectStatus.NOT_APPLICABLE,
+                reason="setpoint_only_test",
+            )
+        else:
+            verification_manager.readback_timeout(restore_tracked.command_id)
     return result(
         (
             NativeWriteStatus.RESTORE_FAILED
@@ -151,3 +241,20 @@ async def _await_readback(read_property: ReadProperty, expected: float,
             mismatch = value
         await asyncio.sleep(poll_interval)
     return None, mismatch
+
+
+async def _send_tracked_restore(
+    send_property: SendProperty, property_name: str, value: float,
+    correlation_id: str,
+    manager: NativeCommandVerificationManager | None,
+    tracked: object | None,
+) -> TransportWriteResult:
+    if manager is not None and tracked is not None:
+        manager.sent(tracked.command_id)
+    outcome = await send_property(property_name, value, correlation_id)
+    if manager is not None and tracked is not None:
+        manager.transport_result(
+            tracked.command_id, ok=outcome.accepted,
+            status=(str(outcome.status) if outcome.status is not None else None),
+        )
+    return outcome

--- a/docs/architecture/native-command-verification-v5.0.0.md
+++ b/docs/architecture/native-command-verification-v5.0.0.md
@@ -1,0 +1,64 @@
+# V5 native command verification
+
+Issue #334 generalizes the first verified ZenSDK write from #333 into a
+transport-neutral lifecycle below the PowerController and above every native
+transport adapter.
+
+## Boundary
+
+The execution chain is:
+
+`PowerController -> DeviceCommand -> DeviceCommandGate -> Transport -> CommandVerification`
+
+The PowerController owns the requested physical outcome. The gate owns current
+write authority and safety. A transport owns only sending and its technical
+acknowledgement. `NativeCommandVerificationManager` owns correlation of fresh
+readback and optional physical effect.
+
+A transport acknowledgement can never complete a command. Completion requires
+a fresh, correctly addressed readback. Effect verification is a separate,
+command-specific decision and may legitimately be `not_applicable` or
+`not_observable`.
+
+## Correlation and concurrency
+
+Each command has a random command ID and an exact `(device_id, target_key)`
+ownership key. A newer command for the same device and target supersedes the
+older command. Other targets and other devices remain independent. Late
+readback for a superseded command is ignored.
+
+Readback is accepted only when the device, property and timestamp match the
+command. The timestamp must be later than the send timestamp. A per-command
+tolerance represents verified device quantization or clamping; it is never a
+global guessed tolerance.
+
+## Result states
+
+The lifecycle distinguishes preparation, gate acceptance, sending, transport
+acceptance, readback confirmation and effect confirmation. Blocked, transport
+error, readback timeout/mismatch, contradictory response, effect
+timeout/mismatch, superseded and cancelled are separate outcomes.
+
+An ambiguous transport error followed by the expected device value is recorded
+as a contradictory response rather than silently converted to success.
+
+Retry permission is explicit per command through `max_attempts`. The default is
+one attempt. The manager never schedules retries itself.
+
+## Diagnostics
+
+Diagnostics expose requested/final values, transport status, readback,
+effect status and the following measured intervals:
+
+- gate to send
+- send to transport result
+- send to readback
+- send to physical effect
+
+Device identifiers are pseudonymized. Command metadata, payloads, credentials,
+tokens and serial numbers are not part of the diagnostic model. History is
+bounded, and repeated ineffective commands are counted per pseudonymous device.
+
+The Dev14 reversible SF2400AC test is the first consumer of this generalized
+layer. Normal PowerController writes remain on the Home Assistant/Z-HA backend;
+this issue enables no additional native command or transport.

--- a/tests/test_native_command_verification.py
+++ b/tests/test_native_command_verification.py
@@ -1,0 +1,210 @@
+"""Transport-neutral native command verification contracts."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import unittest
+
+from support import bootstrap
+
+bootstrap()
+
+from custom_components.battery_smartflow_ai.core.models import ZendureTransport  # noqa: E402
+from custom_components.battery_smartflow_ai.native_command_verification import (  # noqa: E402
+    CommandVerificationStatus,
+    EffectStatus,
+    NativeCommandVerificationManager,
+    ReadbackPolicy,
+)
+
+
+NOW = datetime(2026, 9, 4, 12, 0, tzinfo=timezone.utc)
+
+
+def prepared(manager, *, device="private-device-a", target="output_limit",
+             expected=100.0, tolerance=0.0, at=NOW, max_attempts=1):
+    return manager.prepare(
+        device_id=device, command_type="set_output_limit", target_key=target,
+        transport=ZendureTransport.ZENSDK, requested_value=expected,
+        final_value=expected,
+        readback=ReadbackPolicy("outputLimit", expected, tolerance),
+        prepared_at=at, max_attempts=max_attempts,
+    )
+
+
+def sent(manager, command):
+    manager.gate(command.command_id, accepted=True, at=NOW + timedelta(milliseconds=10))
+    manager.sent(command.command_id, at=NOW + timedelta(milliseconds=20))
+    manager.transport_result(
+        command.command_id, ok=True, status="http_200",
+        at=NOW + timedelta(milliseconds=40),
+    )
+
+
+class NativeCommandVerificationTests(unittest.TestCase):
+    def test_transport_ok_readback_and_effect_are_distinct(self):
+        manager = NativeCommandVerificationManager()
+        command = prepared(manager)
+        sent(manager, command)
+        self.assertEqual(command.status, CommandVerificationStatus.TRANSPORT_OK)
+        self.assertTrue(manager.observe_readback(
+            command.command_id, device_id="private-device-a",
+            property_name="outputLimit", value=100,
+            observed_at=NOW + timedelta(milliseconds=120),
+        ))
+        self.assertEqual(command.status, CommandVerificationStatus.READBACK_CONFIRMED)
+        manager.effect(
+            command.command_id, status=EffectStatus.CONFIRMED,
+            at=NOW + timedelta(milliseconds=250),
+        )
+        self.assertEqual(command.status, CommandVerificationStatus.EFFECT_CONFIRMED)
+        self.assertEqual(command.diagnostics()["send_to_readback_seconds"], 0.1)
+        self.assertEqual(command.diagnostics()["send_to_effect_seconds"], 0.23)
+
+    def test_stale_wrong_device_and_wrong_property_never_confirm(self):
+        manager = NativeCommandVerificationManager()
+        command = prepared(manager)
+        sent(manager, command)
+        for device, prop, observed in (
+            ("private-device-a", "outputLimit", NOW),
+            ("private-device-b", "outputLimit", NOW + timedelta(seconds=1)),
+            ("private-device-a", "inputLimit", NOW + timedelta(seconds=1)),
+        ):
+            self.assertFalse(manager.observe_readback(
+                command.command_id, device_id=device, property_name=prop,
+                value=100, observed_at=observed,
+            ))
+        self.assertEqual(command.status, CommandVerificationStatus.TRANSPORT_OK)
+
+    def test_tolerance_accepts_quantized_readback(self):
+        manager = NativeCommandVerificationManager()
+        command = prepared(manager, expected=101, tolerance=2)
+        sent(manager, command)
+        self.assertTrue(manager.observe_readback(
+            command.command_id, device_id="private-device-a",
+            property_name="outputLimit", value=100,
+            observed_at=NOW + timedelta(seconds=1),
+        ))
+
+    def test_mismatch_contradiction_and_timeouts_are_distinct(self):
+        manager = NativeCommandVerificationManager()
+        mismatch = prepared(manager)
+        sent(manager, mismatch)
+        manager.observe_readback(
+            mismatch.command_id, device_id="private-device-a",
+            property_name="outputLimit", value=90,
+            observed_at=NOW + timedelta(seconds=1),
+        )
+        self.assertEqual(mismatch.status, CommandVerificationStatus.READBACK_MISMATCH)
+        manager.observe_readback(
+            mismatch.command_id, device_id="private-device-a",
+            property_name="outputLimit", value=80,
+            observed_at=NOW + timedelta(seconds=2),
+        )
+        self.assertEqual(mismatch.status, CommandVerificationStatus.CONTRADICTORY_RESPONSE)
+
+        timeout = prepared(manager, target="input_limit")
+        sent(manager, timeout)
+        manager.readback_timeout(timeout.command_id)
+        self.assertEqual(timeout.status, CommandVerificationStatus.READBACK_TIMEOUT)
+
+    def test_effect_not_observable_is_not_failure(self):
+        manager = NativeCommandVerificationManager()
+        command = prepared(manager)
+        sent(manager, command)
+        manager.observe_readback(
+            command.command_id, device_id="private-device-a",
+            property_name="outputLimit", value=100,
+            observed_at=NOW + timedelta(seconds=1),
+        )
+        manager.effect(command.command_id, status=EffectStatus.NOT_OBSERVABLE)
+        self.assertEqual(command.status, CommandVerificationStatus.READBACK_CONFIRMED)
+        self.assertEqual(command.effect_status, EffectStatus.NOT_OBSERVABLE)
+
+    def test_transport_error_followed_by_applied_value_is_contradictory(self):
+        manager = NativeCommandVerificationManager()
+        command = prepared(manager)
+        manager.gate(command.command_id, accepted=True, at=NOW)
+        manager.sent(command.command_id, at=NOW + timedelta(milliseconds=10))
+        manager.transport_result(
+            command.command_id, ok=False, status="timeout",
+            at=NOW + timedelta(seconds=1),
+        )
+        self.assertFalse(manager.observe_readback(
+            command.command_id, device_id="private-device-a",
+            property_name="outputLimit", value=100,
+            observed_at=NOW + timedelta(seconds=2),
+        ))
+        self.assertEqual(
+            command.status, CommandVerificationStatus.CONTRADICTORY_RESPONSE
+        )
+        self.assertEqual(
+            command.reason, "transport_error_but_readback_confirmed"
+        )
+
+    def test_newer_same_target_supersedes_only_matching_device_target(self):
+        manager = NativeCommandVerificationManager()
+        old = prepared(manager)
+        sent(manager, old)
+        other_device = prepared(manager, device="private-device-b")
+        other_target = prepared(manager, target="input_limit")
+        new = prepared(manager, expected=80)
+        self.assertEqual(old.status, CommandVerificationStatus.SUPERSEDED)
+        self.assertEqual(old.superseded_by, new.command_id)
+        self.assertEqual(other_device.status, CommandVerificationStatus.PREPARED)
+        self.assertEqual(other_target.status, CommandVerificationStatus.PREPARED)
+        self.assertFalse(manager.observe_readback(
+            old.command_id, device_id="private-device-a",
+            property_name="outputLimit", value=100,
+            observed_at=NOW + timedelta(seconds=1),
+        ))
+
+    def test_retry_limit_and_cancel_before_send_are_enforced(self):
+        manager = NativeCommandVerificationManager()
+        command = prepared(manager)
+        manager.gate(command.command_id, accepted=True)
+        manager.sent(command.command_id)
+        with self.assertRaisesRegex(ValueError, "gate accepted"):
+            manager.sent(command.command_id)
+        cancellable = prepared(manager, target="mode")
+        manager.cancel(cancellable.command_id)
+        self.assertEqual(cancellable.status, CommandVerificationStatus.CANCELLED)
+
+    def test_effect_timeout_and_mismatch_are_failures(self):
+        manager = NativeCommandVerificationManager()
+        for index, effect in enumerate((EffectStatus.TIMEOUT, EffectStatus.MISMATCH)):
+            command = prepared(manager, target=f"target-{index}")
+            sent(manager, command)
+            manager.observe_readback(
+                command.command_id, device_id="private-device-a",
+                property_name="outputLimit", value=100,
+                observed_at=NOW + timedelta(seconds=1),
+            )
+            manager.effect(command.command_id, status=effect)
+        self.assertEqual(
+            manager.diagnostics()["failures_by_device"].popitem()[1], 2
+        )
+
+    def test_history_is_bounded_without_removing_active_commands(self):
+        manager = NativeCommandVerificationManager(history_limit=2)
+        active = prepared(manager, target="active")
+        for index in range(3):
+            command = prepared(manager, target=f"done-{index}")
+            manager.cancel(command.command_id)
+        commands = manager.diagnostics()["commands"]
+        self.assertEqual(len(commands), 2)
+        self.assertIn(active.command_id, {item["command_id"] for item in commands})
+
+    def test_diagnostics_pseudonymize_devices_and_exclude_secrets(self):
+        manager = NativeCommandVerificationManager()
+        command = prepared(manager, device="serial-and-token-secret")
+        manager.gate(command.command_id, accepted=False, reasons=("hems_active",))
+        diagnostics = manager.diagnostics()
+        text = str(diagnostics)
+        self.assertNotIn("serial-and-token-secret", text)
+        self.assertIn("device_", text)
+        self.assertNotIn("metadata", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_zendure_first_write.py
+++ b/tests/test_zendure_first_write.py
@@ -18,6 +18,11 @@ from custom_components.battery_smartflow_ai.zendure_first_write import (  # noqa
 )
 from custom_components.battery_smartflow_ai.core.models import DeviceCommand, ZendureTransport  # noqa: E402
 from custom_components.battery_smartflow_ai.native_device_command_gate import NativeCommandRequest  # noqa: E402
+from custom_components.battery_smartflow_ai.native_command_verification import (  # noqa: E402
+    CommandVerificationStatus,
+    EffectStatus,
+    NativeCommandVerificationManager,
+)
 
 
 def request(value: float) -> NativeCommandRequest:
@@ -47,6 +52,7 @@ class Gate:
 class FirstWriteTests(unittest.IsolatedAsyncioTestCase):
     async def test_write_and_restore_both_require_fresh_readback(self):
         writes = []
+        manager = NativeCommandVerificationManager()
 
         async def send(prop, value, correlation):
             writes.append((prop, value, correlation))
@@ -60,11 +66,21 @@ class FirstWriteTests(unittest.IsolatedAsyncioTestCase):
             gate=Gate(), request=request(101.0), context=None,
             property_name="outputLimit", original_value=100.0,
             requested_value=101.0, send_property=send, read_property=read,
-            timeout=0.1, poll_interval=0,
+            timeout=0.1, poll_interval=0, verification_manager=manager,
         )
         self.assertEqual(result.status, NativeWriteStatus.RESTORED)
         self.assertEqual([item[1] for item in writes], [101.0, 100.0])
         self.assertEqual(writes[1][2], "safe-correlation-restore")
+        commands = manager.diagnostics()["commands"]
+        self.assertEqual(len(commands), 2)
+        self.assertTrue(all(
+            item["status"] == CommandVerificationStatus.READBACK_CONFIRMED.value
+            for item in commands
+        ))
+        self.assertTrue(all(
+            item["effect_status"] == EffectStatus.NOT_APPLICABLE.value
+            for item in commands
+        ))
 
     async def test_transport_ok_without_readback_is_timeout_and_not_retried(self):
         writes = []


### PR DESCRIPTION
## Summary

- add a transport-neutral native command verification manager above all adapters
- distinguish prepared, gate accepted, sent, transport result, fresh readback, and optional physical effect
- reject stale, wrong-device, and wrong-property readback as confirmation
- support capability-provided readback tolerances without a guessed global tolerance
- model timeout, mismatch, contradictory response, effect failure, cancellation, and supersession explicitly
- supersede only an older command for the same device and target; keep devices and target properties isolated
- keep retries explicit and bounded, with one attempt by default and no retry scheduler
- retain bounded privacy-safe diagnostics, per-device failure counts, and all latency timestamps
- migrate the Dev14 reversible SF2400AC write and restore test onto the shared verification layer
- document the architectural boundary and lifecycle

## Scope

- no new command type or transport is enabled
- no production PowerController native write is enabled
- no latency benchmark is run in this issue
- version remains 5.0.0.dev14; no additional development release

## Validation

- full suite: 530 tests passed
- Python compilation passed
- manifest JSON validation passed
- diff/whitespace validation passed

Closes #334