### PR TITLE
Fix native Zendure start and regulation commands

### DIFF
--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -38,7 +38,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "5.0.0.dev16"
+INTEGRATION_VERSION = "5.0.0.dev17"
 
 # V5 native Zendure discovery is observation-only in the first development
 # build. The App Token is account discovery material and must never be copied

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": ["paho-mqtt==2.1.0"],
-  "version": "5.0.0.dev16"
+  "version": "5.0.0.dev17"
 }

--- a/custom_components/battery_smartflow_ai/native_zendure_runtime.py
+++ b/custom_components/battery_smartflow_ai/native_zendure_runtime.py
@@ -704,16 +704,30 @@ def _skip_matching_writes(command: DeviceCommand, state: Any) -> DeviceCommand:
     )
     input_value = state.setpoints.input_limit_w
     output_value = state.setpoints.output_limit_w
+    charge_power = state.charge_power_w
+    discharge_power = state.discharge_power_w
+    input_is_inactive = bool(
+        float(command.input_limit_w) > 0
+        and charge_power.valid
+        and float(charge_power.value) <= 0
+    )
+    output_is_inactive = bool(
+        float(command.output_limit_w) > 0
+        and discharge_power.valid
+        and float(discharge_power.value) <= 0
+    )
     return replace(
         command,
         metadata=dict(command.metadata),
         should_write_mode=command.should_write_mode and not mode_matches,
         should_write_input=(command.should_write_input and not (
-            input_value.valid
+            not input_is_inactive
+            and input_value.valid
             and float(input_value.value) == float(command.input_limit_w)
         )),
         should_write_output=(command.should_write_output and not (
-            output_value.valid
+            not output_is_inactive
+            and output_value.valid
             and float(output_value.value) == float(command.output_limit_w)
         )),
     )

--- a/custom_components/battery_smartflow_ai/zendure_cloud_mqtt.py
+++ b/custom_components/battery_smartflow_ai/zendure_cloud_mqtt.py
@@ -109,11 +109,11 @@ class CloudMqttSession(Protocol):
         timestamp: int,
     ) -> None: ...
 
-    def write_property(
+    def write_properties(
         self,
         product_id: str,
         device_id: str,
-        write: CloudPropertyWrite,
+        writes: tuple[CloudPropertyWrite, ...],
     ) -> bool: ...
 
     def disconnect(self) -> None: ...
@@ -506,20 +506,27 @@ def _parse_payload(payload: bytes) -> tuple[Any, str]:
 def _property_write_request(
     product_id: str,
     device_id: str,
-    write: CloudPropertyWrite,
+    writes: tuple[CloudPropertyWrite, ...],
 ) -> tuple[str, str]:
-    """Build the one allow-listed Zendure Cloud property-write envelope."""
+    """Build one atomic allow-listed Zendure Cloud property-write envelope."""
 
-    if not product_id or not device_id or not write.property_name:
+    if (
+        not product_id
+        or not device_id
+        or not writes
+        or any(not write.property_name for write in writes)
+    ):
         raise CloudMqttError("invalid_write_address")
     return (
         f"iot/{product_id}/{device_id}/properties/write",
         json.dumps(
             {
-                "properties": {write.property_name: write.value},
-                "messageId": write.message_id,
+                "properties": {
+                    write.property_name: write.value for write in writes
+                },
+                "messageId": writes[0].message_id,
                 "deviceId": device_id,
-                "timestamp": write.timestamp,
+                "timestamp": writes[0].timestamp,
             },
             separators=(",", ":"),
         ),
@@ -657,13 +664,13 @@ class PahoReadOnlyMqttSession:
         if result_code != 0:
             raise CloudMqttError("state_request_failed")
 
-    def write_property(
+    def write_properties(
         self,
         product_id: str,
         device_id: str,
-        write: CloudPropertyWrite,
+        writes: tuple[CloudPropertyWrite, ...],
     ) -> bool:
-        topic, payload = _property_write_request(product_id, device_id, write)
+        topic, payload = _property_write_request(product_id, device_id, writes)
         result = self._client.publish(topic, payload, qos=0, retain=False)
         result_code = getattr(result, "rc", None)
         if result_code is None:

--- a/custom_components/battery_smartflow_ai/zendure_cloud_mqtt_commands.py
+++ b/custom_components/battery_smartflow_ai/zendure_cloud_mqtt_commands.py
@@ -42,7 +42,12 @@ class CloudCommandResult:
 
 
 class CloudPropertyPublisher(Protocol):
-    def write_property(self, product_id: str, device_id: str, write: CloudPropertyWrite) -> bool: ...
+    def write_properties(
+        self,
+        product_id: str,
+        device_id: str,
+        writes: tuple[CloudPropertyWrite, ...],
+    ) -> bool: ...
 
 
 _MODE_VALUES = {"input": 1, "output": 2}
@@ -75,14 +80,33 @@ def map_cloud_command(
 
     command = authorized.command
     requested: list[tuple[str, int]] = []
-    if command.should_write_mode:
+    directional_write = any((
+        command.should_write_mode,
+        command.should_write_input,
+        command.should_write_output,
+    ))
+    if directional_write:
         if command.ac_mode not in _MODE_VALUES:
             raise ValueError("unsupported_mode")
-        requested.append(("acMode", _MODE_VALUES[command.ac_mode]))
-    if command.should_write_input:
-        requested.append(("inputLimit", _whole_watts(command.input_limit_w)))
-    if command.should_write_output:
-        requested.append(("outputLimit", _whole_watts(command.output_limit_w)))
+        input_limit = (
+            _whole_watts(command.input_limit_w)
+            if command.ac_mode == "input"
+            else 0
+        )
+        output_limit = (
+            _whole_watts(command.output_limit_w)
+            if command.ac_mode == "output"
+            else 0
+        )
+        active_limit = input_limit if command.ac_mode == "input" else output_limit
+        # Zendure directional control is one complete command. A bare limit
+        # write can update the stored setpoint without starting Smart Mode.
+        requested.extend((
+            ("smartMode", 1 if active_limit > 0 else 0),
+            ("acMode", _MODE_VALUES[command.ac_mode]),
+            ("outputLimit", output_limit),
+            ("inputLimit", input_limit),
+        ))
     if command.should_write_min_soc:
         requested.append(("minSoc", _soc_tenths(command.min_soc_pct)))
     if command.should_write_max_soc:
@@ -123,7 +147,7 @@ class ZendureCloudCommandAdapter:
             return CloudCommandResult(CloudCommandStatus.REJECTED, str(error))
         self._message_id += len(writes)
         verification_ids: list[str] = []
-        sent = 0
+        prepared: list[tuple[CloudPropertyWrite, str]] = []
         for write in writes:
             verification = self._verification.prepare(
                 device_id=authorized.device_id, command_type=write.property_name,
@@ -135,18 +159,25 @@ class ZendureCloudCommandAdapter:
             verification_ids.append(verification.command_id)
             self._verification.gate(verification.command_id, accepted=True, at=now)
             self._verification.sent(verification.command_id, at=now)
-            try:
-                ok = self._publisher.write_property(product_id, device_id, write)
-            except Exception:
-                ok = False
+            prepared.append((write, verification.command_id))
+        try:
+            ok = self._publisher.write_properties(product_id, device_id, writes)
+        except Exception:
+            ok = False
+        for _write, command_id in prepared:
             self._verification.transport_result(
-                verification.command_id, ok=ok,
+                command_id, ok=ok,
                 status="mqtt_publish_accepted" if ok else "mqtt_publish_failed",
                 at=self._clock(),
             )
-            if not ok:
-                return CloudCommandResult(CloudCommandStatus.TRANSPORT_ERROR, "publish_failed", tuple(verification_ids), sent)
-            sent += 1
+        if not ok:
+            return CloudCommandResult(
+                CloudCommandStatus.TRANSPORT_ERROR,
+                "publish_failed",
+                tuple(verification_ids),
+                0,
+            )
+        sent = len(writes)
         return CloudCommandResult(CloudCommandStatus.SENT, "awaiting_readback", tuple(verification_ids), sent)
 
     def observe_properties(self, *, device_id: str, properties: Mapping[str, object], observed_at: datetime) -> int:

--- a/custom_components/battery_smartflow_ai/zendure_device_matrix.py
+++ b/custom_components/battery_smartflow_ai/zendure_device_matrix.py
@@ -120,6 +120,7 @@ _COMMON_MAIN_READS = frozenset(
         "inverseMaxPower",
         "minSoc",
         "socSet",
+        "smartMode",
         "hemsState",
         "faultLevel",
         "heatState",
@@ -145,6 +146,7 @@ _COMMON_PACK_READS = frozenset(
     }
 )
 _REFERENCE_WRITES = {
+    "smartMode": VerificationLevel.REFERENCE_ONLY,
     "acMode": VerificationLevel.REFERENCE_ONLY,
     "inputLimit": VerificationLevel.REFERENCE_ONLY,
     "outputLimit": VerificationLevel.REFERENCE_ONLY,

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -13,7 +13,7 @@ COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
 
 
 class DebugIntegrationContractTests(unittest.TestCase):
-    def test_manifest_and_runtime_version_match_v5_dev16_release(self) -> None:
+    def test_manifest_and_runtime_version_match_v5_dev17_release(self) -> None:
         manifest_version = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )["version"]
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "5.0.0.dev16")
+        self.assertEqual(manifest_version, "5.0.0.dev17")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_native_power_controller.py
+++ b/tests/test_native_power_controller.py
@@ -49,11 +49,13 @@ def measured(value):
     return MeasuredValue.available(value, observed_at=NOW)
 
 
-def state(*, input_w=0, output_w=0, hems=False):
+def state(*, input_w=0, output_w=0, charge_w=0, discharge_w=0, hems=False):
     return SimpleNamespace(
         online=measured(True),
         protection_active=measured(False),
         hems_active=measured(hems),
+        charge_power_w=measured(charge_w),
+        discharge_power_w=measured(discharge_w),
         mode=measured(DeviceOperatingMode.DISCHARGE),
         setpoints=ReportedDeviceSetpoints(
             measured(input_w), measured(output_w), measured(2400),
@@ -132,7 +134,7 @@ class NativePowerControllerTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(stop_target._transport.commands[-1].command.output_limit_w, 0)
 
     async def test_no_change_never_writes(self):
-        target = runtime(current_state=state(output_w=250))
+        target = runtime(current_state=state(output_w=250, discharge_w=250))
         result = await target.async_execute_device_command(DeviceCommand(
             "output", output_limit_w=250, should_write_mode=True,
             should_write_input=False, should_write_output=True,
@@ -140,6 +142,16 @@ class NativePowerControllerTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result.status, CommandExecutionStatus.SKIPPED)
         self.assertEqual(result.reason, "native_setpoints_unchanged")
         self.assertEqual(target._transport.commands, [])
+
+    async def test_matching_stored_limit_restarts_inactive_direction(self):
+        target = runtime(current_state=state(output_w=250, discharge_w=0))
+        result = await target.async_execute_device_command(DeviceCommand(
+            "output", output_limit_w=250, should_write_mode=True,
+            should_write_input=False, should_write_output=True,
+        ))
+        self.assertEqual(result.status, CommandExecutionStatus.APPLIED)
+        command = target._transport.commands[-1].command
+        self.assertTrue(command.should_write_output)
 
     async def test_profile_limit_is_clamped_only_by_central_gate(self):
         target = runtime()

--- a/tests/test_native_zendure_ha_integration.py
+++ b/tests/test_native_zendure_ha_integration.py
@@ -13,11 +13,11 @@ COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
 
 
 class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
-    def test_dev16_version_and_mqtt_dependency_are_packaged(self) -> None:
+    def test_dev17_version_and_mqtt_dependency_are_packaged(self) -> None:
         manifest = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )
-        self.assertEqual(manifest["version"], "5.0.0.dev16")
+        self.assertEqual(manifest["version"], "5.0.0.dev17")
         self.assertIn("paho-mqtt==2.1.0", manifest["requirements"])
 
     def test_options_flow_uses_a_password_field_and_never_suggests_token(self) -> None:

--- a/tests/test_zendure_cloud_mqtt.py
+++ b/tests/test_zendure_cloud_mqtt.py
@@ -57,8 +57,8 @@ class FakeSession:
     def subscribe(self, topics): self.subscriptions = topics
     def request_all(self, product_id, device_id, message_id, timestamp):
         self.state_requests.append((product_id, device_id, message_id, timestamp))
-    def write_property(self, product_id, device_id, write):
-        self.property_writes.append((product_id, device_id, write))
+    def write_properties(self, product_id, device_id, writes):
+        self.property_writes.append((product_id, device_id, writes))
         return True
     def disconnect(self): self.disconnected = True
     def emit(self, topic, payload): self.on_message(topic, payload)
@@ -356,11 +356,23 @@ class CloudMqttTransportTests(unittest.IsolatedAsyncioTestCase):
 
     def test_typed_property_write_has_confirmed_topic_and_envelope(self):
         topic, payload = _property_write_request(
-            "product-a", "main-1", CloudPropertyWrite("outputLimit", 0, 8, 1788444001)
+            "product-a",
+            "main-1",
+            (
+                CloudPropertyWrite("smartMode", 1, 8, 1788444001),
+                CloudPropertyWrite("acMode", 2, 9, 1788444001),
+                CloudPropertyWrite("outputLimit", 500, 10, 1788444001),
+                CloudPropertyWrite("inputLimit", 0, 11, 1788444001),
+            ),
         )
         self.assertEqual(topic, "iot/product-a/main-1/properties/write")
         self.assertEqual(json.loads(payload), {
-            "properties": {"outputLimit": 0}, "messageId": 8,
+            "properties": {
+                "smartMode": 1,
+                "acMode": 2,
+                "outputLimit": 500,
+                "inputLimit": 0,
+            }, "messageId": 8,
             "deviceId": "main-1", "timestamp": 1788444001,
         })
 

--- a/tests/test_zendure_cloud_mqtt_commands.py
+++ b/tests/test_zendure_cloud_mqtt_commands.py
@@ -44,8 +44,8 @@ class Publisher:
     def __init__(self, result=True):
         self.result = result
         self.calls = []
-    def write_property(self, product_id, device_id, write):
-        self.calls.append((product_id, device_id, write))
+    def write_properties(self, product_id, device_id, writes):
+        self.calls.append((product_id, device_id, writes))
         return self.result
 
 
@@ -68,7 +68,7 @@ class CloudCommandMappingTests(unittest.TestCase):
         self.assertEqual((product, device), ("product-a", "main-1"))
         self.assertEqual(
             [(item.property_name, item.value, item.message_id) for item in writes],
-            [("acMode", 1, 4), ("inputLimit", 123, 5), ("outputLimit", 0, 6), ("minSoc", 105, 7), ("socSet", 930, 8)],
+            [("smartMode", 1, 4), ("acMode", 1, 5), ("outputLimit", 0, 6), ("inputLimit", 123, 7), ("minSoc", 105, 8), ("socSet", 930, 9)],
         )
 
     def test_output_mode_and_valid_zero_are_preserved(self):
@@ -77,7 +77,20 @@ class CloudCommandMappingTests(unittest.TestCase):
             should_write_input=False, should_write_output=True,
         )
         *_, writes = map_cloud_command(envelope(command), self.data, first_message_id=1, timestamp=1)
-        self.assertEqual([(item.property_name, item.value) for item in writes], [("acMode", 2), ("outputLimit", 0)])
+        self.assertEqual([(item.property_name, item.value) for item in writes], [("smartMode", 0), ("acMode", 2), ("outputLimit", 0), ("inputLimit", 0)])
+
+    def test_active_output_is_complete_directional_command(self):
+        command = DeviceCommand(
+            "output", output_limit_w=351, should_write_mode=False,
+            should_write_input=False, should_write_output=True,
+        )
+        *_, writes = map_cloud_command(
+            envelope(command), self.data, first_message_id=1, timestamp=1
+        )
+        self.assertEqual(
+            [(item.property_name, item.value) for item in writes],
+            [("smartMode", 1), ("acMode", 2), ("outputLimit", 351), ("inputLimit", 0)],
+        )
 
     def test_wrong_transport_device_pack_or_model_never_maps(self):
         command = DeviceCommand("output", should_write_mode=False, should_write_input=False, should_write_output=True)
@@ -105,11 +118,12 @@ class CloudCommandMappingTests(unittest.TestCase):
         command = DeviceCommand("output", output_limit_w=77, should_write_mode=False, should_write_input=False, should_write_output=True)
         result = adapter.execute(envelope(command))
         self.assertEqual(result.status, CloudCommandStatus.SENT)
-        self.assertEqual(result.writes_sent, 1)
-        tracked = verification.get(result.verification_ids[0])
+        self.assertEqual(result.writes_sent, 4)
+        tracked = verification.get(result.verification_ids[2])
         self.assertEqual(tracked.status, CommandVerificationStatus.TRANSPORT_OK)
         self.assertEqual(adapter.observe_properties(device_id="cloud_mqtt:main-1", properties={"outputLimit": 77}, observed_at=now + timedelta(seconds=1)), 1)
         self.assertEqual(tracked.status, CommandVerificationStatus.READBACK_CONFIRMED)
+        self.assertEqual(len(publisher.calls), 1)
 
     def test_newer_same_target_supersedes_old_and_publish_failure_stops(self):
         publisher = Publisher(result=True)


### PR DESCRIPTION
## Summary

- publish native Zendure directional control as one atomic properties/write command
- include smartMode, acMode, active setpoint, and cleared opposite setpoint
- resend matching stored limits when measured power proves the direction is inactive
- bump the prerelease version to 5.0.0.dev17

## Field diagnosis

Dev16 received fresh native data and selected the native output path, but it emitted no effective start command. Z-HA immediately started the same price-based discharge. Returning to native control then left the last Z-HA value frozen. The Zendure-HA reference implementation shows that directional control requires the complete four-property command, including smartMode.

## Validation

- 64 focused tests pass across native command mapping, MQTT transport, native runtime, command gate, device matrix, version, and HA integration contracts
- Python compileall passes
- git diff --check passes
- broad unittest discovery runs 553 tests; the only three local loader errors are optional pytest-based modules because pytest is unavailable in the bundled runtime

Closes #408