### PR TITLE
Harden native single-writer authority

### DIFF
--- a/custom_components/battery_smartflow_ai/native_transport_router.py
+++ b/custom_components/battery_smartflow_ai/native_transport_router.py
@@ -1,0 +1,149 @@
+"""Single-writer authority for native Zendure control transports."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from .core.models import MainDevice, ZendureTransport
+from .zendure_device_matrix import preferred_local_transport
+
+NativeTransportSender = Callable[[Any], Awaitable[Any]]
+
+
+@dataclass(frozen=True, slots=True)
+class AutomaticTransportDecision:
+    """Fail-closed automatic transport selection for one logical device."""
+
+    transport: ZendureTransport | None
+    reason: str
+
+    @property
+    def selected(self) -> bool:
+        return self.transport is not None
+
+
+def automatic_control_transport(device: MainDevice) -> AutomaticTransportDecision:
+    """Resolve one local write transport from all verified device identities."""
+
+    transports = {
+        transport
+        for identity in device.native_identities
+        if (transport := preferred_local_transport(identity)) is not None
+    }
+    if not transports:
+        return AutomaticTransportDecision(None, "local_transport_unsupported")
+    if len(transports) != 1:
+        return AutomaticTransportDecision(None, "local_transport_ambiguous")
+    return AutomaticTransportDecision(next(iter(transports)), "model_family")
+
+
+@dataclass(frozen=True, slots=True)
+class NativeWriteAuthoritySnapshot:
+    """Current single-writer lease; a lease is never transferable."""
+
+    device_id: str | None
+    transport: ZendureTransport | None
+    generation: int
+    synchronized: bool
+    reason: str
+    changed_at: datetime
+
+
+class NativeTransportRouter:
+    """Own exactly one synchronized native writer without runtime fallback."""
+
+    def __init__(self) -> None:
+        self._snapshot = NativeWriteAuthoritySnapshot(
+            None,
+            None,
+            0,
+            False,
+            "not_configured",
+            datetime.now(timezone.utc),
+        )
+
+    @property
+    def snapshot(self) -> NativeWriteAuthoritySnapshot:
+        return self._snapshot
+
+    def select(
+        self,
+        device_id: str | None,
+        transport: ZendureTransport | None,
+    ) -> NativeWriteAuthoritySnapshot:
+        """Select an authority but require fresh synchronization before writes."""
+
+        if (
+            self._snapshot.device_id == device_id
+            and self._snapshot.transport is transport
+        ):
+            return self._snapshot
+        self._snapshot = NativeWriteAuthoritySnapshot(
+            device_id,
+            transport,
+            self._snapshot.generation + 1,
+            False,
+            "awaiting_synchronization" if transport is not None else "not_selected",
+            datetime.now(timezone.utc),
+        )
+        return self._snapshot
+
+    def update_readiness(self, *, ready: bool, reason: str) -> None:
+        """Grant or revoke the selected writer after current-state validation."""
+
+        synchronized = bool(ready and self._snapshot.transport is not None)
+        if (
+            self._snapshot.synchronized == synchronized
+            and self._snapshot.reason == reason
+        ):
+            return
+        generation = self._snapshot.generation
+        if self._snapshot.synchronized and not synchronized:
+            # Invalidates every authorization issued before disconnect/staleness.
+            generation += 1
+        self._snapshot = NativeWriteAuthoritySnapshot(
+            self._snapshot.device_id,
+            self._snapshot.transport,
+            generation,
+            synchronized,
+            reason,
+            datetime.now(timezone.utc),
+        )
+
+    async def execute(
+        self,
+        *,
+        device_id: str,
+        transport: ZendureTransport,
+        generation: int,
+        command: Any,
+        sender: NativeTransportSender,
+    ) -> Any:
+        """Execute once only when the exact current writer lease still matches."""
+
+        authority = self._snapshot
+        if not authority.synchronized:
+            raise RuntimeError("write_authority_not_synchronized")
+        if authority.device_id != device_id:
+            raise RuntimeError("write_authority_device_mismatch")
+        if authority.transport is not transport:
+            raise RuntimeError("write_authority_transport_mismatch")
+        if authority.generation != generation:
+            raise RuntimeError("write_authority_superseded")
+        return await sender(command)
+
+    def diagnostics(self) -> dict[str, Any]:
+        """Expose bounded state without physical identities or credentials."""
+
+        value = self._snapshot
+        return {
+            "selected": value.transport is not None,
+            "transport": value.transport.value if value.transport else None,
+            "generation": value.generation,
+            "synchronized": value.synchronized,
+            "reason": value.reason,
+            "changed_at": value.changed_at,
+        }

--- a/custom_components/battery_smartflow_ai/native_zendure_runtime.py
+++ b/custom_components/battery_smartflow_ai/native_zendure_runtime.py
@@ -31,11 +31,14 @@ from .native_device_command_gate import (
     NativeDeviceCommandGate,
 )
 from .native_device_overview import build_native_device_overview
+from .native_transport_router import (
+    NativeTransportRouter,
+    automatic_control_transport,
+)
 from .zendure_cloud import ZendureCloudClient
 from .zendure_cloud_mqtt import ConnectionState, ZendureCloudMqttTransport
 from .zendure_device_matrix import (
     VerificationLevel,
-    preferred_local_transport,
     resolve_zendure_device,
 )
 from .zendure_first_write import (
@@ -148,6 +151,7 @@ class NativeZendureRuntime:
         self._zensdk_command_adapter: ZendureZenSdkCommandAdapter | None = None
         self._last_command_result: dict[str, Any] | None = None
         self._control_baseline_consumed = False
+        self._transport_router = NativeTransportRouter()
 
     @property
     def configured(self) -> bool:
@@ -206,6 +210,10 @@ class NativeZendureRuntime:
         self._task = asyncio.create_task(self._async_run())
 
     async def async_stop(self) -> None:
+        self._transport_router.update_readiness(
+            ready=False,
+            reason="runtime_stopped",
+        )
         task, self._task = self._task, None
         if task is not None:
             task.cancel()
@@ -348,6 +356,7 @@ class NativeZendureRuntime:
                 ),
                 "local_mqtt": self._local_mqtt_diagnostics(),
                 "last_command_result": self._last_command_result,
+                "write_authority": self._transport_router.diagnostics(),
                 "overview": self.overview_attributes(),
             }
         )
@@ -467,15 +476,31 @@ class NativeZendureRuntime:
                 return self._remember_command_result(_command_result(
                     CommandExecutionStatus.SKIPPED, "native_state_not_fresh"
                 ))
-            control_transport = preferred_local_transport(
-                source_device.native_identities[0]
-            ) if source_device.native_identities else None
+            selection = automatic_control_transport(source_device)
+            control_transport = selection.transport
+            self._transport_router.select(
+                self._selected_device,
+                control_transport,
+            )
             if control_transport is None:
+                self._transport_router.update_readiness(
+                    ready=False,
+                    reason=selection.reason,
+                )
                 return self._remember_command_result(_command_result(
                     CommandExecutionStatus.SKIPPED,
-                    "native_local_transport_unsupported",
+                    f"native_{selection.reason}",
                 ))
-            if not self._control_transport_ready(control_transport):
+            transport_ready = self._control_transport_ready(control_transport)
+            self._transport_router.update_readiness(
+                ready=transport_ready,
+                reason=(
+                    "ready"
+                    if transport_ready
+                    else f"{control_transport.value}_not_ready"
+                ),
+            )
+            if not transport_ready:
                 return self._remember_command_result(_command_result(
                     CommandExecutionStatus.SKIPPED,
                     f"native_{control_transport.value}_not_ready",
@@ -549,8 +574,19 @@ class NativeZendureRuntime:
                     CommandExecutionStatus.SKIPPED,
                     "native_local_transport_not_implemented",
                 ))
+            authority_generation = self._transport_router.snapshot.generation
+
+            async def execute_authorized(authorized):
+                return await self._transport_router.execute(
+                    device_id=authorized.device_id,
+                    transport=authorized.transport,
+                    generation=authority_generation,
+                    command=authorized,
+                    sender=executor,
+                )
+
             gate, transport = await NativeDeviceCommandGate(self._hems_gate).execute(
-                request, context, executor
+                request, context, execute_authorized
             )
             if not gate.accepted or transport is None:
                 return self._remember_command_result(_command_result(
@@ -664,6 +700,10 @@ class NativeZendureRuntime:
         except asyncio.CancelledError:
             raise
         except Exception as error:
+            self._transport_router.update_readiness(
+                ready=False,
+                reason="runtime_error",
+            )
             self._error = _safe_reason(error)
             self._set_status(STATUS_ERROR)
             _LOGGER.warning(
@@ -830,6 +870,47 @@ class NativeZendureRuntime:
                 now=now,
             )
             self._apply_state(result.state)
+        self._refresh_write_authority()
+
+    def _refresh_write_authority(self) -> None:
+        """Continuously revoke or synchronize the one configured writer."""
+
+        if not self._control_enabled or self._selected_device is None:
+            self._transport_router.select(None, None)
+            self._transport_router.update_readiness(
+                ready=False,
+                reason="native_control_disabled",
+            )
+            return
+        device = self._inventory.devices.get(self._selected_device)
+        state = self._states.get(self._selected_device)
+        if device is None:
+            self._transport_router.select(self._selected_device, None)
+            self._transport_router.update_readiness(
+                ready=False,
+                reason="selected_device_missing",
+            )
+            return
+        selection = automatic_control_transport(device)
+        self._transport_router.select(self._selected_device, selection.transport)
+        ready = bool(
+            selection.transport is not None
+            and state is not None
+            and _fresh_native_state(state)
+            and self._control_transport_ready(selection.transport)
+        )
+        self._transport_router.update_readiness(
+            ready=ready,
+            reason=(
+                "ready"
+                if ready
+                else (
+                    selection.reason
+                    if selection.transport is None
+                    else f"{selection.transport.value}_not_ready"
+                )
+            ),
+        )
 
     def _hems_activity_diagnostics(self, system_id: str) -> dict[str, Any]:
         if self._normalizer is None:
@@ -978,7 +1059,7 @@ class NativeZendureRuntime:
         device = self._inventory.devices.get(self._selected_device)
         if device is None or not device.native_identities:
             return None
-        return preferred_local_transport(device.native_identities[0])
+        return automatic_control_transport(device).transport
 
     def _control_sensor_state(self) -> str:
         transport = self._selected_local_transport()

--- a/docs/architecture/zendure-local-mqtt-v5.0.0.md
+++ b/docs/architecture/zendure-local-mqtt-v5.0.0.md
@@ -57,6 +57,19 @@ The adapter publishes to the exact discovered product/device
 property readback. A newer target supersedes an older pending verification;
 commands are not retried or replayed after reconnect.
 
+## Single-writer authority
+
+Transport selection inspects every known identity of the logical main device.
+All identities must resolve to the same verified local model family; unknown
+or conflicting results remain read-only. The selected writer receives a
+generation-bound authority only after current telemetry confirms that the
+transport is ready.
+
+Startup, disconnect and stale data revoke synchronization. Recovery requires
+a fresh validation and starts a new authority generation, so an old or pending
+command cannot be replayed after reconnect or moved to another transport.
+Cloud MQTT and the Z-HA entity backend are never automatic write fallbacks.
+
 ## Field boundary
 
 Automated tests prove filtering, identity, normalization provenance, payload

--- a/tests/test_native_power_controller.py
+++ b/tests/test_native_power_controller.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
 import sys
-from types import ModuleType
-from types import SimpleNamespace
 import unittest
+from datetime import datetime, timedelta, timezone
+from types import ModuleType, SimpleNamespace
 
 from support import bootstrap
 
@@ -30,24 +29,27 @@ from custom_components.battery_smartflow_ai.core.models import (  # noqa: E402
     ZendureTransport,
 )
 from custom_components.battery_smartflow_ai.native_zendure_runtime import (  # noqa: E402
-    NativeZendureRuntime,
     STATUS_OBSERVING,
+    NativeZendureRuntime,
 )
-from custom_components.battery_smartflow_ai.zendure_cloud_mqtt import ConnectionState  # noqa: E402
+from custom_components.battery_smartflow_ai.zendure_cloud_mqtt import (
+    ConnectionState,  # noqa: E402
+)
 from custom_components.battery_smartflow_ai.zendure_cloud_mqtt_commands import (  # noqa: E402
     CloudCommandResult,
     CloudCommandStatus,
 )
-from custom_components.battery_smartflow_ai.zendure_device_matrix import VerificationLevel  # noqa: E402
-from custom_components.battery_smartflow_ai.zendure_zensdk_commands import (  # noqa: E402
-    ZenSdkCommandResult,
-    ZenSdkCommandStatus,
+from custom_components.battery_smartflow_ai.zendure_device_matrix import (
+    VerificationLevel,  # noqa: E402
 )
 from custom_components.battery_smartflow_ai.zendure_local_mqtt_commands import (  # noqa: E402
     LocalMqttCommandResult,
     LocalMqttCommandStatus,
 )
-
+from custom_components.battery_smartflow_ai.zendure_zensdk_commands import (  # noqa: E402
+    ZenSdkCommandResult,
+    ZenSdkCommandStatus,
+)
 
 DEVICE = "cloud_mqtt:main-1"
 NOW = datetime.now(timezone.utc)
@@ -203,6 +205,53 @@ class NativePowerControllerTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result.reason, "native_local_mqtt_not_ready")
         self.assertEqual(target._local_transport.commands, [])
         self.assertEqual(target._zensdk_command_adapter.commands, [])
+        self.assertEqual(target._transport.commands, [])
+
+    async def test_conflicting_model_families_never_select_a_writer(self):
+        target = runtime()
+        current = target._inventory.devices[DEVICE]
+        legacy = NativeDeviceIdentity(
+            ZendureTransport.CLOUD_MQTT,
+            device_id="legacy-alias",
+            product_model="Hyper 2000",
+        )
+        target._inventory = DeviceInventory(devices=(MainDevice(
+            current.system_id,
+            current.display_name,
+            model=current.model,
+            profile_key=current.profile_key,
+            selected_transport=current.selected_transport,
+            available_transports=current.available_transports,
+            native_identities=(*current.native_identities, legacy),
+        ),))
+
+        result = await target.async_execute_device_command(DeviceCommand(
+            "output", output_limit_w=450, should_write_output=True,
+        ))
+
+        self.assertEqual(result.status, CommandExecutionStatus.SKIPPED)
+        self.assertEqual(result.reason, "native_local_transport_ambiguous")
+        self.assertEqual(target._zensdk_command_adapter.commands, [])
+        self.assertEqual(target._transport.commands, [])
+
+    async def test_disconnect_revokes_authority_without_cloud_or_zha_fallback(self):
+        target = runtime()
+        command = DeviceCommand(
+            "output", output_limit_w=450, should_write_output=True,
+        )
+        applied = await target.async_execute_device_command(command)
+        initial_generation = target._transport_router.snapshot.generation
+        target._zensdk_last_success[DEVICE] = NOW - timedelta(minutes=5)
+
+        blocked = await target.async_execute_device_command(command)
+
+        self.assertEqual(applied.status, CommandExecutionStatus.APPLIED)
+        self.assertEqual(blocked.reason, "native_zensdk_not_ready")
+        self.assertGreater(
+            target._transport_router.snapshot.generation,
+            initial_generation,
+        )
+        self.assertEqual(len(target._zensdk_command_adapter.commands), 1)
         self.assertEqual(target._transport.commands, [])
     async def test_fresh_running_setpoint_is_consumed_once_as_handover_baseline(self):
         target = runtime(current_state=state(output_w=950, discharge_w=947))

--- a/tests/test_native_transport_router.py
+++ b/tests/test_native_transport_router.py
@@ -1,0 +1,145 @@
+"""Automatic native transport selection and single-writer authority tests."""
+
+from __future__ import annotations
+
+import unittest
+
+from support import bootstrap
+
+bootstrap()
+
+from custom_components.battery_smartflow_ai.core.models import (  # noqa: E402
+    MainDevice,
+    NativeDeviceIdentity,
+    ZendureTransport,
+)
+from custom_components.battery_smartflow_ai.native_transport_router import (  # noqa: E402
+    NativeTransportRouter,
+    automatic_control_transport,
+)
+
+
+def identity(model: str) -> NativeDeviceIdentity:
+    return NativeDeviceIdentity(
+        ZendureTransport.CLOUD_MQTT,
+        device_id=model,
+        product_model=model,
+    )
+
+
+def device(*models: str) -> MainDevice:
+    return MainDevice(
+        "system-1",
+        "Main",
+        native_identities=tuple(identity(model) for model in models),
+    )
+
+
+class AutomaticTransportSelectionTests(unittest.TestCase):
+    def test_zensdk_family_is_selected_without_user_transport_option(self):
+        result = automatic_control_transport(device("SolarFlow 2400 AC"))
+
+        self.assertEqual(result.transport, ZendureTransport.ZENSDK)
+        self.assertEqual(result.reason, "model_family")
+
+    def test_legacy_family_is_selected_without_user_transport_option(self):
+        result = automatic_control_transport(device("Hyper 2000"))
+
+        self.assertEqual(result.transport, ZendureTransport.LOCAL_MQTT)
+
+    def test_unknown_or_conflicting_identity_fails_closed(self):
+        unknown = automatic_control_transport(device("Unknown"))
+        conflict = automatic_control_transport(
+            device("Hyper 2000", "SolarFlow 2400 AC")
+        )
+
+        self.assertIsNone(unknown.transport)
+        self.assertEqual(unknown.reason, "local_transport_unsupported")
+        self.assertIsNone(conflict.transport)
+        self.assertEqual(conflict.reason, "local_transport_ambiguous")
+
+
+class NativeTransportRouterTests(unittest.IsolatedAsyncioTestCase):
+    async def test_restart_selection_requires_fresh_synchronization(self):
+        router = NativeTransportRouter()
+        selected = router.select("system-1", ZendureTransport.ZENSDK)
+        calls = []
+
+        with self.assertRaisesRegex(RuntimeError, "not_synchronized"):
+            await router.execute(
+                device_id="system-1",
+                transport=ZendureTransport.ZENSDK,
+                generation=selected.generation,
+                command="command",
+                sender=lambda command: calls.append(command),
+            )
+        self.assertEqual(calls, [])
+
+    async def test_exact_selected_sender_is_invoked_once(self):
+        router = NativeTransportRouter()
+        router.select("system-1", ZendureTransport.LOCAL_MQTT)
+        router.update_readiness(ready=True, reason="ready")
+        authority = router.snapshot
+        calls = []
+
+        async def sender(command):
+            calls.append(command)
+            return "sent"
+
+        result = await router.execute(
+            device_id="system-1",
+            transport=ZendureTransport.LOCAL_MQTT,
+            generation=authority.generation,
+            command="command",
+            sender=sender,
+        )
+
+        self.assertEqual(result, "sent")
+        self.assertEqual(calls, ["command"])
+
+    async def test_disconnect_revokes_old_command_generation(self):
+        router = NativeTransportRouter()
+        router.select("system-1", ZendureTransport.ZENSDK)
+        router.update_readiness(ready=True, reason="ready")
+        old_generation = router.snapshot.generation
+        router.update_readiness(ready=False, reason="zensdk_not_ready")
+        router.update_readiness(ready=True, reason="ready")
+        calls = []
+
+        async def sender(command):
+            calls.append(command)
+
+        with self.assertRaisesRegex(RuntimeError, "superseded"):
+            await router.execute(
+                device_id="system-1",
+                transport=ZendureTransport.ZENSDK,
+                generation=old_generation,
+                command="old-command",
+                sender=sender,
+            )
+        self.assertEqual(calls, [])
+
+    async def test_transport_change_never_replays_old_command(self):
+        router = NativeTransportRouter()
+        router.select("system-1", ZendureTransport.ZENSDK)
+        router.update_readiness(ready=True, reason="ready")
+        old_generation = router.snapshot.generation
+        router.select("system-1", ZendureTransport.LOCAL_MQTT)
+        calls = []
+
+        async def sender(command):
+            calls.append(command)
+
+        with self.assertRaisesRegex(RuntimeError, "not_synchronized"):
+            await router.execute(
+                device_id="system-1",
+                transport=ZendureTransport.ZENSDK,
+                generation=old_generation,
+                command="old-command",
+                sender=sender,
+            )
+        self.assertEqual(calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #343.

- add a dedicated native single-writer authority and routing boundary
- derive the local control transport from every known device identity instead of identity order or a user-selected transport
- fail closed for unknown or conflicting model-family classifications
- require fresh synchronization after startup before granting write authority
- revoke the current authority generation immediately when telemetry becomes stale, the transport disconnects, or the runtime stops
- prevent pending commands from being replayed after reconnect or transferred to another device or transport
- keep Cloud MQTT and the Home Assistant/Z-HA backend out of the native fallback path
- expose privacy-safe write-authority diagnostics

This completes the automatic transport-selection and write-isolation layer built on the ZenSDK and Legacy Local MQTT adapters. The real-device acceptance of Legacy telemetry and commands remains tracked separately in #337, #338, and #339.

No version change or development release is included; `5.0.0.dev24` remains the current field-test build.

## Validation

- 668 tests passed
- 421 subtests passed
- targeted Ruff checks passed
- diff whitespace check passed