### PR TITLE
Add native transport reliability metrics

### DIFF
--- a/custom_components/battery_smartflow_ai/coordinator.py
+++ b/custom_components/battery_smartflow_ai/coordinator.py
@@ -5830,6 +5830,17 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self._store_command_effectiveness_result(
                 command_effectiveness_result
             )
+            native_runtime = getattr(self, "native_zendure", None)
+            if (
+                native_runtime is not None
+                and native_runtime.control_enabled
+                and hasattr(native_runtime, "observe_command_effectiveness")
+            ):
+                native_runtime.observe_command_effectiveness(
+                    direction=str(command_effectiveness_result.state.direction),
+                    status=str(command_effectiveness_result.status),
+                    observed_at=dt_util.as_utc(now),
+                )
 
             effectiveness_retry_direction = (
                 command_effectiveness_result.retry_direction

--- a/custom_components/battery_smartflow_ai/native_command_verification.py
+++ b/custom_components/battery_smartflow_ai/native_command_verification.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import StrEnum
 from hashlib import sha256
-import math
 from typing import Any
 from uuid import uuid4
 
@@ -295,6 +295,11 @@ class NativeCommandVerificationManager:
                 _public_device_id(key): value for key, value in self._failures.items()
             },
         }
+
+    def measurements(self) -> tuple[CommandVerification, ...]:
+        """Return the bounded in-memory history for aggregate diagnostics."""
+
+        return tuple(self._commands.values())
 
     def _mutable(self, command_id: str) -> CommandVerification:
         command = self._commands[command_id]

--- a/custom_components/battery_smartflow_ai/native_transport_metrics.py
+++ b/custom_components/battery_smartflow_ai/native_transport_metrics.py
@@ -1,0 +1,241 @@
+"""Privacy-safe, model-specific native transport measurements."""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime
+from hashlib import sha256
+from statistics import median
+from typing import Any, Iterable
+
+from .core.models import ZendureTransport
+
+_MAX_TELEMETRY_SAMPLES = 500
+_PERCENTILE_MIN_SAMPLES = 20
+
+
+@dataclass(frozen=True, slots=True)
+class TransportDeviceContext:
+    """Non-secret grouping fields for one physical test device."""
+
+    model: str
+    firmware: str | None = None
+
+
+@dataclass(slots=True)
+class _TelemetrySeries:
+    timestamps: list[datetime] = field(default_factory=list)
+    message_count: int = 0
+    retained_messages: int = 0
+    reconnects: int = 0
+    disconnects: int = 0
+    last_connected: bool | None = None
+
+
+class NativeTransportMetrics:
+    """Collect comparable command and telemetry metrics without identifiers."""
+
+    def __init__(self) -> None:
+        self._contexts: dict[str, TransportDeviceContext] = {}
+        self._telemetry: dict[tuple[str, ZendureTransport], _TelemetrySeries] = {}
+
+    def register_device(
+        self,
+        device_id: str,
+        *,
+        model: str | None,
+        firmware: str | None = None,
+    ) -> None:
+        self._contexts[device_id] = TransportDeviceContext(
+            _bounded_label(model, "unknown"),
+            _bounded_label(firmware, None),
+        )
+
+    def observe_telemetry(
+        self,
+        *,
+        device_id: str,
+        transport: ZendureTransport,
+        observed_at: datetime,
+        retained: bool = False,
+    ) -> None:
+        series = self._series(device_id, transport)
+        series.message_count += 1
+        if not series.timestamps or observed_at > series.timestamps[-1]:
+            series.timestamps.append(observed_at)
+            if len(series.timestamps) > _MAX_TELEMETRY_SAMPLES:
+                del series.timestamps[:-_MAX_TELEMETRY_SAMPLES]
+        if retained:
+            series.retained_messages += 1
+
+    def observe_connection(
+        self,
+        *,
+        device_id: str,
+        transport: ZendureTransport,
+        connected: bool,
+    ) -> None:
+        series = self._series(device_id, transport)
+        current = bool(connected)
+        if series.last_connected is False and current:
+            series.reconnects += 1
+        elif series.last_connected is True and not current:
+            series.disconnects += 1
+        series.last_connected = current
+
+    def export(self, commands: Iterable[Any]) -> dict[str, Any]:
+        """Aggregate comparable samples; omit percentiles for small samples."""
+
+        grouped: dict[tuple[str, str, str | None, str, str], list[Any]] = defaultdict(list)
+        for command in commands:
+            context = self._contexts.get(
+                command.device_id,
+                TransportDeviceContext("unknown"),
+            )
+            grouped[(
+                command.device_id,
+                context.model,
+                context.firmware,
+                command.transport.value,
+                command.command_type,
+            )].append(command)
+
+        command_groups = []
+        for key, samples in sorted(grouped.items(), key=lambda item: item[0][1:]):
+            device_id, model, firmware, transport, command_type = key
+            statuses = Counter(str(item.status) for item in samples)
+            effects = Counter(str(item.effect_status) for item in samples)
+            timeout_count = sum(
+                count for status, count in statuses.items()
+                if "timeout" in status
+            )
+            mismatch_count = sum(
+                count for status, count in statuses.items()
+                if "mismatch" in status or "contradictory" in status
+            )
+            transport_error_count = statuses.get("transport_error", 0)
+            superseded_count = statuses.get("superseded", 0)
+            command_groups.append({
+                "device": _public_device_id(device_id),
+                "model": model,
+                "firmware": firmware,
+                "transport": transport,
+                "command_type": command_type,
+                "sample_count": len(samples),
+                "status_counts": dict(sorted(statuses.items())),
+                "effect_counts": dict(sorted(effects.items())),
+                "timeout_count": timeout_count,
+                "timeout_rate": _rate(timeout_count, len(samples)),
+                "mismatch_count": mismatch_count,
+                "mismatch_rate": _rate(mismatch_count, len(samples)),
+                "transport_error_count": transport_error_count,
+                "transport_error_rate": _rate(
+                    transport_error_count,
+                    len(samples),
+                ),
+                "superseded_count": superseded_count,
+                "superseded_rate": _rate(superseded_count, len(samples)),
+                "latency_seconds": {
+                    "gate_to_send": _statistics(
+                        _latency(item.gate_at, item.sent_at) for item in samples
+                    ),
+                    "send_to_transport": _statistics(
+                        _latency(item.sent_at, item.transport_at) for item in samples
+                    ),
+                    "send_to_readback": _statistics(
+                        _latency(item.sent_at, item.readback_at) for item in samples
+                    ),
+                    "send_to_effect": _statistics(
+                        _latency(item.sent_at, item.effect_at) for item in samples
+                    ),
+                },
+            })
+
+        telemetry_groups = []
+        for (device_id, transport), series in sorted(
+            self._telemetry.items(),
+            key=lambda item: (
+                self._contexts.get(item[0][0], TransportDeviceContext("unknown")).model,
+                item[0][1].value,
+            ),
+        ):
+            context = self._contexts.get(device_id, TransportDeviceContext("unknown"))
+            intervals = [
+                (later - earlier).total_seconds()
+                for earlier, later in zip(series.timestamps, series.timestamps[1:])
+                if later >= earlier
+            ]
+            telemetry_groups.append({
+                "device": _public_device_id(device_id),
+                "model": context.model,
+                "firmware": context.firmware,
+                "transport": transport.value,
+                "message_count": series.message_count,
+                "interval_sample_count": max(0, len(series.timestamps) - 1),
+                "update_interval_seconds": _statistics(intervals),
+                "retained_message_count": series.retained_messages,
+                "disconnect_count": series.disconnects,
+                "reconnect_count": series.reconnects,
+                "connected": series.last_connected,
+            })
+
+        return {
+            "schema": "battery_smartflow_ai.native_transport_metrics",
+            "schema_version": 1,
+            "percentiles_minimum_samples": _PERCENTILE_MIN_SAMPLES,
+            "command_groups": command_groups,
+            "telemetry_groups": telemetry_groups,
+        }
+
+    def _series(
+        self,
+        device_id: str,
+        transport: ZendureTransport,
+    ) -> _TelemetrySeries:
+        return self._telemetry.setdefault((device_id, transport), _TelemetrySeries())
+
+
+def _statistics(values: Iterable[float | None]) -> dict[str, Any]:
+    samples = sorted(float(item) for item in values if item is not None)
+    if not samples:
+        return {"count": 0, "median": None, "minimum": None, "maximum": None,
+                "p90": None, "p95": None}
+    enough = len(samples) >= _PERCENTILE_MIN_SAMPLES
+    return {
+        "count": len(samples),
+        "median": round(median(samples), 3),
+        "minimum": round(samples[0], 3),
+        "maximum": round(samples[-1], 3),
+        "p90": round(_percentile(samples, 0.90), 3) if enough else None,
+        "p95": round(_percentile(samples, 0.95), 3) if enough else None,
+    }
+
+
+def _percentile(samples: list[float], fraction: float) -> float:
+    index = (len(samples) - 1) * fraction
+    lower = int(index)
+    upper = min(lower + 1, len(samples) - 1)
+    weight = index - lower
+    return samples[lower] * (1.0 - weight) + samples[upper] * weight
+
+
+def _rate(count: int, total: int) -> float:
+    return round(count / total, 4) if total else 0.0
+
+
+def _latency(start: datetime | None, end: datetime | None) -> float | None:
+    if start is None or end is None:
+        return None
+    return max(0.0, (end - start).total_seconds())
+
+
+def _public_device_id(value: str) -> str:
+    return f"device_{sha256(value.encode('utf-8')).hexdigest()[:12]}"
+
+
+def _bounded_label(value: Any, fallback: str | None) -> str | None:
+    if value is None:
+        return fallback
+    text = str(value).strip()
+    return text[:80] if text else fallback

--- a/custom_components/battery_smartflow_ai/native_zendure_runtime.py
+++ b/custom_components/battery_smartflow_ai/native_zendure_runtime.py
@@ -24,13 +24,17 @@ from .core.models import (
     ValueValidity,
     ZendureTransport,
 )
-from .native_command_verification import NativeCommandVerificationManager
+from .native_command_verification import (
+    EffectStatus,
+    NativeCommandVerificationManager,
+)
 from .native_device_command_gate import (
     NativeCommandContext,
     NativeCommandRequest,
     NativeDeviceCommandGate,
 )
 from .native_device_overview import build_native_device_overview
+from .native_transport_metrics import NativeTransportMetrics
 from .native_transport_router import (
     NativeTransportRouter,
     automatic_control_transport,
@@ -148,6 +152,7 @@ class NativeZendureRuntime:
         self._write_lock = asyncio.Lock()
         self._write_sequence = 0
         self._command_verification = NativeCommandVerificationManager()
+        self._transport_metrics = NativeTransportMetrics()
         self._zensdk_command_adapter: ZendureZenSdkCommandAdapter | None = None
         self._last_command_result: dict[str, Any] | None = None
         self._control_baseline_consumed = False
@@ -203,6 +208,45 @@ class NativeZendureRuntime:
             self._control_baseline_consumed = True
             return ("idle", 0, 0)
         return None
+
+    def observe_command_effectiveness(
+        self,
+        *,
+        direction: str,
+        status: str,
+        observed_at: datetime,
+    ) -> bool:
+        """Correlate neutral physical-effect feedback with a native command."""
+
+        if self._selected_device is None:
+            return False
+        target_key = {
+            "input": "inputLimit",
+            "output": "outputLimit",
+        }.get(str(direction))
+        if target_key is None:
+            return False
+        command = self._command_verification.active_for(
+            self._selected_device,
+            target_key,
+        )
+        if command is None or command.readback_at is None:
+            return False
+        if status == "effective":
+            effect_status = EffectStatus.CONFIRMED
+            reason = "measured_power_active"
+        elif status == "exhausted":
+            effect_status = EffectStatus.TIMEOUT
+            reason = "maximum_retries_reached"
+        else:
+            return False
+        self._command_verification.effect(
+            command.command_id,
+            status=effect_status,
+            at=observed_at,
+            reason=reason,
+        )
+        return True
 
     def start(self) -> None:
         if not self.configured or self._task is not None:
@@ -350,6 +394,9 @@ class NativeZendureRuntime:
                     if self._first_write_result is not None else None
                 ),
                 "command_verification": self._command_verification.diagnostics(),
+                "transport_metrics": self._transport_metrics.export(
+                    self._command_verification.measurements()
+                ),
                 "cloud_command_verification": (
                     self._transport.command_diagnostics
                     if self._transport is not None else {"commands": []}
@@ -852,6 +899,28 @@ class NativeZendureRuntime:
             return
         now = datetime.now(timezone.utc)
         for system_id in tuple(self._inventory.devices):
+            if self._transport is not None:
+                self._transport_metrics.observe_connection(
+                    device_id=system_id,
+                    transport=ZendureTransport.CLOUD_MQTT,
+                    connected=self._transport.state is ConnectionState.CONNECTED,
+                )
+            if self._local_transport is not None:
+                if system_id in self._local_transport.device_states:
+                    self._transport_metrics.observe_connection(
+                        device_id=system_id,
+                        transport=ZendureTransport.LOCAL_MQTT,
+                        connected=(
+                            self._local_transport.state
+                            is ConnectionState.CONNECTED
+                        ),
+                    )
+            if system_id in self._zensdk_last_result:
+                self._transport_metrics.observe_connection(
+                    device_id=system_id,
+                    transport=ZendureTransport.ZENSDK,
+                    connected=bool(self._zensdk_health(system_id, now)["available"]),
+                )
             self._normalizer.set_hems_monitoring(
                 system_id,
                 (
@@ -1002,6 +1071,17 @@ class NativeZendureRuntime:
         if self._normalizer is None:
             return
         for message in messages:
+            device_id = message.device_candidate_id
+            try:
+                message_transport = ZendureTransport(str(message.transport))
+            except ValueError:
+                message_transport = None
+            if device_id is not None and message_transport is not None:
+                self._transport_metrics.observe_telemetry(
+                    device_id=device_id,
+                    transport=message_transport,
+                    observed_at=message.received_at,
+                )
             if (
                 message.transport == "zensdk"
                 and self._zensdk_command_adapter is not None
@@ -1074,6 +1154,11 @@ class NativeZendureRuntime:
         device = self._inventory.devices[state.system_id]
         identity = device.native_identities[0] if device.native_identities else None
         profile = resolve_zendure_device(identity) if identity is not None else None
+        self._transport_metrics.register_device(
+            state.system_id,
+            model=state.model or device.model or device.profile_key,
+            firmware=_value(state.firmware),
+        )
         capability = (
             profile.hems_status if profile is not None else VerificationLevel.UNKNOWN
         )

--- a/docs/architecture/native-transport-metrics-v5.0.0.md
+++ b/docs/architecture/native-transport-metrics-v5.0.0.md
@@ -1,0 +1,53 @@
+# Native transport measurements for V5.0.0
+
+Issue #344 measures whether each automatically selected local transport carries
+neutral BSFAI commands and telemetry reliably. Measurements never select a
+write transport and never enable fallback.
+
+## Metrics schema
+
+The privacy-safe native diagnostics include
+`battery_smartflow_ai.native_transport_metrics` schema version 1. Command
+samples are grouped by pseudonymized physical device, model, firmware,
+transport and command type. They expose separate statistics for:
+
+- gate to send;
+- send to transport response;
+- send to fresh readback;
+- send to physical effect, where observable;
+- neutral status/effect counts plus timeout, mismatch, transport-error and
+  superseded counts and rates.
+
+Telemetry samples are grouped by device, model, firmware and transport. They
+expose update-interval statistics plus disconnect and reconnect counts. Only a
+bounded in-memory sample is retained. Median, minimum and maximum remain useful
+for small field samples; p90 and p95 are deliberately omitted until at least 20
+samples exist.
+
+The export contains no serial number, device key, broker address, IP address,
+token, username, password or command payload. Device identity is represented by
+a one-way truncated hash that is stable only for grouping the same installation.
+
+## Controlled SF2400AC baseline
+
+The first controlled measurement used one SF2400AC with V5 development build
+5.0.0.dev15 and five reversible 0 -> 1 -> 0 W output-limit cycles under the
+same Home Assistant installation and network conditions.
+
+- direct ZenSDK confirmed readback median: 1.528 seconds;
+- Z-HA end-to-end entity-state median: 2.994 seconds;
+- observed reduction under this setup: approximately 49 percent.
+
+The Z-HA number measures from the Home Assistant service request to the
+confirmed Z-HA entity state, so it is not a pure network-latency comparison.
+This is first-device evidence, not a performance guarantee for another model,
+firmware, network or installation. It does not validate Cloud MQTT or Legacy
+Local MQTT.
+
+## Outstanding field measurements
+
+Longer runs must still cover command types, restarts, reconnects, idle and
+active regulation, Near-Zero behavior and physical effect. Hyper 2000 and
+SolarFlow Hub 2000 require separate Local MQTT versus Z-HA measurements on real
+already-provisioned Legacy hardware. Results remain attached to their exact
+model, firmware, transport and test conditions.

--- a/tests/test_native_power_controller.py
+++ b/tests/test_native_power_controller.py
@@ -28,6 +28,10 @@ from custom_components.battery_smartflow_ai.core.models import (  # noqa: E402
     ReportedDeviceSetpoints,
     ZendureTransport,
 )
+from custom_components.battery_smartflow_ai.native_command_verification import (  # noqa: E402
+    CommandVerificationStatus,
+    ReadbackPolicy,
+)
 from custom_components.battery_smartflow_ai.native_zendure_runtime import (  # noqa: E402
     STATUS_OBSERVING,
     NativeZendureRuntime,
@@ -175,6 +179,56 @@ def legacy_runtime(*, current_state=None):
 
 
 class NativePowerControllerTests(unittest.IsolatedAsyncioTestCase):
+    async def test_native_effectiveness_confirms_physical_effect_separately(self):
+        target = runtime()
+        verification = target._command_verification.prepare(
+            device_id=DEVICE,
+            command_type="outputLimit",
+            target_key="outputLimit",
+            transport=ZendureTransport.ZENSDK,
+            requested_value=450,
+            final_value=450,
+            readback=ReadbackPolicy("outputLimit", 450),
+            prepared_at=NOW - timedelta(seconds=3),
+        )
+        target._command_verification.gate(
+            verification.command_id,
+            accepted=True,
+            at=NOW - timedelta(seconds=2.9),
+        )
+        target._command_verification.sent(
+            verification.command_id,
+            at=NOW - timedelta(seconds=2.8),
+        )
+        target._command_verification.transport_result(
+            verification.command_id,
+            ok=True,
+            at=NOW - timedelta(seconds=2.7),
+        )
+        target._command_verification.observe_readback(
+            verification.command_id,
+            device_id=DEVICE,
+            property_name="outputLimit",
+            value=450,
+            observed_at=NOW - timedelta(seconds=2),
+        )
+
+        confirmed = target.observe_command_effectiveness(
+            direction="output",
+            status="effective",
+            observed_at=NOW,
+        )
+
+        self.assertTrue(confirmed)
+        self.assertEqual(
+            verification.status,
+            CommandVerificationStatus.EFFECT_CONFIRMED,
+        )
+        self.assertEqual(
+            verification.diagnostics()["send_to_effect_seconds"],
+            2.8,
+        )
+
     async def test_legacy_device_routes_exactly_once_to_local_mqtt(self):
         target = legacy_runtime()
 

--- a/tests/test_native_transport_metrics.py
+++ b/tests/test_native_transport_metrics.py
@@ -1,0 +1,161 @@
+"""Model-specific, privacy-safe transport metrics tests."""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timedelta, timezone
+
+from support import bootstrap
+
+bootstrap()
+
+from custom_components.battery_smartflow_ai.core.models import (
+    ZendureTransport,  # noqa: E402
+)
+from custom_components.battery_smartflow_ai.native_command_verification import (  # noqa: E402
+    EffectStatus,
+    NativeCommandVerificationManager,
+    ReadbackPolicy,
+)
+from custom_components.battery_smartflow_ai.native_transport_metrics import (  # noqa: E402
+    NativeTransportMetrics,
+)
+
+NOW = datetime(2026, 9, 6, 12, 0, tzinfo=timezone.utc)
+DEVICE = "private-serial-and-device-key"
+
+
+def completed_command(
+    manager: NativeCommandVerificationManager,
+    *,
+    index: int,
+):
+    prepared_at = NOW + timedelta(seconds=index * 2)
+    command = manager.prepare(
+        device_id=DEVICE,
+        command_type="outputLimit",
+        target_key=f"outputLimit-{index}",
+        transport=ZendureTransport.ZENSDK,
+        requested_value=100 + index,
+        final_value=100 + index,
+        readback=ReadbackPolicy("outputLimit", 100 + index),
+        prepared_at=prepared_at,
+    )
+    manager.gate(
+        command.command_id,
+        accepted=True,
+        at=prepared_at + timedelta(milliseconds=10),
+    )
+    manager.sent(
+        command.command_id,
+        at=prepared_at + timedelta(milliseconds=20),
+    )
+    manager.transport_result(
+        command.command_id,
+        ok=True,
+        status="http_200",
+        at=prepared_at + timedelta(milliseconds=40),
+    )
+    manager.observe_readback(
+        command.command_id,
+        device_id=DEVICE,
+        property_name="outputLimit",
+        value=100 + index,
+        observed_at=prepared_at + timedelta(milliseconds=120 + index),
+    )
+    manager.effect(
+        command.command_id,
+        status=EffectStatus.CONFIRMED,
+        at=prepared_at + timedelta(milliseconds=220 + index),
+    )
+    return command
+
+
+class NativeTransportMetricsTests(unittest.TestCase):
+    def test_command_latencies_are_grouped_by_model_firmware_and_transport(self):
+        manager = NativeCommandVerificationManager(history_limit=30)
+        metrics = NativeTransportMetrics()
+        metrics.register_device(
+            DEVICE,
+            model="SolarFlow 2400 AC",
+            firmware="1.2.3",
+        )
+        for index in range(20):
+            completed_command(manager, index=index)
+
+        group = metrics.export(manager.measurements())["command_groups"][0]
+
+        self.assertEqual(group["model"], "SolarFlow 2400 AC")
+        self.assertEqual(group["firmware"], "1.2.3")
+        self.assertEqual(group["transport"], "zensdk")
+        self.assertEqual(group["sample_count"], 20)
+        self.assertEqual(group["timeout_rate"], 0.0)
+        self.assertEqual(group["transport_error_rate"], 0.0)
+        self.assertEqual(group["latency_seconds"]["send_to_readback"]["count"], 20)
+        self.assertIsNotNone(group["latency_seconds"]["send_to_readback"]["p95"])
+
+    def test_small_samples_do_not_claim_percentile_precision(self):
+        manager = NativeCommandVerificationManager()
+        metrics = NativeTransportMetrics()
+        completed_command(manager, index=0)
+
+        stats = metrics.export(manager.measurements())["command_groups"][0][
+            "latency_seconds"
+        ]["send_to_readback"]
+
+        self.assertEqual(stats["count"], 1)
+        self.assertEqual(stats["median"], 0.1)
+        self.assertIsNone(stats["p90"])
+        self.assertIsNone(stats["p95"])
+
+    def test_telemetry_interval_and_reconnects_are_separate(self):
+        metrics = NativeTransportMetrics()
+        metrics.register_device(DEVICE, model="Hyper 2000")
+        metrics.observe_connection(
+            device_id=DEVICE,
+            transport=ZendureTransport.LOCAL_MQTT,
+            connected=True,
+        )
+        metrics.observe_connection(
+            device_id=DEVICE,
+            transport=ZendureTransport.LOCAL_MQTT,
+            connected=False,
+        )
+        metrics.observe_connection(
+            device_id=DEVICE,
+            transport=ZendureTransport.LOCAL_MQTT,
+            connected=True,
+        )
+        for offset in (0, 2, 5):
+            metrics.observe_telemetry(
+                device_id=DEVICE,
+                transport=ZendureTransport.LOCAL_MQTT,
+                observed_at=NOW + timedelta(seconds=offset),
+            )
+
+        group = metrics.export(())["telemetry_groups"][0]
+
+        self.assertEqual(group["disconnect_count"], 1)
+        self.assertEqual(group["reconnect_count"], 1)
+        self.assertEqual(group["update_interval_seconds"]["median"], 2.5)
+
+    def test_export_pseudonymizes_identity_and_contains_no_secrets(self):
+        manager = NativeCommandVerificationManager()
+        metrics = NativeTransportMetrics()
+        metrics.register_device(
+            DEVICE,
+            model="SolarFlow 2400 AC",
+            firmware="1.2.3",
+        )
+        completed_command(manager, index=0)
+
+        exported = repr(metrics.export(manager.measurements()))
+
+        self.assertNotIn(DEVICE, exported)
+        self.assertNotIn("token", exported.lower())
+        self.assertNotIn("password", exported.lower())
+        self.assertIn("device_", exported)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements the measurement-infrastructure part of #344.

- aggregate native command timing separately for gate-to-send, transport response, fresh readback, and physical effect
- group measurements by pseudonymized device, model, firmware, transport, and command type
- report median/minimum/maximum and expose p90/p95 only once at least 20 samples exist
- count and rate timeout, mismatch, transport-error, and superseded outcomes
- track bounded telemetry update intervals plus disconnect and reconnect transitions per transport
- correlate the existing neutral command-effectiveness result with native verification without changing regulation parameters
- include the privacy-safe metrics schema in Home Assistant diagnostics
- document the controlled SF2400AC Dev15 baseline and its first-device/method limitations

The implementation does not select transports, tune regulation, enable fallback, or claim unmeasured Legacy performance.

## Validation

- 673 tests passed
- 421 subtests passed
- targeted Ruff checks passed
- diff whitespace check passed

## Remaining field scope

Issue #344 intentionally remains open after this PR. Longer model-/firmware-specific runs, Near-Zero comparisons, restart/reconnect scenarios, and separate Hyper 2000 / SolarFlow Hub 2000 Local MQTT measurements still require real hardware. No version change or development release is included; `5.0.0.dev24` remains the current field-test build.