### PR TITLE
Limit initial sync capture retention

### DIFF
--- a/custom_components/battery_smartflow_ai/zendure_initial_sync.py
+++ b/custom_components/battery_smartflow_ai/zendure_initial_sync.py
@@ -3,14 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+import json
+import os
+import tempfile
+import time
 from base64 import b64encode
 from dataclasses import dataclass
 from datetime import datetime, timezone
-import json
-import os
 from pathlib import Path
-import tempfile
-import time
 from typing import Any, Callable, Mapping
 
 from .zendure_cloud import ZendureCloudBootstrap
@@ -22,13 +22,14 @@ from .zendure_cloud_mqtt import (
 from .zendure_privacy import ZendureDiagnosticSanitizer
 from .zendure_zensdk import ZenSdkReadAttempt
 
-
 SCHEMA = "battery_smartflow_ai.zendure_initial_sync"
 SCHEMA_VERSION = 1
 INITIAL_SYNC_DIRECTORY = Path("bsfai") / "debug"
 DEFAULT_QUIET_PERIOD = 3.0
 DEFAULT_HARD_TIMEOUT = 30.0
 DEFAULT_MAX_EXPORT_BYTES = 32 * 1024 * 1024
+DEFAULT_MAX_RETAINED_CAPTURES = 3
+_INITIAL_SYNC_FILE_GLOB = "zendure_initial_sync_*.json"
 
 
 class InitialSyncExportError(RuntimeError):
@@ -103,6 +104,7 @@ class InitialSyncCaptureResult:
 class InitialSyncExportResult:
     path: Path
     size_bytes: int
+    removed_old_captures: int = 0
 
 
 class ZendureInitialSyncRecorder:
@@ -272,8 +274,12 @@ def export_initial_sync_capture(
     *,
     config_directory: str | Path,
     max_export_bytes: int = DEFAULT_MAX_EXPORT_BYTES,
+    max_retained_captures: int = DEFAULT_MAX_RETAINED_CAPTURES,
 ) -> InitialSyncExportResult:
     """Atomically export only the already sanitized JSON representation."""
+
+    if max_retained_captures < 1:
+        raise ValueError("max_retained_captures must be at least 1")
 
     try:
         payload = (
@@ -310,7 +316,33 @@ def export_initial_sync_capture(
     finally:
         if temporary is not None:
             temporary.unlink(missing_ok=True)
-    return InitialSyncExportResult(destination, len(payload))
+    removed = _prune_initial_sync_captures(
+        directory,
+        retain=max_retained_captures,
+    )
+    return InitialSyncExportResult(destination, len(payload), removed)
+
+
+def _prune_initial_sync_captures(directory: Path, *, retain: int) -> int:
+    """Keep only recent owned captures; never touch other debug artifacts."""
+
+    captures: list[tuple[int, str, Path]] = []
+    for path in directory.glob(_INITIAL_SYNC_FILE_GLOB):
+        try:
+            if path.is_file() and not path.is_symlink():
+                captures.append((path.stat().st_mtime_ns, path.name, path))
+        except OSError:
+            continue
+    captures.sort(reverse=True)
+    removed = 0
+    for _modified, _name, path in captures[retain:]:
+        try:
+            path.unlink()
+            removed += 1
+        except OSError:
+            # A cleanup problem must not invalidate a useful new capture.
+            continue
+    return removed
 
 
 def _raw_message(message: CloudMqttMessage) -> dict[str, Any]:

--- a/tests/test_zendure_initial_sync.py
+++ b/tests/test_zendure_initial_sync.py
@@ -2,15 +2,14 @@
 
 from __future__ import annotations
 
-from base64 import b64encode
-from datetime import datetime, timedelta, timezone
 import json
-from pathlib import Path
 import tempfile
 import unittest
+from base64 import b64encode
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
 
 from support import bootstrap
-
 
 bootstrap()
 
@@ -344,6 +343,49 @@ class InitialSyncCaptureTests(unittest.IsolatedAsyncioTestCase):
             )
             self.assertFalse(data["meta"]["complete"])
             self.assertFalse(list(exported.path.parent.glob("*.tmp")))
+
+    async def test_repeated_startup_exports_keep_only_three_owned_captures(self):
+        result = self.recorder().finish(complete=False, reason="hard_timeout")
+        with tempfile.TemporaryDirectory() as directory:
+            debug_directory = Path(directory) / "bsfai" / "debug"
+            debug_directory.mkdir(parents=True)
+            unrelated_debug = debug_directory / "bsfai_debug_keep.json"
+            unrelated_json = debug_directory / "user_file.json"
+            matching_directory = debug_directory / "zendure_initial_sync_keep.json"
+            unrelated_debug.write_text("{}", encoding="utf-8")
+            unrelated_json.write_text("{}", encoding="utf-8")
+            matching_directory.mkdir()
+
+            exported = None
+            removed = 0
+            for _index in range(6):
+                exported = export_initial_sync_capture(
+                    result,
+                    config_directory=directory,
+                )
+                removed += exported.removed_old_captures
+
+            captures = list(debug_directory.glob("zendure_initial_sync_*.json"))
+            self.assertEqual(len([item for item in captures if item.is_file()]), 3)
+            self.assertEqual(removed, 3)
+            self.assertIsNotNone(exported)
+            self.assertTrue(exported.path.is_file())
+            self.assertTrue(unrelated_debug.is_file())
+            self.assertTrue(unrelated_json.is_file())
+            self.assertTrue(matching_directory.is_dir())
+
+    async def test_retention_limit_must_keep_at_least_current_capture(self):
+        result = self.recorder().finish(complete=False, reason="hard_timeout")
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(
+                ValueError,
+                "max_retained_captures must be at least 1",
+            ):
+                export_initial_sync_capture(
+                    result,
+                    config_directory=directory,
+                    max_retained_captures=0,
+                )
 
     async def test_zensdk_report_and_attempt_are_exported_without_lan_identity(self):
         local_report = message(


### PR DESCRIPTION
## Summary

Closes #431.

- keep automatic initial-sync captures available for V5 model, pack, and multi-device field diagnostics
- retain only the three newest BSFAI-owned `zendure_initial_sync_*.json` files
- prune only regular non-symlink files inside the dedicated `bsfai/debug` directory
- leave full debug packages, unrelated JSON files, directories, temporary files, and paths outside the integration directory untouched
- keep a successful new capture even if cleanup of an older file fails
- report the number of removed captures in the internal export result
- reject an invalid retention limit before writing a file

The next startup after this change also reduces an existing larger collection to the three newest matching initial-sync files.

No version change or development release is included; `5.0.0.dev24` remains the current field-test build.

## Validation

- 675 tests passed
- 421 subtests passed
- targeted Ruff checks passed
- diff whitespace check passed