### PR TITLE
Fix native handover and publish 5.0.0.dev23

### DIFF
--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -38,7 +38,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "5.0.0.dev22"
+INTEGRATION_VERSION = "5.0.0.dev23"
 
 # V5 native Zendure discovery is observation-only in the first development
 # build. The App Token is account discovery material and must never be copied

--- a/custom_components/battery_smartflow_ai/coordinator.py
+++ b/custom_components/battery_smartflow_ai/coordinator.py
@@ -3824,6 +3824,24 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
             now = self._clock.utc_now()
 
+            native_runtime = getattr(self, "native_zendure", None)
+            native_baseline = (
+                native_runtime.consume_control_baseline()
+                if native_runtime is not None
+                and hasattr(native_runtime, "consume_control_baseline")
+                else None
+            )
+            if native_baseline is not None:
+                baseline_mode, baseline_input_w, baseline_output_w = native_baseline
+                self._persist["last_set_mode"] = baseline_mode
+                self._persist["last_set_input_w"] = baseline_input_w
+                self._persist["last_set_output_w"] = baseline_output_w
+                self._persist["prev_charge_w"] = baseline_input_w
+                self._persist["prev_discharge_w"] = baseline_output_w
+                self._persist["native_handover_baseline_mode"] = baseline_mode
+                self._persist["native_handover_baseline_input_w"] = baseline_input_w
+                self._persist["native_handover_baseline_output_w"] = baseline_output_w
+
             soc = _to_float(self._state(self.entities.soc), None)
             pv = _to_float(self._state(self.entities.pv), None)
             native_pv = _to_float(self._state(self.entities.native_pv), None)

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": ["paho-mqtt==2.1.0"],
-  "version": "5.0.0.dev22"
+  "version": "5.0.0.dev23"
 }

--- a/custom_components/battery_smartflow_ai/native_zendure_runtime.py
+++ b/custom_components/battery_smartflow_ai/native_zendure_runtime.py
@@ -128,6 +128,7 @@ class NativeZendureRuntime:
         self._command_verification = NativeCommandVerificationManager()
         self._zensdk_command_adapter: ZendureZenSdkCommandAdapter | None = None
         self._last_command_result: dict[str, Any] | None = None
+        self._control_baseline_consumed = False
 
     @property
     def configured(self) -> bool:
@@ -146,6 +147,39 @@ class NativeZendureRuntime:
     @property
     def status(self) -> str:
         return self._status
+
+    def consume_control_baseline(self) -> tuple[str, int, int] | None:
+        """Return one fresh device baseline when native control takes ownership."""
+
+        if self._control_baseline_consumed or not self._control_enabled:
+            return None
+        if self._selected_device is None:
+            return None
+        state = self._states.get(self._selected_device)
+        if state is None or not _fresh_native_state(state):
+            return None
+
+        mode = state.mode
+        input_limit = state.setpoints.input_limit_w
+        output_limit = state.setpoints.output_limit_w
+        if not all(
+            _fresh_measured_value(item)
+            for item in (mode, input_limit, output_limit)
+        ):
+            return None
+
+        input_w = int(round(max(0.0, float(input_limit.value))))
+        output_w = int(round(max(0.0, float(output_limit.value))))
+        if str(mode.value) in {"charge", "input"}:
+            self._control_baseline_consumed = True
+            return ("input", input_w, 0)
+        if str(mode.value) in {"discharge", "output"}:
+            self._control_baseline_consumed = True
+            return ("output", 0, output_w)
+        if str(mode.value) == "idle":
+            self._control_baseline_consumed = True
+            return ("idle", 0, 0)
+        return None
 
     def start(self) -> None:
         if not self.configured or self._task is not None:
@@ -913,6 +947,19 @@ def _fresh_native_state(state: Any, *, maximum_age_seconds: float = 30.0) -> boo
         and 0 <= (now - item.observed_at).total_seconds() <= maximum_age_seconds
         for item in required
     )
+
+
+def _fresh_measured_value(
+    measured: Any,
+    *,
+    maximum_age_seconds: float = 30.0,
+) -> bool:
+    """Return whether one native value is valid and recently observed."""
+
+    if not measured.valid or measured.observed_at is None:
+        return False
+    age = (datetime.now(timezone.utc) - measured.observed_at).total_seconds()
+    return 0 <= age <= maximum_age_seconds
 
 
 def _skip_matching_writes(command: DeviceCommand, state: Any) -> DeviceCommand:

--- a/custom_components/battery_smartflow_ai/zendure_zensdk_commands.py
+++ b/custom_components/battery_smartflow_ai/zendure_zensdk_commands.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import StrEnum
+import math
 from typing import Callable, Mapping
 
 from .core.models import ZendureTransport
@@ -237,9 +238,9 @@ class ZendureZenSdkCommandAdapter:
 
 def _whole_watts(value: float) -> int:
     number = float(value)
-    if not number.is_integer() or number < 0:
+    if not math.isfinite(number) or number < 0:
         raise ValueError("invalid_power_value")
-    return int(number)
+    return int(round(number))
 
 
 def _soc_tenths(value: float | None) -> int:

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -13,7 +13,7 @@ COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
 
 
 class DebugIntegrationContractTests(unittest.TestCase):
-    def test_manifest_and_runtime_version_match_v5_dev22_release(self) -> None:
+    def test_manifest_and_runtime_version_match_v5_dev23_release(self) -> None:
         manifest_version = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )["version"]
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "5.0.0.dev22")
+        self.assertEqual(manifest_version, "5.0.0.dev23")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_native_power_controller.py
+++ b/tests/test_native_power_controller.py
@@ -131,6 +131,23 @@ def runtime(*, enabled=True, current_state=None):
 
 
 class NativePowerControllerTests(unittest.IsolatedAsyncioTestCase):
+    async def test_fresh_running_setpoint_is_consumed_once_as_handover_baseline(self):
+        target = runtime(current_state=state(output_w=950, discharge_w=947))
+
+        self.assertEqual(
+            target.consume_control_baseline(),
+            ("output", 0, 950),
+        )
+        self.assertIsNone(target.consume_control_baseline())
+
+    async def test_disabled_control_never_exposes_handover_baseline(self):
+        target = runtime(
+            enabled=False,
+            current_state=state(output_w=950, discharge_w=947),
+        )
+
+        self.assertIsNone(target.consume_control_baseline())
+
     async def test_output_uses_only_explicitly_selected_zensdk_transport(self):
         target = runtime()
 

--- a/tests/test_native_zendure_ha_integration.py
+++ b/tests/test_native_zendure_ha_integration.py
@@ -13,11 +13,11 @@ COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
 
 
 class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
-    def test_dev22_version_and_mqtt_dependency_are_packaged(self) -> None:
+    def test_dev23_version_and_mqtt_dependency_are_packaged(self) -> None:
         manifest = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )
-        self.assertEqual(manifest["version"], "5.0.0.dev22")
+        self.assertEqual(manifest["version"], "5.0.0.dev23")
         self.assertIn("paho-mqtt==2.1.0", manifest["requirements"])
 
     def test_options_flow_uses_a_password_field_and_never_suggests_token(self) -> None:

--- a/tests/test_zendure_zensdk_commands.py
+++ b/tests/test_zendure_zensdk_commands.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from base64 import b64encode
 from datetime import datetime, timedelta, timezone
+import math
 import unittest
 
 from support import bootstrap as bootstrap_test_environment
@@ -191,7 +192,7 @@ class ZenSdkCommandAdapterTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result.reason, "property_not_approved:minSoc")
         self.assertEqual(calls, [])
 
-    async def test_wrong_transport_and_non_integral_power_are_rejected(self):
+    async def test_wrong_transport_is_rejected_and_fractional_power_is_rounded(self):
         data = await make_bootstrap()
         with self.assertRaisesRegex(ValueError, "wrong_transport"):
             map_zensdk_command(
@@ -199,10 +200,18 @@ class ZenSdkCommandAdapterTests(unittest.IsolatedAsyncioTestCase):
                 data,
                 first_request_id=1,
             )
-        with self.assertRaisesRegex(ValueError, "invalid_power_value"):
-            map_zensdk_command(
-                authorized(output_command(300.5)), data, first_request_id=1
-            )
+        mapped = map_zensdk_command(
+            authorized(output_command(300.5)), data, first_request_id=1
+        )
+        self.assertEqual(mapped.properties["outputLimit"], 300)
+        for invalid_value in (-1, math.nan, math.inf):
+            with self.subTest(invalid_value=invalid_value):
+                with self.assertRaisesRegex(ValueError, "invalid_power_value"):
+                    map_zensdk_command(
+                        authorized(output_command(invalid_value)),
+                        data,
+                        first_request_id=1,
+                    )
 
     async def test_http_failure_is_transport_error_and_never_retried(self):
         data = await make_bootstrap()


### PR DESCRIPTION
## Summary

- adopt the fresh ZenSDK mode and power setpoint once before native control starts regulating
- keep an existing Z-HA-driven charge or discharge as the handover baseline instead of restarting near zero
- normalize finite non-negative ZenSDK power commands to whole watts so fractional regulator outputs are no longer rejected
- publish the combined fix directly as `5.0.0.dev23`

## Validation

- 40 focused tests passed for native handover, ZenSDK commands, command-state feedback, version consistency, and Home Assistant integration
- 589 tests passed in the broader unittest run; three unchanged pytest-based modules could not load locally because pytest is not installed
- Python compile check passed
- `git diff --check` passed

Relates to #408.