### PR TITLE
Fix native regulation after initial ZenSDK setpoint

### DIFF
--- a/custom_components/battery_smartflow_ai/command_execution_state.py
+++ b/custom_components/battery_smartflow_ai/command_execution_state.py
@@ -1,0 +1,47 @@
+"""Persisted regulation state derived from successful device commands."""
+
+from __future__ import annotations
+
+from .core.models import (
+    CommandExecutionResult,
+    CommandExecutionStatus,
+    DeviceCommand,
+)
+
+
+def applied_command_state_updates(
+    command: DeviceCommand,
+    result: CommandExecutionResult,
+) -> dict[str, object]:
+    """Return cache updates only for the successfully written active side.
+
+    Home Assistant entity writers update this cache themselves. Native
+    backends bypass those writers, so their successful feedback must advance
+    the same regulator state explicitly.
+    """
+
+    if result.status is not CommandExecutionStatus.APPLIED:
+        return {}
+
+    if command.ac_mode == "input" and result.input_written:
+        value = int(round(max(0.0, float(command.input_limit_w or 0.0))))
+        return {
+            "last_set_mode": "input",
+            "last_set_input_w": value,
+            "last_set_output_w": 0,
+            "input_write_last_success_w": value,
+        }
+
+    if command.ac_mode == "output" and result.output_written:
+        value = int(round(max(0.0, float(command.output_limit_w or 0.0))))
+        return {
+            "last_set_mode": "output",
+            "last_set_input_w": 0,
+            "last_set_output_w": value,
+            "output_write_last_success_w": value,
+        }
+
+    if result.mode_written:
+        return {"last_set_mode": str(command.ac_mode)}
+
+    return {}

--- a/custom_components/battery_smartflow_ai/coordinator.py
+++ b/custom_components/battery_smartflow_ai/coordinator.py
@@ -173,6 +173,7 @@ from .regulation_power_controller import (
     build_regulation_power_config,
 )
 from .device_command import DeviceCommandBuilder, clamp_number_power_request
+from .command_execution_state import applied_command_state_updates
 from .adapters.home_assistant.device_backend import (
     HomeAssistantEntityBackend,
 )
@@ -2097,6 +2098,9 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             native_runtime = getattr(self, "native_zendure", None)
             if native_runtime is not None and native_runtime.control_enabled:
                 result = await native_runtime.async_execute_device_command(command)
+                self._persist.update(
+                    applied_command_state_updates(command, result)
+                )
             else:
                 result = await self._device_backend.execute(
                     command,

--- a/tests/test_command_execution_state.py
+++ b/tests/test_command_execution_state.py
@@ -1,0 +1,99 @@
+"""Successful native command feedback advances the regulator setpoint."""
+
+from __future__ import annotations
+
+import unittest
+
+from support import bootstrap
+
+bootstrap()
+
+from custom_components.battery_smartflow_ai.command_execution_state import (  # noqa: E402
+    applied_command_state_updates,
+)
+from custom_components.battery_smartflow_ai.core.models import (  # noqa: E402
+    CommandExecutionResult,
+    CommandExecutionStatus,
+    DeviceCommand,
+)
+
+
+class CommandExecutionStateTests(unittest.TestCase):
+    def test_applied_output_advances_previous_regulation_value(self) -> None:
+        updates = applied_command_state_updates(
+            DeviceCommand(
+                "output",
+                output_limit_w=807.0,
+                should_write_output=True,
+            ),
+            CommandExecutionResult(
+                CommandExecutionStatus.APPLIED,
+                "awaiting_readback",
+                output_written=True,
+            ),
+        )
+
+        self.assertEqual(updates["last_set_mode"], "output")
+        self.assertEqual(updates["last_set_output_w"], 807)
+        self.assertEqual(updates["last_set_input_w"], 0)
+
+    def test_applied_input_keeps_input_as_active_atomic_side(self) -> None:
+        updates = applied_command_state_updates(
+            DeviceCommand(
+                "input",
+                input_limit_w=425.0,
+                output_limit_w=0.0,
+                should_write_input=True,
+                should_write_output=True,
+            ),
+            CommandExecutionResult(
+                CommandExecutionStatus.APPLIED,
+                "awaiting_readback",
+                input_written=True,
+                output_written=True,
+            ),
+        )
+
+        self.assertEqual(updates["last_set_mode"], "input")
+        self.assertEqual(updates["last_set_input_w"], 425)
+        self.assertEqual(updates["last_set_output_w"], 0)
+
+    def test_skipped_and_failed_commands_never_advance_cache(self) -> None:
+        command = DeviceCommand(
+            "output",
+            output_limit_w=900.0,
+            should_write_output=True,
+        )
+
+        for status in (
+            CommandExecutionStatus.SKIPPED,
+            CommandExecutionStatus.FAILED,
+        ):
+            with self.subTest(status=status):
+                self.assertEqual(
+                    applied_command_state_updates(
+                        command,
+                        CommandExecutionResult(
+                            status,
+                            "not_applied",
+                            output_written=True,
+                        ),
+                    ),
+                    {},
+                )
+
+    def test_mode_only_feedback_updates_no_power_value(self) -> None:
+        updates = applied_command_state_updates(
+            DeviceCommand("output", should_write_mode=True),
+            CommandExecutionResult(
+                CommandExecutionStatus.APPLIED,
+                "applied",
+                mode_written=True,
+            ),
+        )
+
+        self.assertEqual(updates, {"last_set_mode": "output"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- advance the existing regulator setpoint cache after an accepted native command
- keep the active direction and opposite-side zero state aligned with atomic ZenSDK writes
- never advance cached setpoints for skipped or failed native commands
- add regression coverage for output, input, mode-only, skipped, and failed feedback

## Field cause

- Dev20 successfully started SF2400AC discharge through ZenSDK, but every following cycle still used 0 W as the previous output. It recalculated the same startup step, while the native layer correctly skipped that already active device setpoint.

## Validation

- 4 new command-feedback regression tests pass
- 12 native PowerController tests pass
- 8 device-backend boundary tests pass
- full unittest discovery: 581 tests pass; 3 pytest-based modules are not collectable in the bundled local runtime because pytest is not installed
- compileall passes
- diff check passes

Refs #408