### PR TITLE
Use 5.0.0.beta1 version format

### DIFF
--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -38,7 +38,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "5.0.0-Beta1"
+INTEGRATION_VERSION = "5.0.0.beta1"
 
 # V5 native Zendure discovery is observation-only in the first development
 # build. The App Token is account discovery material and must never be copied

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": ["paho-mqtt==2.1.0"],
-  "version": "5.0.0-Beta1"
+  "version": "5.0.0.beta1"
 }

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "5.0.0-Beta1")
+        self.assertEqual(manifest_version, "5.0.0.beta1")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_native_zendure_ha_integration.py
+++ b/tests/test_native_zendure_ha_integration.py
@@ -17,7 +17,7 @@ class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
         manifest = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )
-        self.assertEqual(manifest["version"], "5.0.0-Beta1")
+        self.assertEqual(manifest["version"], "5.0.0.beta1")
         self.assertIn("paho-mqtt==2.1.0", manifest["requirements"])
 
     def test_options_flow_uses_a_password_field_and_never_suggests_token(self) -> None:


### PR DESCRIPTION
## Summary

- use the exact prerelease version 5.0.0.beta1 in the manifest and runtime
- align version contract tests with the dotted lowercase beta format

## Validation

- 617 tests passed
- diff whitespace check passed

The incorrectly formatted 5.0.0-Beta1 release and tag have been removed. After this PR is merged, the prerelease will be published as 5.0.0.beta1.