### PR TITLE
Send atomic ZenSDK direction commands

### DIFF
--- a/custom_components/battery_smartflow_ai/core/models/native_device_state.py
+++ b/custom_components/battery_smartflow_ai/core/models/native_device_state.py
@@ -77,3 +77,4 @@ class NeutralDeviceState:
     battery_voltage_v: MeasuredValue[float]
     last_message_at: datetime | None
     packs: tuple[NeutralPackState, ...]
+    offgrid_power_w: MeasuredValue[float]

--- a/custom_components/battery_smartflow_ai/native_zendure_runtime.py
+++ b/custom_components/battery_smartflow_ai/native_zendure_runtime.py
@@ -447,6 +447,18 @@ class NativeZendureRuntime:
                 native_identities=(control_identity,),
             )
             final_command = _skip_matching_writes(command, state)
+            offgrid_power = getattr(state, "offgrid_power_w", None)
+            final_command = replace(
+                final_command,
+                metadata={
+                    **final_command.metadata,
+                    "native_offgrid_power_w": (
+                        float(offgrid_power.value)
+                        if offgrid_power is not None and offgrid_power.valid
+                        else None
+                    ),
+                },
+            )
             if not _has_writes(final_command):
                 return self._remember_command_result(_command_result(
                     CommandExecutionStatus.SKIPPED, "native_setpoints_unchanged"

--- a/custom_components/battery_smartflow_ai/zendure_device_matrix.py
+++ b/custom_components/battery_smartflow_ai/zendure_device_matrix.py
@@ -113,6 +113,7 @@ _COMMON_MAIN_READS = frozenset(
         "gridInputPower",
         "outputHomePower",
         "solarInputPower",
+        "gridOffPower",
         "acMode",
         "inputLimit",
         "outputLimit",
@@ -161,6 +162,7 @@ _COMMON_DEVICE_TARGETS = frozenset(
         "ac_input_power_w",
         "ac_output_power_w",
         "pv_power_w",
+        "offgrid_power_w",
         "mode",
         "input_limit_w",
         "output_limit_w",
@@ -252,10 +254,13 @@ def _entry(
             VerificationLevel.VERIFIED,
             VerificationLevel.VERIFIED,
             VerificationLevel.REFERENCE_ONLY,
-            ("Only explicit reversible outputLimit verification is approved",),
+            ("SF2400AC ZenSDK directional command group approved for field validation",),
         )
-        writes["outputLimit"] = VerificationLevel.VERIFIED
-        transport_writes[ZendureTransport.ZENSDK]["outputLimit"] = VerificationLevel.VERIFIED
+        for property_name in ("smartMode", "acMode", "inputLimit", "outputLimit"):
+            writes[property_name] = VerificationLevel.VERIFIED
+            transport_writes[ZendureTransport.ZENSDK][property_name] = (
+                VerificationLevel.VERIFIED
+            )
     return ZendureDeviceMatrixEntry(
         profile_key=profile_key,
         canonical_model=canonical_model,

--- a/custom_components/battery_smartflow_ai/zendure_normalizer.py
+++ b/custom_components/battery_smartflow_ai/zendure_normalizer.py
@@ -122,6 +122,10 @@ MAIN_PROPERTY_MAPPINGS = {
             "solarInputPower", "pv_power_w", MappingScope.MAIN,
             (int, float), "W", "W", minimum=0,
         ),
+        _mapping(
+            "gridOffPower", "offgrid_power_w", MappingScope.MAIN,
+            (int, float), "W", "W", minimum=0,
+        ),
         _mapping("acMode", "mode", MappingScope.MAIN, (int,), converter=_mode),
         _mapping(
             "inputLimit", "input_limit_w", MappingScope.MAIN,
@@ -438,6 +442,7 @@ class ZendureCloudNormalizer:
             battery_voltage_v=device_value("battery_voltage_v"),
             last_message_at=self._last_message[system_id],
             packs=packs,
+            offgrid_power_w=device_value("offgrid_power_w"),
         )
         return NormalizationResult(
             state,

--- a/custom_components/battery_smartflow_ai/zendure_zensdk.py
+++ b/custom_components/battery_smartflow_ai/zendure_zensdk.py
@@ -70,6 +70,37 @@ async def async_write_zensdk_property(
 
     if property_name != "outputLimit":
         return ZenSdkWriteResult(False, None, "property_not_allowed")
+    return await async_write_zensdk_properties(
+        bootstrap,
+        device_candidate_id,
+        {property_name: value},
+        request_id,
+        post_json,
+        timeout=timeout,
+    )
+
+
+async def async_write_zensdk_properties(
+    bootstrap: ZendureCloudBootstrap,
+    device_candidate_id: str,
+    properties: Mapping[str, int],
+    request_id: int,
+    post_json: GetJson,
+    *,
+    timeout: float = DEFAULT_ZENSDK_TIMEOUT,
+) -> ZenSdkWriteResult:
+    """Write one complete allow-listed command group in exactly one POST."""
+
+    property_names = frozenset(properties)
+    direction_names = frozenset(
+        {"smartMode", "acMode", "inputLimit", "outputLimit"}
+    )
+    if property_names not in (frozenset({"outputLimit"}), direction_names):
+        return ZenSdkWriteResult(False, None, "property_not_allowed")
+    if any(isinstance(value, bool) or not isinstance(value, int) for value in properties.values()):
+        return ZenSdkWriteResult(False, None, "invalid_property_value")
+    if property_names == direction_names and not _valid_direction_group(properties):
+        return ZenSdkWriteResult(False, None, "invalid_direction_group")
     device = next(
         (item for item in bootstrap.devices
          if item.candidate.candidate_id == device_candidate_id), None
@@ -95,7 +126,7 @@ async def async_write_zensdk_property(
                 f"http://{host}{ZENSDK_WRITE_PATH}",
                 json={
                     "sn": identity.serial_number,
-                    "properties": {property_name: int(value)},
+                    "properties": dict(properties),
                     "id": int(request_id),
                 },
             ),
@@ -108,6 +139,20 @@ async def async_write_zensdk_property(
         )
     except Exception:
         return ZenSdkWriteResult(False, None, "transport_error")
+
+
+def _valid_direction_group(properties: Mapping[str, int]) -> bool:
+    smart_mode = properties["smartMode"]
+    ac_mode = properties["acMode"]
+    input_w = properties["inputLimit"]
+    output_w = properties["outputLimit"]
+    if smart_mode not in (0, 1) or ac_mode not in (1, 2):
+        return False
+    if input_w < 0 or output_w < 0:
+        return False
+    if (ac_mode == 1 and output_w != 0) or (ac_mode == 2 and input_w != 0):
+        return False
+    return smart_mode != 0 or (input_w == 0 and output_w == 0)
 
 
 async def async_read_zensdk_reports(

--- a/custom_components/battery_smartflow_ai/zendure_zensdk_commands.py
+++ b/custom_components/battery_smartflow_ai/zendure_zensdk_commands.py
@@ -15,7 +15,7 @@ from .native_command_verification import (
 from .native_device_command_gate import AuthorizedNativeCommand
 from .zendure_cloud import ZendureCloudBootstrap
 from .zendure_device_matrix import VerificationLevel, resolve_zendure_device
-from .zendure_zensdk import GetJson, async_write_zensdk_property
+from .zendure_zensdk import GetJson, async_write_zensdk_properties
 
 
 class ZenSdkCommandStatus(StrEnum):
@@ -27,13 +27,11 @@ class ZenSdkCommandStatus(StrEnum):
 
 
 @dataclass(frozen=True, slots=True)
-class ZenSdkPropertyWrite:
-    """One allow-listed low-level write plus its readback contract."""
+class ZenSdkCommandWrite:
+    """One atomic directional command plus its readback contracts."""
 
-    property_name: str
-    value: int
+    properties: Mapping[str, int]
     request_id: int
-    readback_tolerance: float = 0.0
 
 
 @dataclass(frozen=True, slots=True)
@@ -44,6 +42,7 @@ class ZenSdkCommandResult:
     reason: str
     verification_ids: tuple[str, ...] = ()
     writes_sent: int = 0
+    requests_sent: int = 0
     http_status: int | None = None
 
 
@@ -52,8 +51,8 @@ def map_zensdk_command(
     bootstrap: ZendureCloudBootstrap,
     *,
     first_request_id: int,
-) -> tuple[ZenSdkPropertyWrite, ...]:
-    """Map only gate-authorized and transport-verified properties."""
+) -> ZenSdkCommandWrite:
+    """Map a neutral direction into the atomic group used by ZenSDK."""
 
     if not isinstance(authorized, AuthorizedNativeCommand):
         raise ValueError("gate_authorization_required")
@@ -79,35 +78,36 @@ def map_zensdk_command(
         raise ValueError("transport_not_approved")
 
     command = authorized.command
-    requested: list[tuple[str, int]] = []
-    if command.should_write_mode:
-        requested.append(("acMode", 1 if command.ac_mode == "input" else 2))
-    if command.should_write_input:
-        requested.append(("inputLimit", _whole_watts(command.input_limit_w)))
-    if command.should_write_output:
-        requested.append(("outputLimit", _whole_watts(command.output_limit_w)))
+    requested: dict[str, int] = {}
+    directional_write = any((
+        command.should_write_mode,
+        command.should_write_input,
+        command.should_write_output,
+    ))
+    if directional_write:
+        input_w = _whole_watts(command.input_limit_w)
+        output_w = _whole_watts(command.output_limit_w)
+        active_w = input_w if command.ac_mode == "input" else output_w
+        requested.update({
+            "smartMode": _smart_mode(active_w, command.metadata),
+            "acMode": 1 if command.ac_mode == "input" else 2,
+            "outputLimit": 0 if command.ac_mode == "input" else output_w,
+            "inputLimit": input_w if command.ac_mode == "input" else 0,
+        })
     if command.should_write_min_soc:
-        requested.append(("minSoc", _soc_tenths(command.min_soc_pct)))
+        requested["minSoc"] = _soc_tenths(command.min_soc_pct)
     if command.should_write_max_soc:
-        requested.append(("socSet", _soc_tenths(command.max_soc_pct)))
+        requested["socSet"] = _soc_tenths(command.max_soc_pct)
     if not requested:
         raise ValueError("empty_command")
 
-    writes = []
-    for offset, (property_name, value) in enumerate(requested):
+    for property_name in requested:
         if (
             matrix.property_write_level(ZendureTransport.ZENSDK, property_name)
             is not VerificationLevel.VERIFIED
         ):
             raise ValueError(f"property_not_approved:{property_name}")
-        writes.append(
-            ZenSdkPropertyWrite(
-                property_name=property_name,
-                value=value,
-                request_id=first_request_id + offset,
-            )
-        )
-    return tuple(writes)
+    return ZenSdkCommandWrite(dict(requested), first_request_id)
 
 
 class ZendureZenSdkCommandAdapter:
@@ -130,11 +130,11 @@ class ZendureZenSdkCommandAdapter:
     async def execute(
         self, authorized: AuthorizedNativeCommand
     ) -> ZenSdkCommandResult:
-        """POST each approved property once; never retry or fall back."""
+        """POST one complete approved group; never retry or fall back."""
 
         now = self._clock()
         try:
-            writes = map_zensdk_command(
+            write = map_zensdk_command(
                 authorized,
                 self._bootstrap,
                 first_request_id=self._request_id + 1,
@@ -142,19 +142,19 @@ class ZendureZenSdkCommandAdapter:
         except ValueError as error:
             return ZenSdkCommandResult(ZenSdkCommandStatus.REJECTED, str(error))
 
-        prepared: list[tuple[ZenSdkPropertyWrite, str]] = []
-        for write in writes:
+        prepared: list[tuple[str, int, str]] = []
+        for property_name, value in write.properties.items():
             verification = self._verification.prepare(
                 device_id=authorized.device_id,
-                command_type=write.property_name,
-                target_key=write.property_name,
+                command_type=property_name,
+                target_key=property_name,
                 transport=ZendureTransport.ZENSDK,
-                requested_value=write.value,
-                final_value=write.value,
+                requested_value=value,
+                final_value=value,
                 readback=ReadbackPolicy(
-                    write.property_name,
-                    write.value,
-                    write.readback_tolerance,
+                    property_name,
+                    value,
+                    0.0,
                 ),
                 prepared_at=now,
                 max_attempts=1,
@@ -162,24 +162,21 @@ class ZendureZenSdkCommandAdapter:
             self._verification.gate(
                 verification.command_id, accepted=True, at=now
             )
-            prepared.append((write, verification.command_id))
+            prepared.append((property_name, value, verification.command_id))
 
-        sent_count = 0
-        last_http_status: int | None = None
-        for write, command_id in prepared:
+        for _property_name, _value, command_id in prepared:
             self._verification.sent(command_id, at=self._clock())
-            # The id belongs to an attempted request, even when its response is
-            # an error or ambiguous timeout. Never reuse it for a later POST.
-            self._request_id = write.request_id
-            outcome = await async_write_zensdk_property(
-                self._bootstrap,
-                authorized.device_id,
-                write.property_name,
-                write.value,
-                write.request_id,
-                self._post_json,
-            )
-            last_http_status = outcome.http_status
+        # The id belongs to an attempted request, even after an ambiguous
+        # timeout. The complete group is deliberately never split or retried.
+        self._request_id = write.request_id
+        outcome = await async_write_zensdk_properties(
+            self._bootstrap,
+            authorized.device_id,
+            write.properties,
+            write.request_id,
+            self._post_json,
+        )
+        for _property_name, _value, command_id in prepared:
             self._verification.transport_result(
                 command_id,
                 ok=outcome.accepted,
@@ -190,24 +187,23 @@ class ZendureZenSdkCommandAdapter:
                 ),
                 at=self._clock(),
             )
-            if not outcome.accepted:
-                for _pending_write, pending_id in prepared[sent_count + 1:]:
-                    self._verification.cancel(pending_id)
-                return ZenSdkCommandResult(
-                    ZenSdkCommandStatus.TRANSPORT_ERROR,
-                    outcome.result,
-                    tuple(item[1] for item in prepared),
-                    sent_count,
-                    outcome.http_status,
-                )
-            sent_count += 1
+        if not outcome.accepted:
+            return ZenSdkCommandResult(
+                status=ZenSdkCommandStatus.TRANSPORT_ERROR,
+                reason=outcome.result,
+                verification_ids=tuple(item[2] for item in prepared),
+                writes_sent=0,
+                requests_sent=1,
+                http_status=outcome.http_status,
+            )
 
         return ZenSdkCommandResult(
-            ZenSdkCommandStatus.SENT,
-            "awaiting_readback",
-            tuple(item[1] for item in prepared),
-            sent_count,
-            last_http_status,
+            status=ZenSdkCommandStatus.SENT,
+            reason="awaiting_readback",
+            verification_ids=tuple(item[2] for item in prepared),
+            writes_sent=len(prepared),
+            requests_sent=1,
+            http_status=outcome.http_status,
         )
 
     def observe_properties(
@@ -253,3 +249,19 @@ def _soc_tenths(value: float | None) -> int:
     if number < 0 or number > 100:
         raise ValueError("invalid_soc_value")
     return int(round(number * 10))
+
+
+def _smart_mode(active_w: int, metadata: Mapping[str, object]) -> int:
+    """Keep the off-grid socket alive when its load is active or unknown."""
+
+    if active_w > 0:
+        return 1
+    raw_offgrid = metadata.get("native_offgrid_power_w")
+    if raw_offgrid is None:
+        return 1
+    if isinstance(raw_offgrid, bool):
+        raise ValueError("invalid_offgrid_power")
+    try:
+        return 1 if float(raw_offgrid) > 0 else 0
+    except (TypeError, ValueError) as error:
+        raise ValueError("invalid_offgrid_power") from error

--- a/tests/test_native_device_command_gate.py
+++ b/tests/test_native_device_command_gate.py
@@ -183,16 +183,30 @@ class NativeDeviceCommandGateTests(unittest.IsolatedAsyncioTestCase):
             self.assertIn(reason, result.reasons)
             self.assertEqual(called, [])
 
-    async def test_production_matrix_keeps_unverified_zensdk_properties_closed(self):
+    async def test_production_matrix_allows_verified_zensdk_direction_group(self):
         hems = ZendureHemsCommandGate()
         hems.update(DEVICE_ID, valid(False), capability=VerificationLevel.VERIFIED)
         gate = NativeDeviceCommandGate(hems)
         result = gate.evaluate(
             NativeCommandRequest(DEVICE_ID, TRANSPORT, command()), context()
         )
+        self.assertTrue(result.accepted)
+        self.assertEqual(result.reasons, ())
+
+    async def test_production_matrix_keeps_unverified_zensdk_soc_closed(self):
+        hems = ZendureHemsCommandGate()
+        hems.update(DEVICE_ID, valid(False), capability=VerificationLevel.VERIFIED)
+        request = command()
+        request.should_write_mode = False
+        request.should_write_input = False
+        request.should_write_output = False
+        request.should_write_min_soc = True
+        request.min_soc_pct = 10
+        result = NativeDeviceCommandGate(hems).evaluate(
+            NativeCommandRequest(DEVICE_ID, TRANSPORT, request), context()
+        )
         self.assertFalse(result.accepted)
-        self.assertIn("command_capability_unsupported:acMode", result.reasons)
-        self.assertIn("command_capability_unsupported:inputLimit", result.reasons)
+        self.assertIn("command_capability_unsupported:minSoc", result.reasons)
 
     async def test_control_selection_and_active_state_are_independent_blockers(self):
         result = ready_gate().evaluate(

--- a/tests/test_native_power_controller.py
+++ b/tests/test_native_power_controller.py
@@ -68,6 +68,7 @@ def state(*, input_w=0, output_w=0, charge_w=0, discharge_w=0, hems=False):
             measured(input_w), measured(output_w), measured(2400),
             measured(2400), measured(10), measured(100),
         ),
+        offgrid_power_w=measured(0),
     )
 
 
@@ -91,7 +92,12 @@ class FakeZenSdkAdapter:
     async def execute(self, authorized):
         self.commands.append(authorized)
         return ZenSdkCommandResult(
-            ZenSdkCommandStatus.SENT, "awaiting_readback", ("zen-id",), 1, 200
+            status=ZenSdkCommandStatus.SENT,
+            reason="awaiting_readback",
+            verification_ids=("zen-id",),
+            writes_sent=4,
+            requests_sent=1,
+            http_status=200,
         )
 
 
@@ -144,7 +150,7 @@ class NativePowerControllerTests(unittest.IsolatedAsyncioTestCase):
             "native_zensdk_active",
         )
 
-    async def test_unverified_zensdk_sequence_is_blocked_without_any_write(self):
+    async def test_verified_zensdk_directional_sequence_reaches_adapter(self):
         target = runtime()
 
         result = await target.async_execute_device_command(DeviceCommand(
@@ -153,9 +159,11 @@ class NativePowerControllerTests(unittest.IsolatedAsyncioTestCase):
             should_write_output=True,
         ))
 
-        self.assertEqual(result.status, CommandExecutionStatus.SKIPPED)
-        self.assertIn("command_capability_unsupported:acMode", result.reason)
-        self.assertEqual(target._zensdk_command_adapter.commands, [])
+        self.assertEqual(result.status, CommandExecutionStatus.APPLIED)
+        self.assertEqual(len(target._zensdk_command_adapter.commands), 1)
+        command = target._zensdk_command_adapter.commands[0].command
+        self.assertEqual(command.ac_mode, "input")
+        self.assertEqual(command.metadata["native_offgrid_power_w"], 0.0)
         self.assertEqual(target._transport.commands, [])
 
     async def test_unavailable_zensdk_never_falls_back_to_cloud(self):

--- a/tests/test_zendure_normalizer.py
+++ b/tests/test_zendure_normalizer.py
@@ -111,6 +111,7 @@ class ZendureNormalizerTests(unittest.IsolatedAsyncioTestCase):
                 "gridInputPower": 279,
                 "outputHomePower": 0,
                 "solarInputPower": 620,
+                "gridOffPower": 37,
                 "acMode": 1,
                 "inputLimit": 279,
                 "outputLimit": 0,
@@ -168,6 +169,7 @@ class ZendureNormalizerTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(state.observed_transport, ZendureTransport.CLOUD_MQTT)
         self.assertEqual(state.soc_pct.value, 55.0)
         self.assertEqual(state.charge_power_w.value, 276.0)
+        self.assertEqual(state.offgrid_power_w.value, 37.0)
         self.assertEqual(state.discharge_power_w.value, 0.0)
         self.assertEqual(state.ac_input_power_w.value, 279.0)
         self.assertEqual(state.ac_output_power_w.value, 0.0)

--- a/tests/test_zendure_zensdk.py
+++ b/tests/test_zendure_zensdk.py
@@ -30,6 +30,7 @@ from custom_components.battery_smartflow_ai.zendure_zensdk import (  # noqa: E40
     _candidate_addresses,
     async_read_zensdk_reports,
     async_write_zensdk_property,
+    async_write_zensdk_properties,
 )
 from custom_components.battery_smartflow_ai.zendure_normalizer import (  # noqa: E402
     ZendureCloudNormalizer,
@@ -120,6 +121,25 @@ class ZenSdkReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(result.accepted)
         self.assertEqual(result.result, "property_not_allowed")
         self.assertFalse(called)
+
+    async def test_direction_group_rejects_inconsistent_payload_without_network(self):
+        data = await make_bootstrap()
+        calls = []
+
+        async def post(*args, **kwargs):
+            calls.append((args, kwargs))
+            return Response({})
+
+        result = await async_write_zensdk_properties(
+            data,
+            "cloud_mqtt:device-real-1",
+            {"smartMode": 1, "acMode": 1, "inputLimit": 200, "outputLimit": 1},
+            1,
+            post,
+        )
+        self.assertFalse(result.accepted)
+        self.assertEqual(result.result, "invalid_direction_group")
+        self.assertEqual(calls, [])
 
     async def test_first_write_never_retries_an_ambiguous_timeout(self):
         data = await make_bootstrap()

--- a/tests/test_zendure_zensdk_commands.py
+++ b/tests/test_zendure_zensdk_commands.py
@@ -84,11 +84,12 @@ def output_command(value=301):
         should_write_mode=False,
         should_write_input=False,
         should_write_output=True,
+        metadata={"native_offgrid_power_w": 0},
     )
 
 
 class ZenSdkCommandAdapterTests(unittest.IsolatedAsyncioTestCase):
-    async def test_maps_only_verified_output_write_and_posts_exactly_once(self):
+    async def test_output_is_one_complete_directional_post(self):
         data = await make_bootstrap()
         calls = []
         manager = NativeCommandVerificationManager()
@@ -103,19 +104,25 @@ class ZenSdkCommandAdapterTests(unittest.IsolatedAsyncioTestCase):
         result = await adapter.execute(authorized(output_command()))
 
         self.assertEqual(result.status, ZenSdkCommandStatus.SENT)
-        self.assertEqual(result.writes_sent, 1)
+        self.assertEqual(result.writes_sent, 4)
+        self.assertEqual(result.requests_sent, 1)
         self.assertEqual(len(calls), 1)
         self.assertEqual(calls[0][0], "http://192.168.1.44/properties/write")
         self.assertEqual(calls[0][1]["json"], {
             "sn": "serial-real-1",
-            "properties": {"outputLimit": 301},
+            "properties": {
+                "smartMode": 1,
+                "acMode": 2,
+                "outputLimit": 301,
+                "inputLimit": 0,
+            },
             "id": 1,
         })
         tracked = manager.active_for(DEVICE, "outputLimit")
         self.assertIsNotNone(tracked)
         self.assertEqual(tracked.status, CommandVerificationStatus.TRANSPORT_OK)
 
-    async def test_unverified_property_is_rejected_without_network(self):
+    async def test_input_is_one_complete_directional_post(self):
         data = await make_bootstrap()
         calls = []
 
@@ -129,14 +136,59 @@ class ZenSdkCommandAdapterTests(unittest.IsolatedAsyncioTestCase):
             should_write_mode=False,
             should_write_input=True,
             should_write_output=False,
+            metadata={"native_offgrid_power_w": 0},
         )
         adapter = ZendureZenSdkCommandAdapter(
             data, post, NativeCommandVerificationManager()
         )
         result = await adapter.execute(authorized(command))
 
+        self.assertEqual(result.status, ZenSdkCommandStatus.SENT)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0][1]["json"]["properties"], {
+            "smartMode": 1,
+            "acMode": 1,
+            "outputLimit": 0,
+            "inputLimit": 200,
+        })
+
+    async def test_zero_command_respects_offgrid_load_and_unknown_state(self):
+        data = await make_bootstrap()
+        for offgrid, expected in ((0, 0), (12, 1), (None, 1)):
+            with self.subTest(offgrid=offgrid):
+                command = output_command(0)
+                command.metadata["native_offgrid_power_w"] = offgrid
+                mapped = map_zensdk_command(
+                    authorized(command), data, first_request_id=7
+                )
+                self.assertEqual(mapped.properties, {
+                    "smartMode": expected,
+                    "acMode": 2,
+                    "outputLimit": 0,
+                    "inputLimit": 0,
+                })
+
+    async def test_soc_property_remains_rejected_without_network(self):
+        data = await make_bootstrap()
+        calls = []
+
+        async def post(*args, **kwargs):
+            calls.append((args, kwargs))
+            return Response({})
+
+        command = DeviceCommand(
+            "output",
+            min_soc_pct=10,
+            should_write_mode=False,
+            should_write_input=False,
+            should_write_output=False,
+            should_write_min_soc=True,
+        )
+        result = await ZendureZenSdkCommandAdapter(
+            data, post, NativeCommandVerificationManager()
+        ).execute(authorized(command))
         self.assertEqual(result.status, ZenSdkCommandStatus.REJECTED)
-        self.assertEqual(result.reason, "property_not_approved:inputLimit")
+        self.assertEqual(result.reason, "property_not_approved:minSoc")
         self.assertEqual(calls, [])
 
     async def test_wrong_transport_and_non_integral_power_are_rejected(self):
@@ -167,9 +219,14 @@ class ZenSdkCommandAdapterTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(result.status, ZenSdkCommandStatus.TRANSPORT_ERROR)
         self.assertEqual(result.http_status, 503)
+        self.assertEqual(result.requests_sent, 1)
         self.assertEqual(len(calls), 1)
-        tracked = manager.get(result.verification_ids[0])
-        self.assertEqual(tracked.status, CommandVerificationStatus.TRANSPORT_ERROR)
+        self.assertEqual(len(result.verification_ids), 4)
+        for command_id in result.verification_ids:
+            tracked = manager.get(command_id)
+            self.assertEqual(
+                tracked.status, CommandVerificationStatus.TRANSPORT_ERROR
+            )
 
     async def test_only_fresh_matching_report_confirms_readback(self):
         data = await make_bootstrap()


### PR DESCRIPTION
## Summary
- send ZenSDK charge, discharge, and stop as one atomic four-property HTTP request matching the current Zendure-HA command contract
- normalize native gridOffPower and preserve off-grid output when stopping; unknown off-grid state fails safe by keeping smartMode active
- approve the complete SF2400AC directional property group while keeping SoC and maintenance writes closed
- retain one-shot/no-fallback behavior and correlate readback independently for every property in the group

## Safety
- exactly one /properties/write POST per logical directional command
- no automatic retry after ambiguous outcomes
- inconsistent low-level directional payloads are rejected before network access
- the release remains limited to the SF2400AC validation path

## Validation
- 24 ZenSDK adapter/transport tests
- 27 command gate/verification tests
- 12 native PowerController tests
- 10 normalizer tests
- 11 device-matrix tests
- git diff --check

The broad unittest discovery reached 578 tests; the three pre-existing pytest-backed modules cannot load in the bundled local runtime because pytest is not installed. GitHub CI remains authoritative for the complete suite.

Follow-up to #342.