### PR TITLE
Recover native start from stale Z-HA setpoint

### DIFF
--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -38,7 +38,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "5.0.0.dev17"
+INTEGRATION_VERSION = "5.0.0.dev18"
 
 # V5 native Zendure discovery is observation-only in the first development
 # build. The App Token is account discovery material and must never be copied

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": ["paho-mqtt==2.1.0"],
-  "version": "5.0.0.dev17"
+  "version": "5.0.0.dev18"
 }

--- a/custom_components/battery_smartflow_ai/native_zendure_runtime.py
+++ b/custom_components/battery_smartflow_ai/native_zendure_runtime.py
@@ -115,6 +115,7 @@ class NativeZendureRuntime:
         self._write_lock = asyncio.Lock()
         self._write_sequence = 0
         self._command_verification = NativeCommandVerificationManager()
+        self._last_command_result: dict[str, Any] | None = None
 
     @property
     def configured(self) -> bool:
@@ -263,6 +264,7 @@ class NativeZendureRuntime:
                     self._transport.command_diagnostics
                     if self._transport is not None else {"commands": []}
                 ),
+                "last_command_result": self._last_command_result,
                 "overview": self.overview_attributes(),
             }
         )
@@ -365,7 +367,9 @@ class NativeZendureRuntime:
         """Route one neutral PowerController command through the native stack."""
 
         if not self._control_enabled:
-            return _command_result(CommandExecutionStatus.SKIPPED, "native_control_disabled")
+            return self._remember_command_result(_command_result(
+                CommandExecutionStatus.SKIPPED, "native_control_disabled"
+            ))
         async with self._write_lock:
             if (
                 self._status != STATUS_OBSERVING
@@ -373,17 +377,23 @@ class NativeZendureRuntime:
                 or self._transport.state is not ConnectionState.CONNECTED
                 or self._selected_device is None
             ):
-                return _command_result(CommandExecutionStatus.SKIPPED, "native_transport_not_ready")
+                return self._remember_command_result(_command_result(
+                    CommandExecutionStatus.SKIPPED, "native_transport_not_ready"
+                ))
             state = self._states.get(self._selected_device)
             source_device = self._inventory.devices.get(self._selected_device)
             if state is None or source_device is None or not _fresh_native_state(state):
-                return _command_result(CommandExecutionStatus.SKIPPED, "native_state_not_fresh")
+                return self._remember_command_result(_command_result(
+                    CommandExecutionStatus.SKIPPED, "native_state_not_fresh"
+                ))
             cloud_identities = tuple(
                 identity for identity in source_device.native_identities
                 if identity.transport is ZendureTransport.CLOUD_MQTT
             )
             if len(cloud_identities) != 1:
-                return _command_result(CommandExecutionStatus.SKIPPED, "native_identity_not_unique")
+                return self._remember_command_result(_command_result(
+                    CommandExecutionStatus.SKIPPED, "native_identity_not_unique"
+                ))
             active_device = replace(
                 source_device,
                 control_state=DeviceControlState.ACTIVE,
@@ -393,7 +403,9 @@ class NativeZendureRuntime:
             )
             final_command = _skip_matching_writes(command, state)
             if not _has_writes(final_command):
-                return _command_result(CommandExecutionStatus.SKIPPED, "native_setpoints_unchanged")
+                return self._remember_command_result(_command_result(
+                    CommandExecutionStatus.SKIPPED, "native_setpoints_unchanged"
+                ))
             request = NativeCommandRequest(
                 self._selected_device, ZendureTransport.CLOUD_MQTT, final_command
             )
@@ -408,19 +420,36 @@ class NativeZendureRuntime:
                 request, context, self._transport.async_execute_authorized
             )
             if not gate.accepted or transport is None:
-                return _command_result(
+                return self._remember_command_result(_command_result(
                     CommandExecutionStatus.SKIPPED,
                     ",".join(gate.reasons) or "native_gate_blocked",
-                )
+                ))
             if transport.status is not CloudCommandStatus.SENT:
-                return _command_result(CommandExecutionStatus.FAILED, transport.reason)
-            return CommandExecutionResult(
+                return self._remember_command_result(_command_result(
+                    CommandExecutionStatus.FAILED, transport.reason
+                ))
+            return self._remember_command_result(CommandExecutionResult(
                 status=CommandExecutionStatus.APPLIED,
                 reason=transport.reason,
                 mode_written=final_command.should_write_mode,
                 input_written=final_command.should_write_input,
                 output_written=final_command.should_write_output,
-            )
+            ))
+
+    def _remember_command_result(
+        self, result: CommandExecutionResult
+    ) -> CommandExecutionResult:
+        """Keep one privacy-safe dispatch outcome for field diagnostics."""
+
+        self._last_command_result = {
+            "status": str(result.status),
+            "reason": str(result.reason),
+            "mode_written": bool(result.mode_written),
+            "input_written": bool(result.input_written),
+            "output_written": bool(result.output_written),
+            "recorded_at": datetime.now(timezone.utc),
+        }
+        return result
 
     async def _async_run(self) -> None:
         try:
@@ -716,20 +745,49 @@ def _skip_matching_writes(command: DeviceCommand, state: Any) -> DeviceCommand:
         and discharge_power.valid
         and float(discharge_power.value) <= 0
     )
-    return replace(
-        command,
-        metadata=dict(command.metadata),
-        should_write_mode=command.should_write_mode and not mode_matches,
-        should_write_input=(command.should_write_input and not (
+    force_input_write = bool(
+        command.ac_mode == "input"
+        and float(command.input_limit_w) > 0
+        and input_is_inactive
+    )
+    force_output_write = bool(
+        command.ac_mode == "output"
+        and float(command.output_limit_w) > 0
+        and output_is_inactive
+    )
+    should_write_input = force_input_write or (
+        command.should_write_input and not (
             not input_is_inactive
             and input_value.valid
             and float(input_value.value) == float(command.input_limit_w)
-        )),
-        should_write_output=(command.should_write_output and not (
+        )
+    )
+    should_write_output = force_output_write or (
+        command.should_write_output and not (
             not output_is_inactive
             and output_value.valid
             and float(output_value.value) == float(command.output_limit_w)
+        )
+    )
+    should_write_mode = command.should_write_mode and not mode_matches
+    return replace(
+        command,
+        metadata=dict(command.metadata),
+        should_write_mode=should_write_mode,
+        should_write_input=should_write_input,
+        should_write_output=should_write_output,
+        skipped=not any((
+            should_write_mode,
+            should_write_input,
+            should_write_output,
+            command.should_write_min_soc,
+            command.should_write_max_soc,
         )),
+        skip_reason=(
+            "none"
+            if any((should_write_mode, should_write_input, should_write_output))
+            else command.skip_reason
+        ),
     )
 
 

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -13,7 +13,7 @@ COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
 
 
 class DebugIntegrationContractTests(unittest.TestCase):
-    def test_manifest_and_runtime_version_match_v5_dev17_release(self) -> None:
+    def test_manifest_and_runtime_version_match_v5_dev18_release(self) -> None:
         manifest_version = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )["version"]
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "5.0.0.dev17")
+        self.assertEqual(manifest_version, "5.0.0.dev18")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_native_power_controller.py
+++ b/tests/test_native_power_controller.py
@@ -56,6 +56,9 @@ def state(*, input_w=0, output_w=0, charge_w=0, discharge_w=0, hems=False):
         hems_active=measured(hems),
         charge_power_w=measured(charge_w),
         discharge_power_w=measured(discharge_w),
+        last_message_at=NOW,
+        packs=(),
+        observed_transport=ZendureTransport.ZENSDK,
         mode=measured(DeviceOperatingMode.DISCHARGE),
         setpoints=ReportedDeviceSetpoints(
             measured(input_w), measured(output_w), measured(2400),
@@ -146,12 +149,26 @@ class NativePowerControllerTests(unittest.IsolatedAsyncioTestCase):
     async def test_matching_stored_limit_restarts_inactive_direction(self):
         target = runtime(current_state=state(output_w=250, discharge_w=0))
         result = await target.async_execute_device_command(DeviceCommand(
-            "output", output_limit_w=250, should_write_mode=True,
-            should_write_input=False, should_write_output=True,
+            "output", output_limit_w=250, should_write_mode=False,
+            should_write_input=False, should_write_output=False,
+            skipped=True, skip_reason="unchanged_within_tolerance",
         ))
         self.assertEqual(result.status, CommandExecutionStatus.APPLIED)
         command = target._transport.commands[-1].command
         self.assertTrue(command.should_write_output)
+        self.assertFalse(command.skipped)
+
+    async def test_last_dispatch_reason_is_visible_without_identity(self):
+        target = runtime(current_state=state(output_w=250, discharge_w=250))
+        await target.async_execute_device_command(DeviceCommand(
+            "output", output_limit_w=250, should_write_mode=False,
+            should_write_input=False, should_write_output=False,
+            skipped=True, skip_reason="unchanged_within_tolerance",
+        ))
+        diagnostic = target.diagnostic_data()["last_command_result"]
+        self.assertEqual(diagnostic["status"], "skipped")
+        self.assertEqual(diagnostic["reason"], "native_setpoints_unchanged")
+        self.assertNotIn(DEVICE, repr(diagnostic))
 
     async def test_profile_limit_is_clamped_only_by_central_gate(self):
         target = runtime()

--- a/tests/test_native_zendure_ha_integration.py
+++ b/tests/test_native_zendure_ha_integration.py
@@ -13,11 +13,11 @@ COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
 
 
 class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
-    def test_dev17_version_and_mqtt_dependency_are_packaged(self) -> None:
+    def test_dev18_version_and_mqtt_dependency_are_packaged(self) -> None:
         manifest = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )
-        self.assertEqual(manifest["version"], "5.0.0.dev17")
+        self.assertEqual(manifest["version"], "5.0.0.dev18")
         self.assertIn("paho-mqtt==2.1.0", manifest["requirements"])
 
     def test_options_flow_uses_a_password_field_and_never_suggests_token(self) -> None:


### PR DESCRIPTION
## Summary

- recover a native start command when the central builder skips because a stale Z-HA setpoint matches the requested value but measured native power is zero
- clear the inherited skipped marker when native state proves a restart is required
- expose the latest privacy-safe native dispatch status and reason in integration diagnostics
- bump the prerelease version to 5.0.0.dev18

## Live Dev17 evidence

- native path enabled and fresh
- HEMS initially blocked as unknown for the intentional 60-second confirmation window, then became inactive
- house load rose from 803 W to 1197 W while output remained at the last Z-HA value of 790 W
- native command and verification lists remained empty

The original Dev17 regression test still supplied should_write_output=True and therefore did not reproduce the preceding builder skip. The new test starts with should_write_output=False and skipped=True, while native state reports requested output 250 W but measured discharge 0 W. The runtime now recovers the command and clears skipped.

## Validation

- native controller regression tests pass, including realistic stale-Z-HA start and diagnostic reason cases
- Cloud MQTT mapping, MQTT transport, command gate, HA integration, and version contract suites pass
- compileall and git diff --check pass

Closes #408