### PR TITLE
Adopt confirmed native setpoint after restart

### DIFF
--- a/custom_components/battery_smartflow_ai/command_execution_state.py
+++ b/custom_components/battery_smartflow_ai/command_execution_state.py
@@ -1,4 +1,4 @@
-"""Persisted regulation state derived from successful device commands."""
+"""Persisted regulation state derived from confirmed device commands."""
 
 from __future__ import annotations
 
@@ -9,37 +9,55 @@ from .core.models import (
 )
 
 
-def applied_command_state_updates(
+NATIVE_SETPOINTS_UNCHANGED = "native_setpoints_unchanged"
+
+
+def confirmed_command_state_updates(
     command: DeviceCommand,
     result: CommandExecutionResult,
 ) -> dict[str, object]:
-    """Return cache updates only for the successfully written active side.
+    """Return cache updates for a written or freshly confirmed active side.
 
     Home Assistant entity writers update this cache themselves. Native
     backends bypass those writers, so their successful feedback must advance
-    the same regulator state explicitly.
+    the same regulator state explicitly.  After a restart, the requested
+    setpoint can already match fresh native device state; that exact no-write
+    result is equally safe to adopt as the next regulation baseline.
     """
 
-    if result.status is not CommandExecutionStatus.APPLIED:
+    applied = result.status is CommandExecutionStatus.APPLIED
+    confirmed_unchanged = bool(
+        result.status is CommandExecutionStatus.SKIPPED
+        and result.reason == NATIVE_SETPOINTS_UNCHANGED
+    )
+    if not applied and not confirmed_unchanged:
         return {}
 
-    if command.ac_mode == "input" and result.input_written:
+    if command.ac_mode == "input" and (
+        result.input_written or confirmed_unchanged
+    ):
         value = int(round(max(0.0, float(command.input_limit_w or 0.0))))
-        return {
+        updates: dict[str, object] = {
             "last_set_mode": "input",
             "last_set_input_w": value,
             "last_set_output_w": 0,
-            "input_write_last_success_w": value,
         }
+        if applied:
+            updates["input_write_last_success_w"] = value
+        return updates
 
-    if command.ac_mode == "output" and result.output_written:
+    if command.ac_mode == "output" and (
+        result.output_written or confirmed_unchanged
+    ):
         value = int(round(max(0.0, float(command.output_limit_w or 0.0))))
-        return {
+        updates = {
             "last_set_mode": "output",
             "last_set_input_w": 0,
             "last_set_output_w": value,
-            "output_write_last_success_w": value,
         }
+        if applied:
+            updates["output_write_last_success_w"] = value
+        return updates
 
     if result.mode_written:
         return {"last_set_mode": str(command.ac_mode)}

--- a/custom_components/battery_smartflow_ai/coordinator.py
+++ b/custom_components/battery_smartflow_ai/coordinator.py
@@ -173,7 +173,7 @@ from .regulation_power_controller import (
     build_regulation_power_config,
 )
 from .device_command import DeviceCommandBuilder, clamp_number_power_request
-from .command_execution_state import applied_command_state_updates
+from .command_execution_state import confirmed_command_state_updates
 from .adapters.home_assistant.device_backend import (
     HomeAssistantEntityBackend,
 )
@@ -2099,7 +2099,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             if native_runtime is not None and native_runtime.control_enabled:
                 result = await native_runtime.async_execute_device_command(command)
                 self._persist.update(
-                    applied_command_state_updates(command, result)
+                    confirmed_command_state_updates(command, result)
                 )
             else:
                 result = await self._device_backend.execute(

--- a/tests/test_command_execution_state.py
+++ b/tests/test_command_execution_state.py
@@ -9,7 +9,7 @@ from support import bootstrap
 bootstrap()
 
 from custom_components.battery_smartflow_ai.command_execution_state import (  # noqa: E402
-    applied_command_state_updates,
+    confirmed_command_state_updates,
 )
 from custom_components.battery_smartflow_ai.core.models import (  # noqa: E402
     CommandExecutionResult,
@@ -20,7 +20,7 @@ from custom_components.battery_smartflow_ai.core.models import (  # noqa: E402
 
 class CommandExecutionStateTests(unittest.TestCase):
     def test_applied_output_advances_previous_regulation_value(self) -> None:
-        updates = applied_command_state_updates(
+        updates = confirmed_command_state_updates(
             DeviceCommand(
                 "output",
                 output_limit_w=807.0,
@@ -38,7 +38,7 @@ class CommandExecutionStateTests(unittest.TestCase):
         self.assertEqual(updates["last_set_input_w"], 0)
 
     def test_applied_input_keeps_input_as_active_atomic_side(self) -> None:
-        updates = applied_command_state_updates(
+        updates = confirmed_command_state_updates(
             DeviceCommand(
                 "input",
                 input_limit_w=425.0,
@@ -71,7 +71,7 @@ class CommandExecutionStateTests(unittest.TestCase):
         ):
             with self.subTest(status=status):
                 self.assertEqual(
-                    applied_command_state_updates(
+                    confirmed_command_state_updates(
                         command,
                         CommandExecutionResult(
                             status,
@@ -83,7 +83,7 @@ class CommandExecutionStateTests(unittest.TestCase):
                 )
 
     def test_mode_only_feedback_updates_no_power_value(self) -> None:
-        updates = applied_command_state_updates(
+        updates = confirmed_command_state_updates(
             DeviceCommand("output", should_write_mode=True),
             CommandExecutionResult(
                 CommandExecutionStatus.APPLIED,
@@ -93,6 +93,58 @@ class CommandExecutionStateTests(unittest.TestCase):
         )
 
         self.assertEqual(updates, {"last_set_mode": "output"})
+
+    def test_matching_native_output_is_adopted_after_restart(self) -> None:
+        updates = confirmed_command_state_updates(
+            DeviceCommand(
+                "output",
+                output_limit_w=300.0,
+                should_write_output=True,
+            ),
+            CommandExecutionResult(
+                CommandExecutionStatus.SKIPPED,
+                "native_setpoints_unchanged",
+            ),
+        )
+
+        self.assertEqual(updates["last_set_mode"], "output")
+        self.assertEqual(updates["last_set_output_w"], 300)
+        self.assertEqual(updates["last_set_input_w"], 0)
+        self.assertNotIn("output_write_last_success_w", updates)
+
+    def test_matching_native_input_is_adopted_after_restart(self) -> None:
+        updates = confirmed_command_state_updates(
+            DeviceCommand(
+                "input",
+                input_limit_w=450.0,
+                should_write_input=True,
+            ),
+            CommandExecutionResult(
+                CommandExecutionStatus.SKIPPED,
+                "native_setpoints_unchanged",
+            ),
+        )
+
+        self.assertEqual(updates["last_set_mode"], "input")
+        self.assertEqual(updates["last_set_input_w"], 450)
+        self.assertEqual(updates["last_set_output_w"], 0)
+        self.assertNotIn("input_write_last_success_w", updates)
+
+    def test_other_skipped_native_reason_is_never_adopted(self) -> None:
+        self.assertEqual(
+            confirmed_command_state_updates(
+                DeviceCommand(
+                    "output",
+                    output_limit_w=300.0,
+                    should_write_output=True,
+                ),
+                CommandExecutionResult(
+                    CommandExecutionStatus.SKIPPED,
+                    "native_state_not_fresh",
+                ),
+            ),
+            {},
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- adopt a fresh matching native setpoint as the PowerController baseline after restart
- distinguish confirmed `native_setpoints_unchanged` from all other skipped outcomes
- preserve write-success diagnostics only for actual applied writes
- cover matching INPUT and OUTPUT restart state plus fail-closed skip behavior

## Field cause

Dev21 restarted while the SF2400AC retained its existing 300 W output. The coordinator recalculated the same startup step from an empty cache, and the native runtime correctly returned `native_setpoints_unchanged`. Since only applied writes advanced the cache, every later cycle repeated that same 300 W calculation.

## Validation

- 7 command feedback tests pass
- 12 native PowerController tests pass
- 8 device backend boundary tests pass
- 3 technical regulation core tests pass
- 28 current regulation scenario tests pass
- compileall passes
- diff check passes

Refs #408