### PR TITLE
Back off failed ZenSDK polling per device

### DIFF
--- a/custom_components/battery_smartflow_ai/native_zendure_runtime.py
+++ b/custom_components/battery_smartflow_ai/native_zendure_runtime.py
@@ -66,6 +66,7 @@ STATUS_ERROR = "error"
 ZENSDK_POLL_INTERVAL = 5.0
 ZENSDK_OFFLINE_AFTER_FAILURES = 3
 ZENSDK_MAX_DATA_AGE = 30.0
+ZENSDK_MAX_RETRY_INTERVAL = 60.0
 
 
 @dataclass(slots=True)
@@ -111,6 +112,8 @@ class NativeZendureRuntime:
         self._zensdk_failures: dict[str, int] = {}
         self._zensdk_last_result: dict[str, str] = {}
         self._zensdk_last_success: dict[str, datetime] = {}
+        self._zensdk_next_poll: dict[str, float] = {}
+        self._zensdk_poll_delay: dict[str, float] = {}
         self._hems_gate = ZendureHemsCommandGate()
         self._first_write_result: NativeWriteVerification | None = None
         self._write_lock = asyncio.Lock()
@@ -498,15 +501,11 @@ class NativeZendureRuntime:
                 self._set_status(STATUS_ERROR)
                 return
             self._set_status(STATUS_OBSERVING)
-            next_zensdk_poll = (
-                asyncio.get_running_loop().time() + ZENSDK_POLL_INTERVAL
-            )
+            self._initialize_zensdk_schedule(asyncio.get_running_loop().time())
             while True:
                 self._consume_messages()
                 loop = asyncio.get_running_loop()
-                if loop.time() >= next_zensdk_poll:
-                    await self._async_poll_zensdk()
-                    next_zensdk_poll = loop.time() + ZENSDK_POLL_INTERVAL
+                await self._async_poll_zensdk(now_monotonic=loop.time())
                 self._refresh_snapshots()
                 self._notify()
                 await asyncio.sleep(1.0)
@@ -562,15 +561,53 @@ class NativeZendureRuntime:
         if cloud_messages:
             self._last_processed_message = cloud_messages[-1]
 
-    async def _async_poll_zensdk(self) -> None:
+    async def _async_poll_zensdk(self, *, now_monotonic: float | None = None) -> None:
         if self._bootstrap is None:
+            return
+        current = (
+            asyncio.get_running_loop().time()
+            if now_monotonic is None else now_monotonic
+        )
+        due = self._due_zensdk_devices(current)
+        if not due:
             return
         result = await async_read_zensdk_reports(
             self._bootstrap,
             self._get_json,
+            candidate_ids=frozenset(due),
         )
         self._record_zensdk_cycle(result)
         self._apply_messages(result.messages)
+        for candidate_id in due:
+            self._schedule_zensdk_poll(candidate_id, current)
+
+    def _initialize_zensdk_schedule(self, now_monotonic: float) -> None:
+        """Schedule every supported local device independently."""
+
+        for candidate_id in self._zensdk_last_result:
+            self._schedule_zensdk_poll(candidate_id, now_monotonic)
+
+    def _schedule_zensdk_poll(
+        self, candidate_id: str, now_monotonic: float
+    ) -> None:
+        failures = self._zensdk_failures.get(candidate_id, 0)
+        delay = (
+            ZENSDK_POLL_INTERVAL
+            if failures == 0
+            else min(
+                ZENSDK_MAX_RETRY_INTERVAL,
+                ZENSDK_POLL_INTERVAL * (2 ** min(failures, 4)),
+            )
+        )
+        self._zensdk_poll_delay[candidate_id] = delay
+        self._zensdk_next_poll[candidate_id] = now_monotonic + delay
+
+    def _due_zensdk_devices(self, now_monotonic: float) -> tuple[str, ...]:
+        return tuple(
+            candidate_id
+            for candidate_id, due_at in sorted(self._zensdk_next_poll.items())
+            if now_monotonic >= due_at
+        )
 
     def _record_zensdk_cycle(self, result: ZenSdkReadResult) -> None:
         successful: dict[str, datetime] = {}
@@ -651,6 +688,8 @@ class NativeZendureRuntime:
                 "last_result": self._zensdk_last_result.get(candidate_id),
                 "consecutive_failures": self._zensdk_failures.get(candidate_id, 0),
                 "last_success": self._zensdk_last_success.get(candidate_id),
+                "poll_delay_seconds": self._zensdk_poll_delay.get(candidate_id),
+                "retry_interval_cap_seconds": ZENSDK_MAX_RETRY_INTERVAL,
                 **self._zensdk_health(candidate_id, current),
             }
             for candidate_id in sorted(self._zensdk_last_result)

--- a/custom_components/battery_smartflow_ai/zendure_zensdk.py
+++ b/custom_components/battery_smartflow_ai/zendure_zensdk.py
@@ -116,6 +116,7 @@ async def async_read_zensdk_reports(
     *,
     timeout: float = DEFAULT_ZENSDK_TIMEOUT,
     clock: Callable[[], datetime] | None = None,
+    candidate_ids: frozenset[str] | None = None,
 ) -> ZenSdkReadResult:
     """Read one local report per supported device without exposing a write API."""
 
@@ -129,6 +130,9 @@ async def async_read_zensdk_reports(
     }
     tasks = []
     for device in bootstrap.devices:
+        candidate_id = device.candidate.candidate_id
+        if candidate_ids is not None and candidate_id not in candidate_ids:
+            continue
         identity = device.candidate.identity
         matrix = resolve_zendure_device(identity)
         if (
@@ -144,7 +148,7 @@ async def async_read_zensdk_reports(
         )
         tasks.append(
             _read_device(
-                device.candidate.candidate_id,
+                candidate_id,
                 addresses,
                 get_json,
                 timeout,

--- a/docs/architecture/zendure-zensdk-read-v5.0.0.md
+++ b/docs/architecture/zendure-zensdk-read-v5.0.0.md
@@ -59,3 +59,13 @@ These are separate observations requiring follow-up. MQTT publish acceptance is
 not device confirmation. The `enable: false` field and missing readback alone do
 not prove Cloud control is unsupported. Identity correlation in verification
 must also be checked before treating missing readback as a transport diagnosis.
+
+## Poll and retry schedule
+
+Scheduling is per device. A successful reader is polled every five seconds.
+Consecutive failed cycles use 10, 20, 40 and then at most 60 seconds. A healthy
+device keeps its own five-second schedule while another device is backed off.
+Every retry still evaluates the Cloud-discovered local address followed by the
+serial-derived hostname, with report identity validation at both addresses. A
+valid recovered report resets the failure counter and restores the five-second
+schedule. There is no automatic transport fallback or replay of old commands.

--- a/tests/test_native_zendure_ha_integration.py
+++ b/tests/test_native_zendure_ha_integration.py
@@ -53,8 +53,11 @@ class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
         ).read_text(encoding="utf-8"))
         self.assertNotIn("def publish", mqtt)
         self.assertIn("self._consume_captured_messages(capture.messages)", runtime)
-        self.assertIn("await self._async_poll_zensdk()", runtime)
+        self.assertIn(
+            "await self._async_poll_zensdk(now_monotonic=loop.time())", runtime
+        )
         self.assertIn("ZENSDK_POLL_INTERVAL = 5.0", runtime)
+        self.assertIn("ZENSDK_MAX_RETRY_INTERVAL = 60.0", runtime)
 
     def test_secret_is_not_exposed_by_sensor_or_diagnostic_surfaces(self) -> None:
         runtime = (COMPONENT / "native_zendure_runtime.py").read_text(

--- a/tests/test_zendure_zensdk.py
+++ b/tests/test_zendure_zensdk.py
@@ -293,6 +293,24 @@ class ZenSdkReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(states["cloud_mqtt:device-real-2"].soc_pct.value, 40)
         self.assertNotEqual(states["cloud_mqtt:device-real-1"].packs, states["cloud_mqtt:device-real-2"].packs)
 
+        requested = []
+
+        async def selected_get(url, **kwargs):
+            requested.append(url)
+            return await get(url, **kwargs)
+
+        selected = await async_read_zensdk_reports(
+            data,
+            selected_get,
+            candidate_ids=frozenset({"cloud_mqtt:device-real-2"}),
+        )
+        self.assertEqual(len(requested), 1)
+        self.assertIn("192.168.1.45", requested[0])
+        self.assertEqual(
+            {message.device_candidate_id for message in selected.messages},
+            {"cloud_mqtt:device-real-2"},
+        )
+
     async def test_http_redirect_is_not_accepted_as_a_report(self):
         data = await make_bootstrap()
 
@@ -419,6 +437,31 @@ class ZenSdkReadTests(unittest.IsolatedAsyncioTestCase):
         target._record_zensdk_cycle(success)
         self.assertTrue(target._zensdk_health(device, now)["available"])
         self.assertEqual(target._zensdk_failures[device], 0)
+
+    def test_poll_backoff_is_bounded_and_independent_per_device(self):
+        target = NativeZendureRuntime(SimpleNamespace(), app_token="configured",
+                                     selected_device=None, notify=lambda: None)
+        target._zensdk_last_result = {"healthy": "success", "failing": "timeout"}
+        target._zensdk_failures = {"healthy": 0, "failing": 1}
+
+        target._initialize_zensdk_schedule(100.0)
+        self.assertEqual(target._zensdk_poll_delay["healthy"], 5.0)
+        self.assertEqual(target._zensdk_poll_delay["failing"], 10.0)
+        self.assertEqual(target._due_zensdk_devices(104.999), ())
+        self.assertEqual(target._due_zensdk_devices(105.0), ("healthy",))
+        self.assertEqual(
+            target._due_zensdk_devices(110.0), ("failing", "healthy")
+        )
+
+        target._zensdk_failures["failing"] = 2
+        target._schedule_zensdk_poll("failing", 110.0)
+        self.assertEqual(target._zensdk_poll_delay["failing"], 20.0)
+        target._zensdk_failures["failing"] = 100
+        target._schedule_zensdk_poll("failing", 130.0)
+        self.assertEqual(target._zensdk_poll_delay["failing"], 60.0)
+        target._zensdk_failures["failing"] = 0
+        target._schedule_zensdk_poll("failing", 190.0)
+        self.assertEqual(target._zensdk_poll_delay["failing"], 5.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- schedule ZenSDK polling independently for every supported device
- back off consecutive failed reads to 10, 20, 40, and at most 60 seconds
- keep healthy devices on the normal five-second interval and reset recovered devices immediately
- expose the active poll delay in native diagnostics and document the behavior

## Validation

- `python -m pytest tests -q --tb=short`
- 627 passed, 407 subtests passed
- `git diff --check`

This is another read-side foundation step for #340. It does not enable automatic transport fallback, command replay, or normal native control, and it does not close #340 or #408.
