### PR TITLE
Show native device serial numbers in Home Assistant

### DIFF
--- a/custom_components/battery_smartflow_ai/core/models/native_device_state.py
+++ b/custom_components/battery_smartflow_ai/core/models/native_device_state.py
@@ -37,6 +37,7 @@ class NeutralPackState:
 
     pack_id: str
     parent_system_id: str
+    serial_number: str | None
     pack_type: MeasuredValue[str]
     firmware: MeasuredValue[str]
     soc_pct: MeasuredValue[float]

--- a/custom_components/battery_smartflow_ai/native_device_overview.py
+++ b/custom_components/battery_smartflow_ai/native_device_overview.py
@@ -23,6 +23,7 @@ from .core.models import (
 class PackOverview:
     public_id: str
     parent_public_id: str
+    serial_number: str | None
     pack_model: str | None
     firmware: MeasuredValue[str]
     measurements: Mapping[str, MeasuredValue]
@@ -39,6 +40,7 @@ class MainSystemOverview:
     public_id: str
     display_name: str
     model: str | None
+    serial_number: str | None
     firmware: MeasuredValue[str]
     measurements: Mapping[str, MeasuredValue]
     product_id: str | None
@@ -86,6 +88,7 @@ def build_native_device_overview(
                 PackOverview(
                     public_id=_public_id("PACK", pack_id),
                     parent_public_id=public_id,
+                    serial_number=pack_identity.serial_number,
                     pack_model=_pack_model(pack_identity.pack_type, device.model),
                     firmware=observed.firmware,
                     measurements=MappingProxyType(
@@ -112,6 +115,14 @@ def build_native_device_overview(
                 public_id=public_id,
                 display_name=device.display_name,
                 model=device.model,
+                serial_number=next(
+                    (
+                        native_identity.serial_number
+                        for native_identity in device.native_identities
+                        if native_identity.serial_number
+                    ),
+                    None,
+                ),
                 firmware=_measurement(state, "firmware"),
                 measurements=MappingProxyType(
                     {

--- a/custom_components/battery_smartflow_ai/native_zendure_runtime.py
+++ b/custom_components/battery_smartflow_ai/native_zendure_runtime.py
@@ -1202,6 +1202,7 @@ class NativeZendureRuntime:
             BatteryPackIdentity(
                 pack_id=pack.pack_id,
                 parent_system_id=state.system_id,
+                serial_number=pack.serial_number,
                 pack_type=_value(pack.pack_type),
                 firmware=_value(pack.firmware),
             )

--- a/custom_components/battery_smartflow_ai/sensor.py
+++ b/custom_components/battery_smartflow_ai/sensor.py
@@ -1589,6 +1589,7 @@ class NativeZendureHardwareSensor(CoordinatorEntity, SensorEntity):
                 name=item.display_name if item else "Zendure system",
                 manufacturer="Zendure",
                 model=(item.model or "Unknown Zendure system") if item else None,
+                serial_number=item.serial_number if item else None,
                 sw_version=str(firmware) if firmware is not None else None,
                 via_device=(DOMAIN, entry.entry_id),
             )
@@ -1615,6 +1616,7 @@ class NativeZendureHardwareSensor(CoordinatorEntity, SensorEntity):
                 name=f"{parent_name} {_battery_pack_label(coordinator.hass.config.language)} {pack_number}",
                 manufacturer="Zendure",
                 model=(item.pack_model or "Unknown battery pack") if item else None,
+                serial_number=item.serial_number if item else None,
                 sw_version=str(firmware) if firmware is not None else None,
                 via_device=(DOMAIN, f"native_zendure_{parent_public_id}"),
             )

--- a/custom_components/battery_smartflow_ai/zendure_normalizer.py
+++ b/custom_components/battery_smartflow_ai/zendure_normalizer.py
@@ -241,6 +241,7 @@ class _Observed:
 @dataclass(slots=True)
 class _PackAccumulator:
     values: dict[str, _Observed]
+    serial_number: str | None = None
     last_message_at: datetime | None = None
 
 
@@ -489,6 +490,13 @@ class ZendureCloudNormalizer:
             accumulator = self._pack_values[system_id].setdefault(
                 pack_id, _PackAccumulator({})
             )
+            serial_number = raw_pack.get("sn")
+            if isinstance(serial_number, (str, int)) and not isinstance(
+                serial_number, bool
+            ):
+                serial_text = str(serial_number).strip()
+                if serial_text:
+                    accumulator.serial_number = serial_text
             accumulator.last_message_at = observed_at
             self._apply_properties(
                 accumulator.values,
@@ -546,6 +554,7 @@ class ZendureCloudNormalizer:
         return NeutralPackState(
             pack_id=pack_id,
             parent_system_id=system_id,
+            serial_number=accumulator.serial_number,
             pack_type=value("pack_type"),
             firmware=value("firmware"),
             soc_pct=value("soc_pct"),

--- a/tests/test_native_device_overview.py
+++ b/tests/test_native_device_overview.py
@@ -23,7 +23,8 @@ def measured(value):
 
 def observed_pack(pack_id, parent):
     values = dict(
-        pack_id=pack_id, parent_system_id=parent, firmware=measured("1.2.3"),
+        pack_id=pack_id, parent_system_id=parent,
+        serial_number=pack_id, firmware=measured("1.2.3"),
         soc_pct=measured(55.0), charge_power_w=measured(100.0),
         discharge_power_w=measured(0.0), voltage_v=measured(49.5),
         current_a=measured(2.0), cell_min_v=measured(3.29),
@@ -105,7 +106,7 @@ class NativeDeviceOverviewTests(unittest.TestCase):
         self.assertEqual(pack.pack_model, "AB3000X")
         self.assertEqual(pack.measurements["pack_type"].value, 5)
 
-    def test_sensitive_full_identifiers_never_enter_projection(self):
+    def test_only_serial_number_is_exposed_for_local_device_information(self):
         identity = NativeDeviceIdentity(
             ZendureTransport.CLOUD_MQTT,
             device_id="full-device-secret",
@@ -121,7 +122,7 @@ class NativeDeviceOverviewTests(unittest.TestCase):
         )
         text = repr(build_native_device_overview(DeviceInventory(devices=(main,)), {}))
         self.assertNotIn("full-device-secret", text)
-        self.assertNotIn("full-serial-secret", text)
+        self.assertIn("full-serial-secret", text)
         self.assertNotIn("logical-system-secret", text)
         self.assertIn("BC8B7F", text)
 

--- a/tests/test_native_zendure_ha_integration.py
+++ b/tests/test_native_zendure_ha_integration.py
@@ -95,11 +95,11 @@ class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
         self.assertNotIn("native_hardware_soc_pct", config)
         self.assertNotIn("native_hardware_charge_power_w", config)
 
-    def test_native_hardware_entity_ids_use_only_privacy_safe_projection_ids(self) -> None:
+    def test_serial_is_device_metadata_but_not_part_of_entity_identity(self) -> None:
         sensor = (COMPONENT / "sensor.py").read_text(encoding="utf-8")
         entity = sensor[sensor.index("class NativeZendureHardwareSensor"):]
         self.assertIn("public_id", entity)
-        self.assertNotIn("serial_number", entity)
+        self.assertIn("serial_number=item.serial_number", entity)
         self.assertNotIn("device_id", entity)
         self.assertNotIn("pack_id", entity)
 

--- a/tests/test_zendure_normalizer.py
+++ b/tests/test_zendure_normalizer.py
@@ -186,6 +186,7 @@ class ZendureNormalizerTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(state.packs), 2)
         first, second = state.packs
         self.assertEqual(first.pack_id, "pack-a")
+        self.assertEqual(first.serial_number, "pack-a")
         self.assertEqual(first.parent_system_id, state.system_id)
         self.assertEqual(first.charge_power_w.value, 227.0)
         self.assertEqual(first.discharge_power_w.value, 0.0)


### PR DESCRIPTION
## Summary

- show available Zendure main-system and battery-pack serial numbers in Home Assistant device information
- retain pack serials separately when normalizing native reports
- keep serial numbers out of device names, entity IDs, logs, diagnostic exports, and shareable JSON captures
- retain privacy-safe hashed identifiers as the stable Home Assistant device identity

## Validation

- 616 tests passed
- diff whitespace check passed