### PR TITLE
Validate ZenSDK read identity before device updates

### DIFF
--- a/custom_components/battery_smartflow_ai/zendure_zensdk.py
+++ b/custom_components/battery_smartflow_ai/zendure_zensdk.py
@@ -149,6 +149,7 @@ async def async_read_zensdk_reports(
                 get_json,
                 timeout,
                 now,
+                identity.serial_number,
             )
         )
     if not tasks:
@@ -166,14 +167,18 @@ async def _read_device(
     get_json: GetJson,
     timeout: float,
     clock: Callable[[], datetime],
+    expected_serial: str | None,
 ) -> tuple[tuple[CloudMqttMessage, ...], tuple[ZenSdkReadAttempt, ...]]:
     attempts: list[ZenSdkReadAttempt] = []
+    if not expected_serial:
+        return (), (ZenSdkReadAttempt(candidate_id, "none", "identity_missing"),)
     if not addresses:
         return (), (ZenSdkReadAttempt(candidate_id, "none", "no_local_address"),)
     for source, host in addresses:
         try:
             response = await asyncio.wait_for(
-                get_json(f"http://{host}{ZENSDK_REPORT_PATH}"), timeout=timeout
+                get_json(f"http://{host}{ZENSDK_REPORT_PATH}", allow_redirects=False),
+                timeout=timeout,
             )
             status = int(response.status)
             if status != 200:
@@ -182,10 +187,27 @@ async def _read_device(
                 )
                 continue
             payload = await asyncio.wait_for(response.json(), timeout=timeout)
-            if not isinstance(payload, Mapping):
+            if (
+                not isinstance(payload, Mapping)
+                or not isinstance(payload.get("properties"), Mapping)
+                or ("packData" in payload and (
+                    not isinstance(payload["packData"], list)
+                    or any(not isinstance(pack, Mapping) for pack in payload["packData"])
+                ))
+            ):
                 attempts.append(
                     ZenSdkReadAttempt(candidate_id, source, "invalid_response", status)
                 )
+                continue
+            # An IP may have been reassigned to another main system. Only the
+            # main report serial establishes identity; pack serials cannot do so.
+            report_serial = payload.get("sn")
+            if not isinstance(report_serial, str) or report_serial != expected_serial:
+                attempts.append(ZenSdkReadAttempt(
+                    candidate_id, source,
+                    "identity_missing" if not report_serial else "identity_mismatch",
+                    status,
+                ))
                 continue
             encoded = json.dumps(payload, separators=(",", ":")).encode("utf-8")
             attempts.append(ZenSdkReadAttempt(candidate_id, source, "success", status))

--- a/docs/architecture/zendure-zensdk-read-v5.0.0.md
+++ b/docs/architecture/zendure-zensdk-read-v5.0.0.md
@@ -1,0 +1,50 @@
+# ZenSDK read identity: issue #340
+
+Status: first hardening step, not completion of #340 or productive ZenSDK control.
+
+The current reader uses the Cloud-discovered main-device serial and local address
+to request `GET /properties/report`. A response must contain the same top-level
+`sn` and a `properties` object. Optional `packData` must be a list of objects.
+Pack serials never establish the identity of the main device.
+
+The SF2400AC field report from 2026-09-04 contains this top-level serial and
+report structure. The pinned Zendure-HA reference at
+`e71b0b83be2e5909fbaf1cd931ad6a530a2be234`, `device.py`, documents the existing
+derived hostname and `/properties/report` request. Hardware/model coverage
+beyond that capture still needs verification.
+
+If an address now belongs to another device, the response is discarded and the
+reader may try the serial-derived local hostname. Missing identity, mismatched
+identity and malformed reports cannot refresh normalized state or mark the device
+recovered. HTTP redirects are not followed. Diagnostic attempts retain only the
+candidate identifier (redacted on export), address-source label, status and safe
+reason; they do not include the received serial or address.
+
+The same candidate ID is retained across Cloud discovery and ZenSDK reports.
+Multiple devices, including identical models in reversed discovery order, are
+resolved independently. Zero remains a valid measurement. Unknown fields and
+pack metadata inside valid reports remain available to the existing normalizer
+and privacy-filtered capture.
+
+## Remaining work
+
+- Complete transport-specific mapping, availability, timing and reconnect/backoff
+  coverage for #340, including model evidence for the requested ZenSDK family.
+- Verify exact API model names/profile mappings for 800 Pro and Pro 2 separately.
+- Keep ZenSDK read, write and readback together when explicitly selected in
+  #341/#342; implement the complete authorized command adapter and selection.
+- Preserve one selected control owner and the existing per-device HEMS blocker.
+  The current activity-based HEMS evidence is separate from local telemetry.
+- Keep #408 open until real start, regulation and stop are confirmed on hardware.
+
+This change does not expand the existing reversible `outputLimit` write probe,
+enable productive ZenSDK writes, change transport selection or create a release.
+
+## Dev19 evidence limits
+
+The recorded Cloud commands timed out without readback. A later command failed
+with `invalid_power_value`; the current mapping rejects fractional watt values.
+These are separate observations requiring follow-up. MQTT publish acceptance is
+not device confirmation. The `enable: false` field and missing readback alone do
+not prove Cloud control is unsupported. Identity correlation in verification
+must also be checked before treating missing readback as a transport diagnosis.

--- a/tests/test_zendure_zensdk.py
+++ b/tests/test_zendure_zensdk.py
@@ -8,6 +8,7 @@ import sys
 from types import SimpleNamespace
 from types import ModuleType
 import unittest
+from dataclasses import replace
 
 from support import bootstrap as bootstrap_test_environment
 
@@ -138,6 +139,7 @@ class ZenSdkReadTests(unittest.IsolatedAsyncioTestCase):
         data = await make_bootstrap()
         requested = []
         payload = {
+            "sn": "serial-real-1",
             "properties": {"electricLevel": 73},
             "packData": [{"sn": "pack-real-1", "socLevel": 72}],
         }
@@ -173,7 +175,7 @@ class ZenSdkReadTests(unittest.IsolatedAsyncioTestCase):
             requested.append(url)
             if "192.168.1.44" in url:
                 raise OSError("unreachable")
-            return Response({"properties": {"electricLevel": 50}})
+            return Response({"sn": "serial-real-1", "properties": {"electricLevel": 50}})
 
         result = await async_read_zensdk_reports(data, get)
 
@@ -193,7 +195,7 @@ class ZenSdkReadTests(unittest.IsolatedAsyncioTestCase):
 
         async def get(url, **_kwargs):
             requested.append(url)
-            return Response({"properties": {}})
+            return Response({"sn": "serial-real-1", "properties": {}})
 
         await async_read_zensdk_reports(data, get)
 
@@ -210,6 +212,97 @@ class ZenSdkReadTests(unittest.IsolatedAsyncioTestCase):
             ),
             (),
         )
+
+    async def test_reassigned_ip_is_rejected_and_hostname_recovers_exact_device(self):
+        data = await make_bootstrap()
+
+        async def get(url, **kwargs):
+            self.assertFalse(kwargs["allow_redirects"])
+            serial = "other-main" if "192.168.1.44" in url else "serial-real-1"
+            return Response({"sn": serial, "properties": {"electricLevel": 0}})
+
+        result = await async_read_zensdk_reports(data, get)
+        self.assertEqual([a.result for a in result.attempts], ["identity_mismatch", "success"])
+        self.assertEqual(len(result.messages), 1)
+        self.assertEqual(result.messages[0].device_candidate_id, "cloud_mqtt:device-real-1")
+        state = ZendureCloudNormalizer(data).apply(result.messages[0]).state
+        self.assertEqual(state.soc_pct.value, 0)
+        self.assertTrue(state.soc_pct.valid)
+
+    async def test_unidentified_and_malformed_reports_do_not_update_state(self):
+        data = await make_bootstrap()
+        cases = (
+            ({"properties": {}, "packData": [{"sn": "serial-real-1"}]}, "identity_missing"),
+            ({"sn": "wrong-device", "properties": {}}, "identity_mismatch"),
+            ({"sn": "serial-real-1"}, "invalid_response"),
+            ({"sn": "serial-real-1", "properties": []}, "invalid_response"),
+            ({"sn": "serial-real-1", "properties": {}, "packData": [None]}, "invalid_response"),
+            ({"sn": "serial-real-1", "properties": {}, "packData": {}}, "invalid_response"),
+        )
+        for payload, reason in cases:
+            with self.subTest(reason=reason, payload=payload):
+                async def get(_url, **_kwargs):
+                    return Response(payload)
+
+                result = await async_read_zensdk_reports(data, get)
+                self.assertEqual(result.messages, ())
+                self.assertEqual({a.result for a in result.attempts}, {reason})
+                self.assertNotIn("serial-real-1", repr(result.attempts))
+                self.assertNotIn("wrong-device", repr(result.attempts))
+
+    async def test_missing_bootstrap_identity_makes_no_network_request(self):
+        data = await make_bootstrap()
+        device = data.devices[0]
+        device = replace(device, candidate=replace(
+            device.candidate, identity=replace(device.candidate.identity, serial_number=None)
+        ))
+        data = replace(data, devices=(device,))
+
+        async def get(*_args, **_kwargs):
+            self.fail("Missing identity must block the request")
+
+        result = await async_read_zensdk_reports(data, get)
+        self.assertEqual(result.messages, ())
+        self.assertEqual(result.attempts[0].result, "identity_missing")
+
+    async def test_multiple_identical_models_keep_states_and_packs_separate(self):
+        data = await make_bootstrap()
+        first = data.devices[0]
+        second = replace(first, candidate=replace(
+            first.candidate,
+            identity=replace(first.candidate.identity, device_id="device-real-2", serial_number="serial-real-2"),
+        ))
+        data = replace(data, devices=(second, first), raw_device_list=(
+            *data.raw_device_list,
+            {**data.raw_device_list[0], "deviceKey": "device-real-2", "snNumber": "serial-real-2", "ip": "192.168.1.45"},
+        ))
+
+        async def get(url, **_kwargs):
+            index = 2 if "192.168.1.45" in url else 1
+            return Response({
+                "sn": f"serial-real-{index}",
+                "properties": {"electricLevel": index * 20},
+                "packData": [{"sn": f"pack-{index}", "socLevel": index * 20}],
+            })
+
+        result = await async_read_zensdk_reports(data, get)
+        normalizer = ZendureCloudNormalizer(data)
+        states = {m.device_candidate_id: normalizer.apply(m).state for m in result.messages}
+        self.assertEqual(len(states), 2)
+        self.assertEqual(states["cloud_mqtt:device-real-1"].soc_pct.value, 20)
+        self.assertEqual(states["cloud_mqtt:device-real-2"].soc_pct.value, 40)
+        self.assertNotEqual(states["cloud_mqtt:device-real-1"].packs, states["cloud_mqtt:device-real-2"].packs)
+
+    async def test_http_redirect_is_not_accepted_as_a_report(self):
+        data = await make_bootstrap()
+
+        async def get(_url, **kwargs):
+            self.assertFalse(kwargs["allow_redirects"])
+            return Response({}, status=302)
+
+        result = await async_read_zensdk_reports(data, get)
+        self.assertEqual(result.messages, ())
+        self.assertEqual({a.result for a in result.attempts}, {"http_error"})
 
     async def test_runtime_marks_offline_after_three_failures_and_recovers_read_only(self):
         data = await make_bootstrap()
@@ -248,7 +341,7 @@ class ZenSdkReadTests(unittest.IsolatedAsyncioTestCase):
         )
 
         async def get(_url, **_kwargs):
-            return Response({"properties": {"electricLevel": 81}})
+            return Response({"sn": "serial-real-1", "properties": {"electricLevel": 81}})
 
         success = await async_read_zensdk_reports(data, get)
         runtime._record_zensdk_cycle(success)


### PR DESCRIPTION
ZenSDK reports were assigned to the device whose address was queried without checking the responding main-device identity. After an IP reassignment, another system's telemetry could therefore update the wrong BSFAI device.

Require the expected top-level serial and a valid report structure before normalization. Reject mismatched or unidentified reports, allow read-only recovery via the existing serial-derived hostname, and disable HTTP redirects. Keep valid zero values, unknown report properties and independent pack data intact.

This is the first read-only hardening step for #340. It does not complete #340, enable productive ZenSDK writes or close #408. No version bump or release is included. Remaining transport/mapping work and the limits of the Dev19 diagnosis are documented in `docs/architecture/zendure-zensdk-read-v5.0.0.md`.

Validation: 624 pytest tests and 407 subtests passed locally (Python 3.12); 13 focused ZenSDK tests passed. Coverage includes reassigned IP, missing/mismatched serial, malformed reports, redirect rejection, multiple identical models, zero values and existing offline/recovery behavior.

Compatibility: reports without a matching top-level main-device serial are now rejected, including models whose report identity has not yet been verified. The captured SF2400AC report supplies this field. Other model schemas need explicit evidence rather than an address-only fallback.

Refs #340, #408.
