### PR TITLE
Prepare 5.0.0 Beta1

### DIFF
--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -38,7 +38,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "5.0.0.dev25"
+INTEGRATION_VERSION = "5.0.0-Beta1"
 
 # V5 native Zendure discovery is observation-only in the first development
 # build. The App Token is account discovery material and must never be copied

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": ["paho-mqtt==2.1.0"],
-  "version": "5.0.0.dev25"
+  "version": "5.0.0-Beta1"
 }

--- a/custom_components/battery_smartflow_ai/native_device_overview.py
+++ b/custom_components/battery_smartflow_ai/native_device_overview.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime
 import hashlib
 from types import MappingProxyType
@@ -219,3 +219,26 @@ def _status_text(state: DeviceControlState, hems_status: HemsStatus) -> str:
         ),
         DeviceControlState.OFFLINE: "Observation mode - device offline",
     }[state]
+
+
+def with_control_state(
+    item: MainSystemOverview,
+    control_state: DeviceControlState,
+) -> MainSystemOverview:
+    """Return one overview item with a runtime-derived control state."""
+
+    return replace(
+        item,
+        control_state=control_state,
+        control_enabled=control_state in {
+            DeviceControlState.ENABLED,
+            DeviceControlState.ACTIVE,
+        },
+        actively_controlled=control_state is DeviceControlState.ACTIVE,
+        status_text=_status_text(control_state, item.hems_status),
+        control_block_reason=(
+            f"zendure_hems_{item.hems_status.value}"
+            if control_state is DeviceControlState.HEMS_BLOCKED
+            else None
+        ),
+    )

--- a/custom_components/battery_smartflow_ai/native_zendure_runtime.py
+++ b/custom_components/battery_smartflow_ai/native_zendure_runtime.py
@@ -18,6 +18,7 @@ from .core.models import (
     CommandExecutionStatus,
     DeviceCommand,
     DeviceControlState,
+    DeviceOperatingMode,
     DeviceInventory,
     MainDevice,
     NativeDeviceIdentity,
@@ -33,7 +34,10 @@ from .native_device_command_gate import (
     NativeCommandRequest,
     NativeDeviceCommandGate,
 )
-from .native_device_overview import build_native_device_overview
+from .native_device_overview import (
+    build_native_device_overview,
+    with_control_state,
+)
 from .native_transport_metrics import NativeTransportMetrics
 from .native_transport_router import (
     NativeTransportRouter,
@@ -378,10 +382,40 @@ class NativeZendureRuntime:
         if selected_index is None:
             return overview
         return tuple(
-            replace(item, selected_transport=selected_transport)
+            with_control_state(
+                replace(item, selected_transport=selected_transport),
+                self._hardware_control_state(),
+            )
             if index == selected_index
             else item
             for index, item in enumerate(overview)
+        )
+
+    def _hardware_control_state(self) -> DeviceControlState:
+        """Describe readiness separately from the current strategy decision."""
+
+        if not self._control_enabled or self._selected_device is None:
+            return DeviceControlState.OBSERVATION
+        device = self._inventory.devices.get(self._selected_device)
+        state = self._states.get(self._selected_device)
+        if device is None:
+            return DeviceControlState.OBSERVATION
+        if device.control_state in {
+            DeviceControlState.HEMS_BLOCKED,
+            DeviceControlState.UNSUPPORTED,
+            DeviceControlState.OFFLINE,
+        }:
+            return device.control_state
+        if state is None or not _fresh_native_state(state) or not device.online:
+            return DeviceControlState.OFFLINE
+        if automatic_control_transport(device).transport is None:
+            return DeviceControlState.UNSUPPORTED
+        if not self._transport_router.snapshot.synchronized:
+            return DeviceControlState.ELIGIBLE
+        return (
+            DeviceControlState.ACTIVE
+            if _native_power_control_active(state)
+            else DeviceControlState.ENABLED
         )
 
     def diagnostic_data(self) -> dict[str, Any]:
@@ -1269,6 +1303,36 @@ def _fresh_measured_value(
         return False
     age = (datetime.now(timezone.utc) - measured.observed_at).total_seconds()
     return 0 <= age <= maximum_age_seconds
+
+
+def _native_power_control_active(state: Any) -> bool:
+    """Return whether a non-zero native charge or discharge target is active."""
+
+    mode = state.mode.value if state.mode.valid else DeviceOperatingMode.UNKNOWN
+    if mode is DeviceOperatingMode.CHARGE or str(mode) == "charge":
+        return any(
+            _positive_measurement(value)
+            for value in (
+                state.setpoints.input_limit_w,
+                state.charge_power_w,
+            )
+        )
+    if mode is DeviceOperatingMode.DISCHARGE or str(mode) == "discharge":
+        return any(
+            _positive_measurement(value)
+            for value in (
+                state.setpoints.output_limit_w,
+                state.discharge_power_w,
+            )
+        )
+    return False
+
+
+def _positive_measurement(value: Any) -> bool:
+    try:
+        return bool(value.valid and float(value.value) > 0)
+    except (TypeError, ValueError, OverflowError):
+        return False
 
 
 def _skip_matching_writes(command: DeviceCommand, state: Any) -> DeviceCommand:

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -13,7 +13,7 @@ COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
 
 
 class DebugIntegrationContractTests(unittest.TestCase):
-    def test_manifest_and_runtime_version_match_v5_dev25_release(self) -> None:
+    def test_manifest_and_runtime_version_match_v5_beta1_release(self) -> None:
         manifest_version = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )["version"]
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "5.0.0.dev25")
+        self.assertEqual(manifest_version, "5.0.0-Beta1")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_native_power_controller.py
+++ b/tests/test_native_power_controller.py
@@ -20,6 +20,7 @@ sys.modules.setdefault("homeassistant.helpers.aiohttp_client", aiohttp_module)
 from custom_components.battery_smartflow_ai.core.models import (  # noqa: E402
     CommandExecutionStatus,
     DeviceCommand,
+    DeviceControlState,
     DeviceInventory,
     DeviceOperatingMode,
     MainDevice,
@@ -179,6 +180,29 @@ def legacy_runtime(*, current_state=None):
 
 
 class NativePowerControllerTests(unittest.IsolatedAsyncioTestCase):
+    async def test_hardware_status_separates_enabled_idle_from_active_control(self):
+        idle = runtime(current_state=state())
+        idle._refresh_write_authority()
+        idle_overview = idle.hardware_overview()[0]
+        self.assertEqual(idle_overview.control_state, DeviceControlState.ENABLED)
+        self.assertTrue(idle_overview.control_enabled)
+        self.assertFalse(idle_overview.actively_controlled)
+
+        active = runtime(
+            current_state=state(output_w=300, discharge_w=300)
+        )
+        active._refresh_write_authority()
+        active_overview = active.hardware_overview()[0]
+        self.assertEqual(active_overview.control_state, DeviceControlState.ACTIVE)
+        self.assertTrue(active_overview.actively_controlled)
+
+        disabled = runtime(enabled=False)
+        disabled._refresh_write_authority()
+        self.assertEqual(
+            disabled.hardware_overview()[0].control_state,
+            DeviceControlState.OBSERVATION,
+        )
+
     async def test_native_effectiveness_confirms_physical_effect_separately(self):
         target = runtime()
         verification = target._command_verification.prepare(

--- a/tests/test_native_zendure_ha_integration.py
+++ b/tests/test_native_zendure_ha_integration.py
@@ -13,11 +13,11 @@ COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
 
 
 class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
-    def test_dev25_version_and_mqtt_dependency_are_packaged(self) -> None:
+    def test_beta1_version_and_mqtt_dependency_are_packaged(self) -> None:
         manifest = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )
-        self.assertEqual(manifest["version"], "5.0.0.dev25")
+        self.assertEqual(manifest["version"], "5.0.0-Beta1")
         self.assertIn("paho-mqtt==2.1.0", manifest["requirements"])
 
     def test_options_flow_uses_a_password_field_and_never_suggests_token(self) -> None:


### PR DESCRIPTION
## Summary

- distinguish native control readiness from the current charging or discharging decision
- show Enabled while native control is ready but idle
- show Active only while a non-zero native charge or discharge target is present
- retain HEMS-blocked, offline, unsupported, eligible, and observation states
- set the integration version to 5.0.0-Beta1

## Validation

- 617 tests passed
- Python compilation passed
- diff whitespace check passed

This prepares the first user-visible V5 beta after native devices, child battery packs, local serial-number display, and hardware entities became available.