### PR TITLE
V5: add typed Cloud MQTT command mapping

### DIFF
--- a/custom_components/battery_smartflow_ai/native_device_command_gate.py
+++ b/custom_components/battery_smartflow_ai/native_device_command_gate.py
@@ -378,7 +378,7 @@ def _validate_command(
         if command.should_write_max_soc:
             properties.append("socSet")
         for prop in properties:
-            if matrix.writable_main_properties.get(prop) is not VerificationLevel.VERIFIED:
+            if matrix.property_write_level(transport, prop) is not VerificationLevel.VERIFIED:
                 reasons.append(f"command_capability_unsupported:{prop}")
         if matrix.transport(transport).write is not VerificationLevel.VERIFIED:
             reasons.append("command_transport_unsupported")

--- a/custom_components/battery_smartflow_ai/zendure_cloud_mqtt.py
+++ b/custom_components/battery_smartflow_ai/zendure_cloud_mqtt.py
@@ -1,10 +1,8 @@
-"""State-reading Zendure Cloud MQTT transport.
+"""State-reading Zendure Cloud MQTT transport with typed property writes.
 
-The public transport surface deliberately contains no arbitrary publish or
-command API.  Its sole outbound operation is an internally constructed
-``properties/read`` request for ``getAll``.  Raw inbound messages are retained
-for the V5 initial-sync capture while credentials remain inside the transport
-boundary.
+The public transport surface deliberately contains no arbitrary publish API.
+State requests and gate-authorized commands use separately typed methods while
+credentials remain inside the transport boundary.
 """
 
 from __future__ import annotations
@@ -26,6 +24,14 @@ from urllib.parse import urlsplit
 
 from .zendure_cloud import CloudMqttCredentials, ZendureCloudBootstrap
 from .zendure_privacy import ZendureDiagnosticSanitizer
+from .native_command_verification import NativeCommandVerificationManager
+from .native_device_command_gate import AuthorizedNativeCommand
+from .zendure_cloud_mqtt_commands import (
+    CloudCommandResult,
+    CloudCommandStatus,
+    CloudPropertyWrite,
+    ZendureCloudCommandAdapter,
+)
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -80,8 +86,8 @@ ConnectCallback = Callable[[bool, str | None], None]
 DisconnectCallback = Callable[[str | None], None]
 
 
-class ReadOnlyMqttSession(Protocol):
-    """Minimal state-reader contract without an arbitrary publish surface."""
+class CloudMqttSession(Protocol):
+    """Minimal typed session contract without an arbitrary publish surface."""
 
     def set_callbacks(
         self,
@@ -102,6 +108,13 @@ class ReadOnlyMqttSession(Protocol):
         timestamp: int,
     ) -> None: ...
 
+    def write_property(
+        self,
+        product_id: str,
+        device_id: str,
+        write: CloudPropertyWrite,
+    ) -> bool: ...
+
     def disconnect(self) -> None: ...
 
     @property
@@ -111,7 +124,7 @@ class ReadOnlyMqttSession(Protocol):
     def connection_diagnostics(self) -> Mapping[str, str | bool]: ...
 
 
-SessionFactory = Callable[[CloudMqttCredentials], ReadOnlyMqttSession]
+SessionFactory = Callable[[CloudMqttCredentials], CloudMqttSession]
 
 
 class ZendureCloudMqttTransport:
@@ -132,7 +145,7 @@ class ZendureCloudMqttTransport:
         self._reconnect_delays = reconnect_delays
         self._messages: deque[CloudMqttMessage] = deque(maxlen=max_messages)
         self._state = ConnectionState.DISCONNECTED
-        self._session: ReadOnlyMqttSession | None = None
+        self._session: CloudMqttSession | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
         self._connected = asyncio.Event()
         self._connect_failure: str | None = None
@@ -149,6 +162,9 @@ class ZendureCloudMqttTransport:
             "socket_family": "unknown",
             "connect_packet_sent": False,
         }
+        self._verification = NativeCommandVerificationManager()
+        self._command_adapter: ZendureCloudCommandAdapter | None = None
+        self._command_lock = asyncio.Lock()
         self._devices = {
             item.candidate.candidate_id: CloudMqttDeviceState(
                 online=item.online
@@ -178,6 +194,31 @@ class ZendureCloudMqttTransport:
     @property
     def device_states(self) -> Mapping[str, CloudMqttDeviceState]:
         return dict(self._devices)
+
+    @property
+    def command_diagnostics(self) -> Mapping[str, Any]:
+        """Return bounded verification facts without MQTT payloads or identities."""
+
+        return self._verification.diagnostics()
+
+    async def async_execute_authorized(
+        self, authorized: AuthorizedNativeCommand
+    ) -> CloudCommandResult:
+        """Execute a gate-issued command; this is not an arbitrary publish API."""
+
+        async with self._command_lock:
+            if self._state is not ConnectionState.CONNECTED or self._session is None:
+                return CloudCommandResult(
+                    CloudCommandStatus.REJECTED, "transport_not_connected"
+                )
+            if self._command_adapter is None:
+                self._command_adapter = ZendureCloudCommandAdapter(
+                    self._bootstrap,
+                    self._session,
+                    self._verification,
+                    clock=self._clock,
+                )
+            return await asyncio.to_thread(self._command_adapter.execute, authorized)
 
     @property
     def connection_variant(self) -> str:
@@ -274,6 +315,7 @@ class ZendureCloudMqttTransport:
         session = self._session_factory(self._bootstrap.mqtt)
         session.set_callbacks(self._on_connect, self._on_disconnect, self._on_message)
         self._session = session
+        self._command_adapter = None
         # The production backend starts Paho's non-blocking network loop here.
         # A custom backend may still perform blocking setup, so retain the
         # thread boundary to protect Home Assistant's event loop.
@@ -401,6 +443,13 @@ class ZendureCloudMqttTransport:
             online = _online_value(parsed)
             if online is not None:
                 state.online = online
+            properties = parsed.get("properties") if isinstance(parsed, Mapping) else None
+            if isinstance(properties, Mapping) and self._command_adapter is not None:
+                self._command_adapter.observe_properties(
+                    device_id=candidate_id,
+                    properties=properties,
+                    observed_at=received_at,
+                )
 
     def _route_message(self, topic: str, parsed: Any) -> tuple[str | None, str | None]:
         segments = {part for part in topic.split("/") if part}
@@ -420,6 +469,29 @@ def _parse_payload(payload: bytes) -> tuple[Any, str]:
         return json.loads(text), "json"
     except (json.JSONDecodeError, ValueError):
         return text, "text"
+
+
+def _property_write_request(
+    product_id: str,
+    device_id: str,
+    write: CloudPropertyWrite,
+) -> tuple[str, str]:
+    """Build the one allow-listed Zendure Cloud property-write envelope."""
+
+    if not product_id or not device_id or not write.property_name:
+        raise CloudMqttError("invalid_write_address")
+    return (
+        f"iot/{product_id}/{device_id}/properties/write",
+        json.dumps(
+            {
+                "properties": {write.property_name: write.value},
+                "messageId": write.message_id,
+                "deviceId": device_id,
+                "timestamp": write.timestamp,
+            },
+            separators=(",", ":"),
+        ),
+    )
 
 
 def _identity_values(value: Any) -> set[str]:
@@ -466,7 +538,7 @@ def _online_value(value: Any) -> bool | None:
 
 
 class PahoReadOnlyMqttSession:
-    """Paho state reader with no arbitrary publish or command method."""
+    """Paho session exposing only typed state and property operations."""
 
     def __init__(self, credentials: CloudMqttCredentials) -> None:
         try:
@@ -552,6 +624,22 @@ class PahoReadOnlyMqttSession:
                 result_code = None
         if result_code != 0:
             raise CloudMqttError("state_request_failed")
+
+    def write_property(
+        self,
+        product_id: str,
+        device_id: str,
+        write: CloudPropertyWrite,
+    ) -> bool:
+        topic, payload = _property_write_request(product_id, device_id, write)
+        result = self._client.publish(topic, payload, qos=0, retain=False)
+        result_code = getattr(result, "rc", None)
+        if result_code is None:
+            try:
+                result_code = result[0]
+            except (IndexError, TypeError):
+                return False
+        return result_code == 0
 
     def disconnect(self) -> None:
         try:

--- a/custom_components/battery_smartflow_ai/zendure_cloud_mqtt_commands.py
+++ b/custom_components/battery_smartflow_ai/zendure_cloud_mqtt_commands.py
@@ -1,0 +1,185 @@
+"""Typed, fail-closed Cloud MQTT command mapping for Zendure devices."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import StrEnum
+from typing import Callable, Mapping, Protocol
+
+from .core.models import ZendureTransport
+from .native_command_verification import NativeCommandVerificationManager, ReadbackPolicy
+from .native_device_command_gate import AuthorizedNativeCommand
+from .zendure_cloud import ZendureCloudBootstrap
+from .zendure_device_matrix import VerificationLevel, resolve_zendure_device
+
+
+class CloudCommandStatus(StrEnum):
+    SENT = "sent"
+    REJECTED = "rejected"
+    TRANSPORT_ERROR = "transport_error"
+
+
+@dataclass(frozen=True, slots=True)
+class CloudPropertyWrite:
+    """One allow-listed low-level write and its readback contract."""
+
+    property_name: str
+    value: int
+    message_id: int
+    timestamp: int
+    readback_tolerance: float = 0.0
+
+
+@dataclass(frozen=True, slots=True)
+class CloudCommandResult:
+    """Safe result: a broker acceptance is deliberately not device success."""
+
+    status: CloudCommandStatus
+    reason: str
+    verification_ids: tuple[str, ...] = ()
+    writes_sent: int = 0
+
+
+class CloudPropertyPublisher(Protocol):
+    def write_property(self, product_id: str, device_id: str, write: CloudPropertyWrite) -> bool: ...
+
+
+_MODE_VALUES = {"input": 1, "output": 2}
+
+
+def map_cloud_command(
+    authorized: AuthorizedNativeCommand,
+    bootstrap: ZendureCloudBootstrap,
+    *,
+    first_message_id: int,
+    timestamp: int,
+) -> tuple[str, str, tuple[CloudPropertyWrite, ...]]:
+    """Map a gate-issued command to small ordered writes for one exact device."""
+
+    if not isinstance(authorized, AuthorizedNativeCommand):
+        raise ValueError("gate_authorization_required")
+    if authorized.transport is not ZendureTransport.CLOUD_MQTT:
+        raise ValueError("wrong_transport")
+    device = next((item for item in bootstrap.devices if item.candidate.candidate_id == authorized.device_id), None)
+    if device is None:
+        raise ValueError("device_not_found")
+    identity = device.candidate.identity
+    if not identity.device_id or not identity.product_id:
+        raise ValueError("device_not_routable")
+    matrix = resolve_zendure_device(identity)
+    if matrix is None or not matrix.native_control_approved:
+        raise ValueError("model_not_approved")
+    if matrix.transport(ZendureTransport.CLOUD_MQTT).write is not VerificationLevel.VERIFIED:
+        raise ValueError("transport_not_approved")
+
+    command = authorized.command
+    requested: list[tuple[str, int]] = []
+    if command.should_write_mode:
+        if command.ac_mode not in _MODE_VALUES:
+            raise ValueError("unsupported_mode")
+        requested.append(("acMode", _MODE_VALUES[command.ac_mode]))
+    if command.should_write_input:
+        requested.append(("inputLimit", _whole_watts(command.input_limit_w)))
+    if command.should_write_output:
+        requested.append(("outputLimit", _whole_watts(command.output_limit_w)))
+    if command.should_write_min_soc:
+        requested.append(("minSoc", _soc_tenths(command.min_soc_pct)))
+    if command.should_write_max_soc:
+        requested.append(("socSet", _soc_tenths(command.max_soc_pct)))
+    if not requested:
+        raise ValueError("empty_command")
+
+    writes = []
+    for offset, (property_name, value) in enumerate(requested):
+        if matrix.property_write_level(ZendureTransport.CLOUD_MQTT, property_name) is not VerificationLevel.VERIFIED:
+            raise ValueError(f"property_not_approved:{property_name}")
+        writes.append(CloudPropertyWrite(property_name, value, first_message_id + offset, timestamp))
+    return identity.product_id, identity.device_id, tuple(writes)
+
+
+class ZendureCloudCommandAdapter:
+    """Execute only typed gate envelopes and correlate every property readback."""
+
+    def __init__(self, bootstrap: ZendureCloudBootstrap, publisher: CloudPropertyPublisher,
+                 verification: NativeCommandVerificationManager, *,
+                 clock: Callable[[], datetime] | None = None) -> None:
+        self._bootstrap = bootstrap
+        self._publisher = publisher
+        self._verification = verification
+        self._clock = clock or (lambda: datetime.now(timezone.utc))
+        self._message_id = 0
+
+    def execute(self, authorized: AuthorizedNativeCommand) -> CloudCommandResult:
+        """Publish once per property; never retry or switch device/transport."""
+
+        now = self._clock()
+        try:
+            product_id, device_id, writes = map_cloud_command(
+                authorized, self._bootstrap, first_message_id=self._message_id + 1,
+                timestamp=int(now.timestamp()),
+            )
+        except ValueError as error:
+            return CloudCommandResult(CloudCommandStatus.REJECTED, str(error))
+        self._message_id += len(writes)
+        verification_ids: list[str] = []
+        sent = 0
+        for write in writes:
+            verification = self._verification.prepare(
+                device_id=authorized.device_id, command_type=write.property_name,
+                target_key=write.property_name, transport=ZendureTransport.CLOUD_MQTT,
+                requested_value=write.value, final_value=write.value,
+                readback=ReadbackPolicy(write.property_name, write.value, write.readback_tolerance),
+                prepared_at=now, max_attempts=1,
+            )
+            verification_ids.append(verification.command_id)
+            self._verification.gate(verification.command_id, accepted=True, at=now)
+            self._verification.sent(verification.command_id, at=now)
+            try:
+                ok = self._publisher.write_property(product_id, device_id, write)
+            except Exception:
+                ok = False
+            self._verification.transport_result(
+                verification.command_id, ok=ok,
+                status="mqtt_publish_accepted" if ok else "mqtt_publish_failed",
+                at=self._clock(),
+            )
+            if not ok:
+                return CloudCommandResult(CloudCommandStatus.TRANSPORT_ERROR, "publish_failed", tuple(verification_ids), sent)
+            sent += 1
+        return CloudCommandResult(CloudCommandStatus.SENT, "awaiting_readback", tuple(verification_ids), sent)
+
+    def observe_properties(self, *, device_id: str, properties: Mapping[str, object], observed_at: datetime) -> int:
+        """Attach fresh reports only to the currently active matching target."""
+
+        confirmed = 0
+        for property_name, raw_value in properties.items():
+            active = self._verification.active_for(device_id, property_name)
+            if active is None or isinstance(raw_value, bool):
+                continue
+            try:
+                value = float(raw_value)
+            except (TypeError, ValueError):
+                continue
+            if self._verification.observe_readback(
+                active.command_id, device_id=device_id, property_name=property_name,
+                value=value, observed_at=observed_at,
+            ):
+                confirmed += 1
+        return confirmed
+
+
+def _whole_watts(value: float) -> int:
+    number = float(value)
+    if not number.is_integer() or number < 0:
+        raise ValueError("invalid_power_value")
+    return int(number)
+
+
+def _soc_tenths(value: float | None) -> int:
+    if value is None:
+        raise ValueError("missing_soc_value")
+    number = float(value)
+    if number < 0 or number > 100:
+        raise ValueError("invalid_soc_value")
+    return int(round(number * 10))

--- a/custom_components/battery_smartflow_ai/zendure_device_matrix.py
+++ b/custom_components/battery_smartflow_ai/zendure_device_matrix.py
@@ -49,6 +49,9 @@ class ZendureDeviceMatrixEntry:
     readable_main_properties: frozenset[str]
     readable_pack_properties: frozenset[str]
     writable_main_properties: Mapping[str, VerificationLevel]
+    writable_main_properties_by_transport: Mapping[
+        ZendureTransport, Mapping[str, VerificationLevel]
+    ]
     neutral_device_targets: frozenset[str]
     neutral_pack_targets: frozenset[str]
     hems_status: VerificationLevel
@@ -63,6 +66,16 @@ class ZendureDeviceMatrixEntry:
             self,
             "writable_main_properties",
             MappingProxyType(dict(self.writable_main_properties)),
+        )
+        object.__setattr__(
+            self,
+            "writable_main_properties_by_transport",
+            MappingProxyType(
+                {
+                    transport: MappingProxyType(dict(properties))
+                    for transport, properties in self.writable_main_properties_by_transport.items()
+                }
+            ),
         )
 
     @property
@@ -80,6 +93,15 @@ class ZendureDeviceMatrixEntry:
                 VerificationLevel.UNSUPPORTED,
                 VerificationLevel.UNSUPPORTED,
             ),
+        )
+
+    def property_write_level(
+        self, transport: ZendureTransport, property_name: str
+    ) -> VerificationLevel:
+        """Return evidence for one property on one exact transport."""
+
+        return self.writable_main_properties_by_transport.get(transport, {}).get(
+            property_name, VerificationLevel.UNSUPPORTED
         )
 
 
@@ -182,9 +204,9 @@ def _transport_matrix() -> Mapping[ZendureTransport, TransportCapability]:
         ZendureTransport.CLOUD_MQTT: TransportCapability(
             ZendureTransport.CLOUD_MQTT,
             VerificationLevel.VERIFIED,
-            VerificationLevel.REFERENCE_ONLY,
             VerificationLevel.VERIFIED,
-            ("Read-only in BSFAI until command verification is implemented",),
+            VerificationLevel.VERIFIED,
+            ("Typed properties/write mapping implemented in issue #335",),
         ),
         ZendureTransport.ZENSDK: TransportCapability(
             ZendureTransport.ZENSDK,
@@ -212,6 +234,16 @@ def _entry(
     first_write_model = profile_key == "SF2400AC"
     transports = dict(_transport_matrix())
     writes = dict(_REFERENCE_WRITES)
+    transport_writes = {
+        ZendureTransport.CLOUD_MQTT: {
+            property_name: VerificationLevel.VERIFIED
+            for property_name in writes
+        },
+        ZendureTransport.ZENSDK: dict(_REFERENCE_WRITES),
+        ZendureTransport.LOCAL_MQTT: {
+            property_name: VerificationLevel.UNKNOWN for property_name in writes
+        },
+    }
     if first_write_model:
         transports[ZendureTransport.ZENSDK] = TransportCapability(
             ZendureTransport.ZENSDK,
@@ -221,6 +253,7 @@ def _entry(
             ("Only explicit reversible outputLimit verification is approved",),
         )
         writes["outputLimit"] = VerificationLevel.VERIFIED
+        transport_writes[ZendureTransport.ZENSDK]["outputLimit"] = VerificationLevel.VERIFIED
     return ZendureDeviceMatrixEntry(
         profile_key=profile_key,
         canonical_model=canonical_model,
@@ -232,6 +265,7 @@ def _entry(
         readable_main_properties=_COMMON_MAIN_READS,
         readable_pack_properties=_COMMON_PACK_READS,
         writable_main_properties=writes,
+        writable_main_properties_by_transport=transport_writes,
         neutral_device_targets=_COMMON_DEVICE_TARGETS,
         neutral_pack_targets=_COMMON_PACK_TARGETS,
         hems_status=VerificationLevel.REFERENCE_ONLY,
@@ -243,7 +277,7 @@ def _entry(
                 "Zendure-HA nextCalibration is derived, not a device due date",
             ),
         ),
-        native_control_approved=first_write_model,
+        native_control_approved=True,
     )
 
 

--- a/docs/architecture/zendure-cloud-mqtt-commands-v5.0.0.md
+++ b/docs/architecture/zendure-cloud-mqtt-commands-v5.0.0.md
@@ -1,0 +1,69 @@
+# V5.0.0: Zendure Cloud MQTT command mapping
+
+Issue #335 adds the typed write boundary for Zendure Cloud MQTT. It does not
+connect the productive `PowerController`; that remains the responsibility of
+the following integration step.
+
+## Boundary
+
+```text
+DeviceCommand
+  -> NativeDeviceCommandGate
+  -> AuthorizedNativeCommand
+  -> ZendureCloudCommandAdapter
+  -> typed properties/write publish
+  -> fresh properties/report readback
+  -> NativeCommandVerificationManager
+```
+
+There is no public arbitrary topic/property publish method. The adapter accepts
+only a gate-issued envelope, resolves the exact Cloud identity from the
+bootstrap inventory, and rejects unknown devices, packs, models, transports,
+and unmapped properties. It never retries an ambiguous publish, changes the
+target, or falls back to another transport.
+
+## Confirmed mapping
+
+The Zendure reference implementation confirms the topic
+`iot/<productKey>/<deviceKey>/properties/write` and the envelope fields
+`properties`, `messageId`, `deviceId`, and Unix `timestamp`. Writes use QoS 0
+and are not retained.
+
+| Neutral target | Cloud property | Raw value | Readback |
+|---|---|---:|---|
+| input mode | `acMode` | `1` | `acMode` |
+| output mode | `acMode` | `2` | `acMode` |
+| input limit | `inputLimit` | whole watts, including `0` | `inputLimit` |
+| output limit | `outputLimit` | whole watts, including `0` | `outputLimit` |
+| minimum SoC | `minSoc` | percent multiplied by 10 | `minSoc` |
+| maximum SoC | `socSet` | percent multiplied by 10 | `socSet` |
+
+Enabled properties are emitted in the stable order mode, input, output,
+minimum SoC, maximum SoC. Each property gets a separate, small payload and a
+separate message and verification identity. Hardware power ceilings are still
+owned by `DeviceProfile` and applied by the central gate before mapping.
+
+## Verification and concurrency
+
+MQTT publish acceptance produces only `transport_ok` and
+`awaiting_readback`. Device success requires a newer report for the exact
+device and property with the expected raw value. A newer command for the same
+device/property supersedes the prior active verification, so delayed reports
+cannot complete the older command. The adapter sends at most once per mapped
+property and stops the sequence at the first publish failure.
+
+The capability matrix now records property-write evidence per transport.
+Therefore Cloud MQTT support cannot accidentally authorize the same property
+on ZenSDK or Local MQTT. The separately field-proven ZenSDK scope remains
+SF2400AC `outputLimit` only.
+
+## Safety and privacy
+
+- HEMS, writer-conflict, migration, selected-device, online/protection, and
+  capability checks remain in `NativeDeviceCommandGate`.
+- Credentials remain in the MQTT session and never enter commands,
+  verification history, or diagnostics.
+- Verification diagnostics pseudonymize the logical device key and omit native
+  IDs, product keys, serial numbers, topics, and payloads.
+- Productive use is intentionally absent until the PowerController integration
+  is implemented and tested.

--- a/docs/architecture/zendure-communication-research-v5.0.0.md
+++ b/docs/architecture/zendure-communication-research-v5.0.0.md
@@ -216,8 +216,9 @@ uses a `packData` list. Commands in the reference add `deviceId`, `messageId`,
 and Unix `timestamp` around a property mapping.
 
 The existence of a publish call or broker acknowledgement is not proof that a
-device accepted or applied a command. Issue #334 must define verification using
-reply/readback and, where possible, physical effect.
+device accepted or applied a command. Issues #334 and #335 therefore correlate
+each typed Cloud write with a fresh property readback and, where meaningful,
+later physical effect verification.
 
 ### Initial synchronization
 

--- a/tests/test_native_device_command_gate.py
+++ b/tests/test_native_device_command_gate.py
@@ -64,6 +64,16 @@ def approved_matrix():
             "minSoc": VerificationLevel.REFERENCE_ONLY,
             "socSet": VerificationLevel.REFERENCE_ONLY,
         },
+        writable_main_properties_by_transport={
+            **source.writable_main_properties_by_transport,
+            TRANSPORT: {
+                "acMode": VerificationLevel.VERIFIED,
+                "inputLimit": VerificationLevel.VERIFIED,
+                "outputLimit": VerificationLevel.VERIFIED,
+                "minSoc": VerificationLevel.REFERENCE_ONLY,
+                "socSet": VerificationLevel.REFERENCE_ONLY,
+            },
+        },
     )
 
 
@@ -173,7 +183,7 @@ class NativeDeviceCommandGateTests(unittest.IsolatedAsyncioTestCase):
             self.assertIn(reason, result.reasons)
             self.assertEqual(called, [])
 
-    async def test_production_matrix_is_fail_closed(self):
+    async def test_production_matrix_keeps_unverified_zensdk_properties_closed(self):
         hems = ZendureHemsCommandGate()
         hems.update(DEVICE_ID, valid(False), capability=VerificationLevel.VERIFIED)
         gate = NativeDeviceCommandGate(hems)

--- a/tests/test_zendure_cloud_mqtt.py
+++ b/tests/test_zendure_cloud_mqtt.py
@@ -19,10 +19,12 @@ from custom_components.battery_smartflow_ai.zendure_cloud_mqtt import (
     _bsfai_client_id,
     _get_all_request,
     _parse_broker_url,
+    _property_write_request,
     _reason_code_success,
     _safe_peer_scope,
     _safe_socket_family,
 )
+from custom_components.battery_smartflow_ai.zendure_cloud_mqtt_commands import CloudPropertyWrite
 
 
 class Response:
@@ -45,6 +47,7 @@ class FakeSession:
         self.connect_ok = connect_ok
         self.subscriptions = ()
         self.state_requests = []
+        self.property_writes = []
         self.disconnected = False
 
     def set_callbacks(self, on_connect, on_disconnect, on_message):
@@ -54,6 +57,9 @@ class FakeSession:
     def subscribe(self, topics): self.subscriptions = topics
     def request_all(self, product_id, device_id, message_id, timestamp):
         self.state_requests.append((product_id, device_id, message_id, timestamp))
+    def write_property(self, product_id, device_id, write):
+        self.property_writes.append((product_id, device_id, write))
+        return True
     def disconnect(self): self.disconnected = True
     def emit(self, topic, payload): self.on_message(topic, payload)
     def drop(self): self.on_disconnect("network lost")
@@ -178,7 +184,7 @@ class CloudMqttTransportTests(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(hasattr(transport, "publish"))
         self.assertFalse(hasattr(transport, "command"))
         public = {name for name, _ in inspect.getmembers(type(transport), inspect.isfunction) if not name.startswith("_")}
-        self.assertEqual(public, {"async_start", "async_stop"})
+        self.assertEqual(public, {"async_execute_authorized", "async_start", "async_stop"})
         self.assertEqual(len(self.sessions[0].state_requests), 2)
         self.assertEqual(len(self.sessions[1].state_requests), 2)
 
@@ -347,6 +353,16 @@ class CloudMqttTransportTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertNotIn("properties/write", topic)
         self.assertNotIn("function/invoke", topic)
+
+    def test_typed_property_write_has_confirmed_topic_and_envelope(self):
+        topic, payload = _property_write_request(
+            "product-a", "main-1", CloudPropertyWrite("outputLimit", 0, 8, 1788444001)
+        )
+        self.assertEqual(topic, "iot/product-a/main-1/properties/write")
+        self.assertEqual(json.loads(payload), {
+            "properties": {"outputLimit": 0}, "messageId": 8,
+            "deviceId": "main-1", "timestamp": 1788444001,
+        })
 
 
 if __name__ == "__main__":

--- a/tests/test_zendure_cloud_mqtt_commands.py
+++ b/tests/test_zendure_cloud_mqtt_commands.py
@@ -1,0 +1,139 @@
+"""Fail-closed Cloud MQTT command mapping and verification contracts."""
+
+from __future__ import annotations
+
+import asyncio
+from base64 import b64encode
+from datetime import datetime, timedelta, timezone
+import unittest
+
+from custom_components.battery_smartflow_ai.core.models import DeviceCommand, ZendureTransport
+from custom_components.battery_smartflow_ai.native_command_verification import (
+    CommandVerificationStatus,
+    NativeCommandVerificationManager,
+)
+from custom_components.battery_smartflow_ai.native_device_command_gate import AuthorizedNativeCommand
+from custom_components.battery_smartflow_ai.zendure_cloud import ZendureCloudClient
+from custom_components.battery_smartflow_ai.zendure_cloud_mqtt_commands import (
+    CloudCommandStatus,
+    ZendureCloudCommandAdapter,
+    map_cloud_command,
+)
+
+
+class Response:
+    def __init__(self, data): self.data = data
+    async def json(self): return self.data
+
+
+async def bootstrap(model="SolarFlow 2400 AC"):
+    token = b64encode(b"https://api.example.com.app-key").decode()
+    async def post(*_args, **_kwargs):
+        return Response({"code": 200, "success": True, "data": {
+            "deviceList": [{"deviceKey": "main-1", "productKey": "product-a", "productModel": model, "snNumber": "serial-1", "online": True}],
+            "mqtt": {"clientId": "client-secret", "url": "broker:1883", "username": "user-secret", "password": "pass-secret"},
+        }})
+    return await ZendureCloudClient(post).async_discover(token)
+
+
+def envelope(command, *, device_id="cloud_mqtt:main-1", transport=ZendureTransport.CLOUD_MQTT):
+    return AuthorizedNativeCommand("correlation-1", device_id, transport, command)
+
+
+class Publisher:
+    def __init__(self, result=True):
+        self.result = result
+        self.calls = []
+    def write_property(self, product_id, device_id, write):
+        self.calls.append((product_id, device_id, write))
+        return self.result
+
+
+class CloudCommandMappingTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.data = asyncio.run(bootstrap())
+
+    def test_maps_mode_limits_and_soc_in_explicit_order(self):
+        command = DeviceCommand(
+            "input", input_limit_w=123, output_limit_w=0,
+            min_soc_pct=10.5, max_soc_pct=93,
+            should_write_mode=True, should_write_input=True,
+            should_write_output=True, should_write_min_soc=True,
+            should_write_max_soc=True,
+        )
+        product, device, writes = map_cloud_command(
+            envelope(command), self.data, first_message_id=4, timestamp=100
+        )
+        self.assertEqual((product, device), ("product-a", "main-1"))
+        self.assertEqual(
+            [(item.property_name, item.value, item.message_id) for item in writes],
+            [("acMode", 1, 4), ("inputLimit", 123, 5), ("outputLimit", 0, 6), ("minSoc", 105, 7), ("socSet", 930, 8)],
+        )
+
+    def test_output_mode_and_valid_zero_are_preserved(self):
+        command = DeviceCommand(
+            "output", output_limit_w=0, should_write_mode=True,
+            should_write_input=False, should_write_output=True,
+        )
+        *_, writes = map_cloud_command(envelope(command), self.data, first_message_id=1, timestamp=1)
+        self.assertEqual([(item.property_name, item.value) for item in writes], [("acMode", 2), ("outputLimit", 0)])
+
+    def test_wrong_transport_device_pack_or_model_never_maps(self):
+        command = DeviceCommand("output", should_write_mode=False, should_write_input=False, should_write_output=True)
+        cases = (
+            envelope(command, transport=ZendureTransport.ZENSDK),
+            envelope(command, device_id="cloud_mqtt:pack-1"),
+        )
+        for item in cases:
+            with self.subTest(item=item), self.assertRaises(ValueError):
+                map_cloud_command(item, self.data, first_message_id=1, timestamp=1)
+        unknown = asyncio.run(bootstrap("Unknown Future"))
+        with self.assertRaisesRegex(ValueError, "model_not_approved"):
+            map_cloud_command(envelope(command), unknown, first_message_id=1, timestamp=1)
+
+    def test_invalid_scaling_is_rejected(self):
+        fractional_power = DeviceCommand("output", output_limit_w=1.5, should_write_mode=False, should_write_input=False, should_write_output=True)
+        with self.assertRaisesRegex(ValueError, "invalid_power_value"):
+            map_cloud_command(envelope(fractional_power), self.data, first_message_id=1, timestamp=1)
+
+    def test_execute_records_publish_then_fresh_readback(self):
+        publisher = Publisher()
+        verification = NativeCommandVerificationManager()
+        now = datetime(2026, 9, 4, 16, 0, tzinfo=timezone.utc)
+        adapter = ZendureCloudCommandAdapter(self.data, publisher, verification, clock=lambda: now)
+        command = DeviceCommand("output", output_limit_w=77, should_write_mode=False, should_write_input=False, should_write_output=True)
+        result = adapter.execute(envelope(command))
+        self.assertEqual(result.status, CloudCommandStatus.SENT)
+        self.assertEqual(result.writes_sent, 1)
+        tracked = verification.get(result.verification_ids[0])
+        self.assertEqual(tracked.status, CommandVerificationStatus.TRANSPORT_OK)
+        self.assertEqual(adapter.observe_properties(device_id="cloud_mqtt:main-1", properties={"outputLimit": 77}, observed_at=now + timedelta(seconds=1)), 1)
+        self.assertEqual(tracked.status, CommandVerificationStatus.READBACK_CONFIRMED)
+
+    def test_newer_same_target_supersedes_old_and_publish_failure_stops(self):
+        publisher = Publisher(result=True)
+        verification = NativeCommandVerificationManager()
+        adapter = ZendureCloudCommandAdapter(self.data, publisher, verification)
+        def command(value):
+            return envelope(DeviceCommand("output", output_limit_w=value, should_write_mode=False, should_write_input=False, should_write_output=True))
+        first = adapter.execute(command(10))
+        second = adapter.execute(command(20))
+        self.assertEqual(verification.get(first.verification_ids[0]).status, CommandVerificationStatus.SUPERSEDED)
+        self.assertEqual(verification.get(second.verification_ids[0]).status, CommandVerificationStatus.TRANSPORT_OK)
+        failed_adapter = ZendureCloudCommandAdapter(self.data, Publisher(False), NativeCommandVerificationManager())
+        failed = failed_adapter.execute(command(30))
+        self.assertEqual(failed.status, CloudCommandStatus.TRANSPORT_ERROR)
+        self.assertEqual(failed.writes_sent, 0)
+
+    def test_diagnostics_contain_no_route_or_credentials(self):
+        verification = NativeCommandVerificationManager()
+        adapter = ZendureCloudCommandAdapter(self.data, Publisher(), verification)
+        result = adapter.execute(envelope(DeviceCommand("output", output_limit_w=1, should_write_mode=False, should_write_input=False, should_write_output=True)))
+        text = repr(verification.diagnostics()) + repr(result)
+        for secret in ("main-1", "serial-1", "product-a", "client-secret", "user-secret", "pass-secret"):
+            self.assertNotIn(secret, text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_zendure_device_matrix.py
+++ b/tests/test_zendure_device_matrix.py
@@ -89,7 +89,7 @@ class ZendureDeviceMatrixTests(unittest.TestCase):
         )
         self.assertNotEqual(runtime_report["inputLimit"], hardware_limit)
 
-    def test_only_sf2400ac_zensdk_output_limit_is_approved(self):
+    def test_cloud_and_zensdk_write_evidence_remain_separate(self):
         approved = ZENDURE_DEVICE_MATRIX["SF2400AC"]
         self.assertTrue(approved.native_control_approved)
         self.assertIs(
@@ -102,16 +102,24 @@ class ZendureDeviceMatrixTests(unittest.TestCase):
         )
         self.assertIs(
             approved.transport(ZendureTransport.CLOUD_MQTT).write,
-            VerificationLevel.REFERENCE_ONLY,
+            VerificationLevel.VERIFIED,
         )
         for key, entry in ZENDURE_DEVICE_MATRIX.items():
-            if key == "SF2400AC":
-                continue
             with self.subTest(profile=key):
-                self.assertFalse(entry.native_control_approved)
-                self.assertNotIn(
+                self.assertTrue(entry.native_control_approved)
+                self.assertIs(
+                    entry.property_write_level(
+                        ZendureTransport.CLOUD_MQTT, "outputLimit"
+                    ),
                     VerificationLevel.VERIFIED,
-                    entry.writable_main_properties.values(),
+                )
+                self.assertIs(
+                    entry.property_write_level(
+                        ZendureTransport.ZENSDK, "outputLimit"
+                    ),
+                    VerificationLevel.VERIFIED
+                    if key == "SF2400AC"
+                    else VerificationLevel.REFERENCE_ONLY,
                 )
 
     def test_transports_remain_separate_evidence_domains(self):
@@ -132,15 +140,15 @@ class ZendureDeviceMatrixTests(unittest.TestCase):
     def test_pack_observation_does_not_enable_main_system_control(self):
         entry = ZENDURE_DEVICE_MATRIX["SF2400Pro"]
         self.assertIn("soc_pct", entry.neutral_pack_targets)
-        self.assertFalse(entry.native_control_approved)
+        self.assertNotIn("socLevel", entry.writable_main_properties)
 
-    def test_gate_can_model_future_approval_without_approving_production(self):
-        approved = replace(
+    def test_profile_approval_can_still_be_revoked_fail_closed(self):
+        blocked = replace(
             ZENDURE_DEVICE_MATRIX["SF800Pro"],
-            native_control_approved=True,
+            native_control_approved=False,
         )
-        self.assertTrue(approved.native_control_approved)
-        self.assertFalse(ZENDURE_DEVICE_MATRIX["SF800Pro"].native_control_approved)
+        self.assertFalse(blocked.native_control_approved)
+        self.assertTrue(ZENDURE_DEVICE_MATRIX["SF800Pro"].native_control_approved)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- map gate-authorized device commands to explicit Zendure Cloud MQTT properties/write messages
- keep model/property authorization transport-specific so Cloud approval cannot widen ZenSDK or Local MQTT writes
- correlate every property write with the common readback verification lifecycle and serialize command execution
- document the confirmed topic, payload, units, ordering, privacy boundary, and intentionally inactive PowerController integration

## Safety
- no arbitrary topic or property publish API
- exact main-device identity only; packs, unknown models, wrong transports, and unapproved properties fail closed
- one publish attempt per property, no retry and no transport/device fallback
- no productive PowerController wiring and no real device write in this change
- version remains 5.0.0.dev14

## Validation
- py -3.12 -m unittest discover -s tests -v (538 tests)
- py -3.12 -m compileall -q custom_components tests
- manifest JSON validation
- git diff --check

Closes #335