### PR TITLE
Track ZenSDK availability independently of merged telemetry

### DIFF
--- a/custom_components/battery_smartflow_ai/native_zendure_runtime.py
+++ b/custom_components/battery_smartflow_ai/native_zendure_runtime.py
@@ -65,6 +65,7 @@ STATUS_OBSERVING = "observing"
 STATUS_ERROR = "error"
 ZENSDK_POLL_INTERVAL = 5.0
 ZENSDK_OFFLINE_AFTER_FAILURES = 3
+ZENSDK_MAX_DATA_AGE = 30.0
 
 
 @dataclass(slots=True)
@@ -572,11 +573,13 @@ class NativeZendureRuntime:
         self._apply_messages(result.messages)
 
     def _record_zensdk_cycle(self, result: ZenSdkReadResult) -> None:
-        successful = {
-            message.device_candidate_id
-            for message in result.messages
-            if message.device_candidate_id is not None
-        }
+        successful: dict[str, datetime] = {}
+        for message in result.messages:
+            device_id = message.device_candidate_id
+            if device_id is not None and message.transport == "zensdk":
+                successful[device_id] = max(
+                    successful.get(device_id, message.received_at), message.received_at
+                )
         attempted = {item.device_candidate_id for item in result.attempts}
         last_results = {
             candidate_id: next(
@@ -586,12 +589,11 @@ class NativeZendureRuntime:
             )
             for candidate_id in attempted
         }
-        observed_at = datetime.now(timezone.utc)
         for candidate_id in attempted:
             self._zensdk_last_result[candidate_id] = last_results[candidate_id]
             if candidate_id in successful:
                 self._zensdk_failures[candidate_id] = 0
-                self._zensdk_last_success[candidate_id] = observed_at
+                self._zensdk_last_success[candidate_id] = successful[candidate_id]
                 if self._normalizer is not None:
                     self._normalizer.set_online(candidate_id, True)
                 if candidate_id in self._inventory.devices:
@@ -640,16 +642,41 @@ class NativeZendureRuntime:
             ),
         }
 
-    def _zensdk_diagnostics(self) -> list[dict[str, Any]]:
+    def _zensdk_diagnostics(self, *, now: datetime | None = None) -> list[dict[str, Any]]:
+        """Report local transport health independently of merged device state."""
+        current = now or datetime.now(timezone.utc)
         return [
             {
                 "device_id": candidate_id,
                 "last_result": self._zensdk_last_result.get(candidate_id),
                 "consecutive_failures": self._zensdk_failures.get(candidate_id, 0),
                 "last_success": self._zensdk_last_success.get(candidate_id),
+                **self._zensdk_health(candidate_id, current),
             }
             for candidate_id in sorted(self._zensdk_last_result)
         ]
+
+    def _zensdk_health(self, candidate_id: str, now: datetime) -> dict[str, Any]:
+        last = self._zensdk_last_success.get(candidate_id)
+        age = (now - last).total_seconds() if last is not None else None
+        failures = self._zensdk_failures.get(candidate_id, 0)
+        if failures >= ZENSDK_OFFLINE_AFTER_FAILURES:
+            status = "offline"
+        elif age is None:
+            status = "unknown"
+        elif age < 0 or age > ZENSDK_MAX_DATA_AGE:
+            status = "stale"
+        elif failures:
+            status = "degraded"
+        else:
+            status = "available"
+        return {
+            "transport": "zensdk",
+            "availability": status,
+            "available": status == "available",
+            "data_age_seconds": round(age, 3) if age is not None else None,
+            "maximum_data_age_seconds": ZENSDK_MAX_DATA_AGE,
+        }
 
     def _apply_messages(self, messages: tuple[Any, ...]) -> None:
         if self._normalizer is None:

--- a/docs/architecture/zendure-zensdk-read-v5.0.0.md
+++ b/docs/architecture/zendure-zensdk-read-v5.0.0.md
@@ -28,6 +28,17 @@ and privacy-filtered capture.
 
 ## Remaining work
 
+Local transport diagnostics now derive availability exclusively from ZenSDK
+reports and local failures, independently of merged device telemetry. They expose
+the report receive timestamp, its age, a 30-second freshness ceiling and the
+states `unknown`, `available`, `degraded`, `stale`, and `offline`. A failed read
+makes availability false immediately (`degraded` with still-recent data); three
+consecutive failures mean `offline`. Without new reports, even a previously
+successful reader becomes `stale`. Future timestamps fail closed. Recovery
+requires a new identity-validated local report. Cloud messages cannot refresh
+this timestamp. The existing combined device state and productive Cloud writer
+are unchanged; #341/#342 must consume this separate health state for local writes.
+
 - Complete transport-specific mapping, availability, timing and reconnect/backoff
   coverage for #340, including model evidence for the requested ZenSDK family.
 - Verify exact API model names/profile mappings for 800 Pro and Pro 2 separately.

--- a/tests/test_zendure_zensdk.py
+++ b/tests/test_zendure_zensdk.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from base64 import b64encode
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 import sys
 from types import SimpleNamespace
 from types import ModuleType
@@ -362,6 +362,63 @@ class ZenSdkReadTests(unittest.IsolatedAsyncioTestCase):
             runtime._states[candidate_id].observed_transport,
             ZendureTransport.ZENSDK,
         )
+
+    async def test_local_health_ages_without_failures_and_cloud_cannot_refresh_it(self):
+        data = await make_bootstrap()
+        device = data.devices[0].candidate.candidate_id
+        now = datetime(2026, 9, 5, tzinfo=timezone.utc)
+        target = NativeZendureRuntime(SimpleNamespace(), app_token="configured",
+                                     selected_device=None, notify=lambda: None)
+
+        async def get(*_args, **_kwargs):
+            return Response({"sn": "serial-real-1", "properties": {"electricLevel": 0}})
+
+        result = await async_read_zensdk_reports(data, get, clock=lambda: now)
+        target._record_zensdk_cycle(result)
+        healthy = target._zensdk_diagnostics(now=now)[0]
+        self.assertEqual(healthy["availability"], "available")
+        self.assertEqual(healthy["data_age_seconds"], 0)
+        self.assertTrue(target._zensdk_diagnostics(now=now + timedelta(seconds=30))[0]["available"])
+        stale = target._zensdk_diagnostics(now=now + timedelta(seconds=31))[0]
+        self.assertEqual(stale["availability"], "stale")
+        self.assertFalse(stale["available"])
+        self.assertEqual(target._zensdk_diagnostics(now=now - timedelta(seconds=1))[0]["availability"], "stale")
+
+        # A Cloud report cannot count as a successful local read, even if
+        # submitted to the cycle recorder for the same logical main device.
+        cloud = replace(result.messages[0], transport="cloud_mqtt", received_at=now + timedelta(seconds=40))
+        target._record_zensdk_cycle(ZenSdkReadResult((cloud,), result.attempts))
+        self.assertEqual(target._zensdk_last_success[device], now)
+        self.assertFalse(target._zensdk_diagnostics(now=now + timedelta(seconds=40))[0]["available"])
+
+    async def test_local_health_failure_and_recovery_are_per_device(self):
+        data = await make_bootstrap()
+        device = data.devices[0].candidate.candidate_id
+        now = datetime(2026, 9, 5, tzinfo=timezone.utc)
+        target = NativeZendureRuntime(SimpleNamespace(), app_token="configured",
+                                     selected_device=None, notify=lambda: None)
+        failure = ZenSdkReadResult((), (ZenSdkReadAttempt(device, "device_list_ip", "timeout"),))
+        target._record_zensdk_cycle(failure)
+        self.assertEqual(target._zensdk_diagnostics(now=now)[0]["availability"], "unknown")
+
+        async def get(*_args, **_kwargs):
+            return Response({"sn": "serial-real-1", "properties": {}})
+
+        success = await async_read_zensdk_reports(data, get, clock=lambda: now)
+        target._record_zensdk_cycle(success)
+        target._zensdk_last_success["another-device"] = now
+        target._zensdk_last_result["another-device"] = "success"
+        target._record_zensdk_cycle(failure)
+        by_id = {item["device_id"]: item for item in target._zensdk_diagnostics(now=now)}
+        self.assertEqual(by_id[device]["availability"], "degraded")
+        self.assertFalse(by_id[device]["available"])
+        self.assertTrue(by_id["another-device"]["available"])
+        target._record_zensdk_cycle(failure)
+        target._record_zensdk_cycle(failure)
+        self.assertEqual(target._zensdk_health(device, now)["availability"], "offline")
+        target._record_zensdk_cycle(success)
+        self.assertTrue(target._zensdk_health(device, now)["available"])
+        self.assertEqual(target._zensdk_failures[device], 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The current merged device state cannot reliably describe ZenSDK transport health when other data sources keep updating the device. Expose local availability using only the last successful ZenSDK report timestamp and consecutive local read failures.

Diagnostics now distinguish unknown, available, degraded, stale and offline. Reports age out after 30 seconds even if no failure callback arrives; future timestamps are unavailable. A failed local read immediately removes availability and three consecutive failures mark it offline. A fresh identity-validated report restores local health. Cloud reports cannot refresh the local timestamp.

This is a preparatory step for #340. Existing combined state and productive Cloud dispatch remain unchanged. The future ZenSDK writer in #341/#342 must use this separate health state. No version bump or release; #340 and #408 remain open.

Validation: 626 tests and 407 subtests passed with pytest on Python 3.12. New tests cover aging without callbacks, future timestamps, Cloud isolation, failure/recovery and per-device independence. Diff whitespace check passed.

Refs #340, #408.
