### PR TITLE
Keep confirmed HEMS state eligible for native control

### DIFF
--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -38,7 +38,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "5.0.0.dev18"
+INTEGRATION_VERSION = "5.0.0.dev19"
 
 # V5 native Zendure discovery is observation-only in the first development
 # build. The App Token is account discovery material and must never be copied

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": ["paho-mqtt==2.1.0"],
-  "version": "5.0.0.dev18"
+  "version": "5.0.0.dev19"
 }

--- a/custom_components/battery_smartflow_ai/native_zendure_runtime.py
+++ b/custom_components/battery_smartflow_ai/native_zendure_runtime.py
@@ -715,8 +715,17 @@ def _value(measured: Any) -> str | None:
 
 
 def _fresh_native_state(state: Any, *, maximum_age_seconds: float = 30.0) -> bool:
+    """Require fresh device safety data; HEMS freshness has its own gate.
+
+    The HEMS activity fallback deliberately keeps the timestamp of the last
+    observed activity.  Once its quiet confirmation window has elapsed that
+    timestamp may therefore be older than this generic state window while the
+    dedicated HEMS command gate still has an explicit, safe decision.  Requiring
+    it here as well would permanently suppress otherwise safe commands.
+    """
+
     now = datetime.now(timezone.utc)
-    required = (state.online, state.protection_active, state.hems_active)
+    required = (state.online, state.protection_active)
     return all(
         item.valid
         and item.observed_at is not None

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -13,7 +13,7 @@ COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
 
 
 class DebugIntegrationContractTests(unittest.TestCase):
-    def test_manifest_and_runtime_version_match_v5_dev18_release(self) -> None:
+    def test_manifest_and_runtime_version_match_v5_dev19_release(self) -> None:
         manifest_version = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )["version"]
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "5.0.0.dev18")
+        self.assertEqual(manifest_version, "5.0.0.dev19")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_native_power_controller.py
+++ b/tests/test_native_power_controller.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 import sys
 from types import ModuleType
 from types import SimpleNamespace
@@ -157,6 +157,45 @@ class NativePowerControllerTests(unittest.IsolatedAsyncioTestCase):
         command = target._transport.commands[-1].command
         self.assertTrue(command.should_write_output)
         self.assertFalse(command.skipped)
+
+    async def test_confirmed_inactive_hems_remains_usable_after_quiet_window(self):
+        current = state(output_w=250, discharge_w=0)
+        current.hems_active = MeasuredValue.available(
+            False, observed_at=NOW - timedelta(minutes=5)
+        )
+        target = runtime(current_state=current)
+
+        result = await target.async_execute_device_command(DeviceCommand(
+            "output", output_limit_w=250, should_write_mode=False,
+            should_write_input=False, should_write_output=False,
+            skipped=True, skip_reason="unchanged_within_tolerance",
+        ))
+
+        self.assertEqual(result.status, CommandExecutionStatus.APPLIED)
+        self.assertEqual(len(target._transport.commands), 1)
+
+    async def test_stale_online_or_protection_state_still_blocks_commands(self):
+        for field in ("online", "protection_active"):
+            with self.subTest(field=field):
+                current = state(output_w=250, discharge_w=0)
+                setattr(
+                    current,
+                    field,
+                    MeasuredValue.available(
+                        field == "online",
+                        observed_at=NOW - timedelta(minutes=5),
+                    ),
+                )
+                target = runtime(current_state=current)
+
+                result = await target.async_execute_device_command(DeviceCommand(
+                    "output", output_limit_w=250, should_write_mode=False,
+                    should_write_input=False, should_write_output=True,
+                ))
+
+                self.assertEqual(result.status, CommandExecutionStatus.SKIPPED)
+                self.assertEqual(result.reason, "native_state_not_fresh")
+                self.assertEqual(target._transport.commands, [])
 
     async def test_last_dispatch_reason_is_visible_without_identity(self):
         target = runtime(current_state=state(output_w=250, discharge_w=250))

--- a/tests/test_native_zendure_ha_integration.py
+++ b/tests/test_native_zendure_ha_integration.py
@@ -13,11 +13,11 @@ COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
 
 
 class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
-    def test_dev18_version_and_mqtt_dependency_are_packaged(self) -> None:
+    def test_dev19_version_and_mqtt_dependency_are_packaged(self) -> None:
         manifest = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )
-        self.assertEqual(manifest["version"], "5.0.0.dev18")
+        self.assertEqual(manifest["version"], "5.0.0.dev19")
         self.assertIn("paho-mqtt==2.1.0", manifest["requirements"])
 
     def test_options_flow_uses_a_password_field_and_never_suggests_token(self) -> None:


### PR DESCRIPTION
## Summary

- stop the generic 30-second state freshness gate from expiring an already confirmed inactive HEMS decision
- keep online and protection freshness checks unchanged and fail-closed
- continue to enforce HEMS through the dedicated per-device command gate immediately before transport writes
- add field-regression coverage for the real quiet-window timeline and safety counter-tests
- bump the development version to 5.0.0.dev19

## Field evidence

Dev18 diagnostics showed fresh ZenSDK data, an online device, inactive and non-blocking HEMS, but every native command was skipped with native_state_not_fresh. The HEMS activity timestamp intentionally records the observation start or last activity and therefore exceeded the unrelated 30-second generic freshness window after its 60-second quiet confirmation.

## Validation

- native power controller regression suite: 9 passed
- full unittest discovery: 557 passed; 3 collection-only errors because pytest is not installed in the local bundled runtime
- compileall: passed
- git diff --check: passed

Closes #408