### PR TITLE
Add typed ZenSDK command adapter

### DIFF
--- a/custom_components/battery_smartflow_ai/zendure_zensdk_commands.py
+++ b/custom_components/battery_smartflow_ai/zendure_zensdk_commands.py
@@ -1,0 +1,255 @@
+"""Typed, fail-closed ZenSDK command mapping for Zendure devices."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import StrEnum
+from typing import Callable, Mapping
+
+from .core.models import ZendureTransport
+from .native_command_verification import (
+    NativeCommandVerificationManager,
+    ReadbackPolicy,
+)
+from .native_device_command_gate import AuthorizedNativeCommand
+from .zendure_cloud import ZendureCloudBootstrap
+from .zendure_device_matrix import VerificationLevel, resolve_zendure_device
+from .zendure_zensdk import GetJson, async_write_zensdk_property
+
+
+class ZenSdkCommandStatus(StrEnum):
+    """Result of the HTTP transport step, not device confirmation."""
+
+    SENT = "sent"
+    REJECTED = "rejected"
+    TRANSPORT_ERROR = "transport_error"
+
+
+@dataclass(frozen=True, slots=True)
+class ZenSdkPropertyWrite:
+    """One allow-listed low-level write plus its readback contract."""
+
+    property_name: str
+    value: int
+    request_id: int
+    readback_tolerance: float = 0.0
+
+
+@dataclass(frozen=True, slots=True)
+class ZenSdkCommandResult:
+    """Privacy-safe command result retained while readback is pending."""
+
+    status: ZenSdkCommandStatus
+    reason: str
+    verification_ids: tuple[str, ...] = ()
+    writes_sent: int = 0
+    http_status: int | None = None
+
+
+def map_zensdk_command(
+    authorized: AuthorizedNativeCommand,
+    bootstrap: ZendureCloudBootstrap,
+    *,
+    first_request_id: int,
+) -> tuple[ZenSdkPropertyWrite, ...]:
+    """Map only gate-authorized and transport-verified properties."""
+
+    if not isinstance(authorized, AuthorizedNativeCommand):
+        raise ValueError("gate_authorization_required")
+    if authorized.transport is not ZendureTransport.ZENSDK:
+        raise ValueError("wrong_transport")
+    device = next(
+        (
+            item
+            for item in bootstrap.devices
+            if item.candidate.candidate_id == authorized.device_id
+        ),
+        None,
+    )
+    if device is None:
+        raise ValueError("device_not_found")
+    matrix = resolve_zendure_device(device.candidate.identity)
+    if matrix is None or not matrix.native_control_approved:
+        raise ValueError("model_not_approved")
+    if (
+        matrix.transport(ZendureTransport.ZENSDK).write
+        is not VerificationLevel.VERIFIED
+    ):
+        raise ValueError("transport_not_approved")
+
+    command = authorized.command
+    requested: list[tuple[str, int]] = []
+    if command.should_write_mode:
+        requested.append(("acMode", 1 if command.ac_mode == "input" else 2))
+    if command.should_write_input:
+        requested.append(("inputLimit", _whole_watts(command.input_limit_w)))
+    if command.should_write_output:
+        requested.append(("outputLimit", _whole_watts(command.output_limit_w)))
+    if command.should_write_min_soc:
+        requested.append(("minSoc", _soc_tenths(command.min_soc_pct)))
+    if command.should_write_max_soc:
+        requested.append(("socSet", _soc_tenths(command.max_soc_pct)))
+    if not requested:
+        raise ValueError("empty_command")
+
+    writes = []
+    for offset, (property_name, value) in enumerate(requested):
+        if (
+            matrix.property_write_level(ZendureTransport.ZENSDK, property_name)
+            is not VerificationLevel.VERIFIED
+        ):
+            raise ValueError(f"property_not_approved:{property_name}")
+        writes.append(
+            ZenSdkPropertyWrite(
+                property_name=property_name,
+                value=value,
+                request_id=first_request_id + offset,
+            )
+        )
+    return tuple(writes)
+
+
+class ZendureZenSdkCommandAdapter:
+    """Send typed ZenSDK writes once and correlate fresh readback reports."""
+
+    def __init__(
+        self,
+        bootstrap: ZendureCloudBootstrap,
+        post_json: GetJson,
+        verification: NativeCommandVerificationManager,
+        *,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._bootstrap = bootstrap
+        self._post_json = post_json
+        self._verification = verification
+        self._clock = clock or (lambda: datetime.now(timezone.utc))
+        self._request_id = 0
+
+    async def execute(
+        self, authorized: AuthorizedNativeCommand
+    ) -> ZenSdkCommandResult:
+        """POST each approved property once; never retry or fall back."""
+
+        now = self._clock()
+        try:
+            writes = map_zensdk_command(
+                authorized,
+                self._bootstrap,
+                first_request_id=self._request_id + 1,
+            )
+        except ValueError as error:
+            return ZenSdkCommandResult(ZenSdkCommandStatus.REJECTED, str(error))
+
+        prepared: list[tuple[ZenSdkPropertyWrite, str]] = []
+        for write in writes:
+            verification = self._verification.prepare(
+                device_id=authorized.device_id,
+                command_type=write.property_name,
+                target_key=write.property_name,
+                transport=ZendureTransport.ZENSDK,
+                requested_value=write.value,
+                final_value=write.value,
+                readback=ReadbackPolicy(
+                    write.property_name,
+                    write.value,
+                    write.readback_tolerance,
+                ),
+                prepared_at=now,
+                max_attempts=1,
+            )
+            self._verification.gate(
+                verification.command_id, accepted=True, at=now
+            )
+            prepared.append((write, verification.command_id))
+
+        sent_count = 0
+        last_http_status: int | None = None
+        for write, command_id in prepared:
+            self._verification.sent(command_id, at=self._clock())
+            # The id belongs to an attempted request, even when its response is
+            # an error or ambiguous timeout. Never reuse it for a later POST.
+            self._request_id = write.request_id
+            outcome = await async_write_zensdk_property(
+                self._bootstrap,
+                authorized.device_id,
+                write.property_name,
+                write.value,
+                write.request_id,
+                self._post_json,
+            )
+            last_http_status = outcome.http_status
+            self._verification.transport_result(
+                command_id,
+                ok=outcome.accepted,
+                status=(
+                    f"http_{outcome.http_status}"
+                    if outcome.http_status is not None
+                    else outcome.result
+                ),
+                at=self._clock(),
+            )
+            if not outcome.accepted:
+                for _pending_write, pending_id in prepared[sent_count + 1:]:
+                    self._verification.cancel(pending_id)
+                return ZenSdkCommandResult(
+                    ZenSdkCommandStatus.TRANSPORT_ERROR,
+                    outcome.result,
+                    tuple(item[1] for item in prepared),
+                    sent_count,
+                    outcome.http_status,
+                )
+            sent_count += 1
+
+        return ZenSdkCommandResult(
+            ZenSdkCommandStatus.SENT,
+            "awaiting_readback",
+            tuple(item[1] for item in prepared),
+            sent_count,
+            last_http_status,
+        )
+
+    def observe_properties(
+        self,
+        *,
+        device_id: str,
+        properties: Mapping[str, object],
+        observed_at: datetime,
+    ) -> int:
+        """Confirm only a new report for the exact device and property."""
+
+        confirmed = 0
+        for property_name, raw_value in properties.items():
+            active = self._verification.active_for(device_id, property_name)
+            if active is None or isinstance(raw_value, bool):
+                continue
+            try:
+                value = float(raw_value)
+            except (TypeError, ValueError):
+                continue
+            if self._verification.observe_readback(
+                active.command_id,
+                device_id=device_id,
+                property_name=property_name,
+                value=value,
+                observed_at=observed_at,
+            ):
+                confirmed += 1
+        return confirmed
+
+
+def _whole_watts(value: float) -> int:
+    number = float(value)
+    if not number.is_integer() or number < 0:
+        raise ValueError("invalid_power_value")
+    return int(number)
+
+
+def _soc_tenths(value: float | None) -> int:
+    if value is None:
+        raise ValueError("missing_soc_value")
+    number = float(value)
+    if number < 0 or number > 100:
+        raise ValueError("invalid_soc_value")
+    return int(round(number * 10))

--- a/docs/architecture/zendure-zensdk-commands-v5.0.0.md
+++ b/docs/architecture/zendure-zensdk-commands-v5.0.0.md
@@ -1,0 +1,36 @@
+# ZenSDK command adapter contract for V5.0.0
+
+The ZenSDK write path follows this boundary:
+
+`DeviceCommand -> NativeDeviceCommandGate -> AuthorizedNativeCommand -> ZenSDK adapter`
+
+The adapter cannot accept an unaddressed property/value pair. It accepts only
+the gate-issued envelope for one exact logical main device, resolves that device
+through the Cloud bootstrap identity, and checks the per-transport property
+evidence in the device matrix again before sending any HTTP request.
+
+## Initial allow-list
+
+The initial field-verified scope is deliberately limited to `outputLimit` on
+the SolarFlow 2400 AC. `acMode`, `smartMode`, `inputLimit`, `minSoc`, and
+`socSet` remain reference-only and therefore cannot produce a POST. Other
+models remain blocked until the same property-level evidence exists for them.
+
+The mapping retains whole watts for `outputLimit`. SoC fields are prepared as
+tenths of a percent, but remain unreachable until their individual matrix
+capabilities are verified.
+
+## Delivery and verification
+
+Each approved property is posted at most once to `/properties/write`. There is
+no retry after a timeout, no alternate-address write, no command replay after
+rediscovery, and no fallback to Cloud or Local MQTT. A 2xx result records only
+HTTP transport acceptance. It does not mark the command as applied.
+
+Every write prepares a transport-neutral readback record before it is sent.
+Only a later ZenSDK report for the same logical device, same property, and a
+timestamp newer than the send timestamp can confirm it. Superseded-command and
+bounded-history behavior stays in the shared verification manager.
+
+This adapter is not connected to the productive PowerController in issue #341.
+That ownership switch remains the separate integration step in issue #342.

--- a/tests/test_zendure_zensdk_commands.py
+++ b/tests/test_zendure_zensdk_commands.py
@@ -1,0 +1,208 @@
+"""Typed ZenSDK command adapter tests."""
+
+from __future__ import annotations
+
+from base64 import b64encode
+from datetime import datetime, timedelta, timezone
+import unittest
+
+from support import bootstrap as bootstrap_test_environment
+
+
+bootstrap_test_environment()
+
+from custom_components.battery_smartflow_ai.core.models import (  # noqa: E402
+    DeviceCommand,
+    ZendureTransport,
+)
+from custom_components.battery_smartflow_ai.native_command_verification import (  # noqa: E402
+    CommandVerificationStatus,
+    NativeCommandVerificationManager,
+)
+from custom_components.battery_smartflow_ai.native_device_command_gate import (  # noqa: E402
+    AuthorizedNativeCommand,
+)
+from custom_components.battery_smartflow_ai.zendure_cloud import (  # noqa: E402
+    ZendureCloudClient,
+)
+from custom_components.battery_smartflow_ai.zendure_zensdk_commands import (  # noqa: E402
+    ZenSdkCommandStatus,
+    ZendureZenSdkCommandAdapter,
+    map_zensdk_command,
+)
+
+
+NOW = datetime(2026, 9, 5, 10, 0, tzinfo=timezone.utc)
+DEVICE = "cloud_mqtt:device-real-1"
+
+
+class Response:
+    def __init__(self, data, status=200):
+        self.data = data
+        self.status = status
+
+    async def json(self):
+        return self.data
+
+
+async def make_bootstrap():
+    token = b64encode(b"https://api.example.com.app-key").decode()
+
+    async def post(*_args, **_kwargs):
+        return Response({
+            "code": 200,
+            "success": True,
+            "data": {
+                "deviceList": [{
+                    "deviceKey": "device-real-1",
+                    "snNumber": "serial-real-1",
+                    "productKey": "BC8B7F",
+                    "productModel": "SolarFlow 2400 AC",
+                    "online": True,
+                    "ip": "192.168.1.44",
+                }],
+                "mqtt": {
+                    "clientId": "client-secret",
+                    "url": "mqtt://broker.example:1883",
+                    "username": "user-secret",
+                    "password": "password-secret",
+                },
+            },
+        })
+
+    return await ZendureCloudClient(post).async_discover(token)
+
+
+def authorized(command: DeviceCommand, *, transport=ZendureTransport.ZENSDK):
+    return AuthorizedNativeCommand("gate-correlation", DEVICE, transport, command)
+
+
+def output_command(value=301):
+    return DeviceCommand(
+        "output",
+        output_limit_w=value,
+        should_write_mode=False,
+        should_write_input=False,
+        should_write_output=True,
+    )
+
+
+class ZenSdkCommandAdapterTests(unittest.IsolatedAsyncioTestCase):
+    async def test_maps_only_verified_output_write_and_posts_exactly_once(self):
+        data = await make_bootstrap()
+        calls = []
+        manager = NativeCommandVerificationManager()
+
+        async def post(url, **kwargs):
+            calls.append((url, kwargs))
+            return Response({"success": True}, 200)
+
+        adapter = ZendureZenSdkCommandAdapter(
+            data, post, manager, clock=lambda: NOW
+        )
+        result = await adapter.execute(authorized(output_command()))
+
+        self.assertEqual(result.status, ZenSdkCommandStatus.SENT)
+        self.assertEqual(result.writes_sent, 1)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0][0], "http://192.168.1.44/properties/write")
+        self.assertEqual(calls[0][1]["json"], {
+            "sn": "serial-real-1",
+            "properties": {"outputLimit": 301},
+            "id": 1,
+        })
+        tracked = manager.active_for(DEVICE, "outputLimit")
+        self.assertIsNotNone(tracked)
+        self.assertEqual(tracked.status, CommandVerificationStatus.TRANSPORT_OK)
+
+    async def test_unverified_property_is_rejected_without_network(self):
+        data = await make_bootstrap()
+        calls = []
+
+        async def post(*args, **kwargs):
+            calls.append((args, kwargs))
+            return Response({})
+
+        command = DeviceCommand(
+            "input",
+            input_limit_w=200,
+            should_write_mode=False,
+            should_write_input=True,
+            should_write_output=False,
+        )
+        adapter = ZendureZenSdkCommandAdapter(
+            data, post, NativeCommandVerificationManager()
+        )
+        result = await adapter.execute(authorized(command))
+
+        self.assertEqual(result.status, ZenSdkCommandStatus.REJECTED)
+        self.assertEqual(result.reason, "property_not_approved:inputLimit")
+        self.assertEqual(calls, [])
+
+    async def test_wrong_transport_and_non_integral_power_are_rejected(self):
+        data = await make_bootstrap()
+        with self.assertRaisesRegex(ValueError, "wrong_transport"):
+            map_zensdk_command(
+                authorized(output_command(), transport=ZendureTransport.CLOUD_MQTT),
+                data,
+                first_request_id=1,
+            )
+        with self.assertRaisesRegex(ValueError, "invalid_power_value"):
+            map_zensdk_command(
+                authorized(output_command(300.5)), data, first_request_id=1
+            )
+
+    async def test_http_failure_is_transport_error_and_never_retried(self):
+        data = await make_bootstrap()
+        calls = []
+        manager = NativeCommandVerificationManager()
+
+        async def post(url, **_kwargs):
+            calls.append(url)
+            return Response({"success": False}, 503)
+
+        result = await ZendureZenSdkCommandAdapter(
+            data, post, manager, clock=lambda: NOW
+        ).execute(authorized(output_command()))
+
+        self.assertEqual(result.status, ZenSdkCommandStatus.TRANSPORT_ERROR)
+        self.assertEqual(result.http_status, 503)
+        self.assertEqual(len(calls), 1)
+        tracked = manager.get(result.verification_ids[0])
+        self.assertEqual(tracked.status, CommandVerificationStatus.TRANSPORT_ERROR)
+
+    async def test_only_fresh_matching_report_confirms_readback(self):
+        data = await make_bootstrap()
+        manager = NativeCommandVerificationManager()
+
+        async def post(*_args, **_kwargs):
+            return Response({"success": True}, 200)
+
+        adapter = ZendureZenSdkCommandAdapter(
+            data, post, manager, clock=lambda: NOW
+        )
+        await adapter.execute(authorized(output_command()))
+
+        self.assertEqual(adapter.observe_properties(
+            device_id=DEVICE,
+            properties={"outputLimit": 301},
+            observed_at=NOW,
+        ), 0)
+        self.assertEqual(adapter.observe_properties(
+            device_id="cloud_mqtt:different-device",
+            properties={"outputLimit": 301},
+            observed_at=NOW + timedelta(seconds=1),
+        ), 0)
+        self.assertEqual(adapter.observe_properties(
+            device_id=DEVICE,
+            properties={"outputLimit": 301},
+            observed_at=NOW + timedelta(seconds=1),
+        ), 1)
+        tracked = manager.active_for(DEVICE, "outputLimit")
+        self.assertEqual(
+            tracked.status, CommandVerificationStatus.READBACK_CONFIRMED
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a typed ZenSDK command adapter that accepts only gate-issued `AuthorizedNativeCommand` envelopes
- resolve the exact logical main device and re-check model, transport, and property evidence before every POST
- initially allow only the field-verified SF2400AC `outputLimit` property; keep mode, input, and SoC writes blocked
- send each approved `/properties/write` request at most once with monotonically increasing request IDs
- correlate HTTP acceptance and later fresh per-device property readback through the shared command-verification manager
- document the fail-closed boundary and the intentionally limited initial allow-list

## Validation

- `python -m pytest tests -q --tb=short`
- 632 passed, 407 subtests passed
- `git diff --check`

This is the first isolated adapter step for #341. It does not connect ZenSDK writes to the productive PowerController, does not broaden unverified model/property capabilities, and does not close #341 or #342.
