### PR TITLE
V5: Add deterministic native read-source arbitration

### DIFF
--- a/custom_components/battery_smartflow_ai/native_read_source.py
+++ b/custom_components/battery_smartflow_ai/native_read_source.py
@@ -1,0 +1,160 @@
+"""Deterministic source selection for native Zendure telemetry."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+from typing import Generic, Mapping, TypeVar
+
+from .core.models import MeasuredValue, ValueValidity, ZendureTransport
+
+
+ValueT = TypeVar("ValueT")
+
+
+class ReadSourceStatus(StrEnum):
+    """Quality of one selected property across all observed transports."""
+
+    CONSISTENT = "sources_consistent"
+    SINGLE = "single_source"
+    FALLBACK = "source_fallback"
+    CONFLICT = "source_conflict"
+    UNAVAILABLE = "source_unavailable"
+
+
+@dataclass(frozen=True, slots=True)
+class SourceMeasurement(Generic[ValueT]):
+    """One normalized value retaining its transport provenance."""
+
+    transport: ZendureTransport
+    measurement: MeasuredValue[ValueT]
+    retained: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class SelectedMeasurement(Generic[ValueT]):
+    """Deterministic winning value plus a privacy-safe selection trace."""
+
+    measurement: MeasuredValue[ValueT]
+    transport: ZendureTransport | None
+    status: ReadSourceStatus
+    reason: str
+    alternatives: tuple[ZendureTransport, ...]
+
+
+_VALIDITY_RANK = {
+    ValueValidity.VALID: 0,
+    ValueValidity.STALE: 1,
+    ValueValidity.OFFLINE: 2,
+    ValueValidity.INVALID: 3,
+    ValueValidity.UNAVAILABLE: 4,
+    ValueValidity.UNKNOWN: 5,
+    ValueValidity.NEVER_RECEIVED: 6,
+    ValueValidity.MISSING: 7,
+    ValueValidity.UNSUPPORTED: 8,
+}
+
+
+class NativeReadSourceArbiter:
+    """Select one value without depending on callback arrival order."""
+
+    def __init__(
+        self,
+        priorities: Mapping[str, tuple[ZendureTransport, ...]] | None = None,
+    ) -> None:
+        self._priorities = dict(priorities or {})
+
+    def select(
+        self,
+        property_name: str,
+        candidates: tuple[SourceMeasurement[ValueT], ...],
+        *,
+        safety_critical: bool = False,
+    ) -> SelectedMeasurement[ValueT]:
+        """Return a stable property winner with conservative conflict handling."""
+
+        if not candidates:
+            return SelectedMeasurement(
+                MeasuredValue.absent(ValueValidity.NEVER_RECEIVED),
+                None,
+                ReadSourceStatus.UNAVAILABLE,
+                "no_source_reported_property",
+                (),
+            )
+
+        priority = self._priorities.get(
+            property_name,
+            (
+                ZendureTransport.ZENSDK,
+                ZendureTransport.LOCAL_MQTT,
+                ZendureTransport.CLOUD_MQTT,
+                ZendureTransport.HOME_ASSISTANT,
+            ),
+        )
+        order = {transport: index for index, transport in enumerate(priority)}
+        ranked = sorted(
+            candidates,
+            key=lambda item: (
+                _VALIDITY_RANK.get(item.measurement.validity, 99),
+                item.retained,
+                order.get(item.transport, len(order)),
+                item.transport.value,
+            ),
+        )
+        usable = tuple(item for item in ranked if item.measurement.valid)
+        if not usable:
+            winner = ranked[0]
+            return SelectedMeasurement(
+                winner.measurement,
+                winner.transport,
+                ReadSourceStatus.UNAVAILABLE,
+                f"best_available_validity:{winner.measurement.validity.value}",
+                tuple(item.transport for item in ranked[1:]),
+            )
+
+        fresh = tuple(item for item in usable if not item.retained)
+        pool = fresh or usable
+        distinct = {_comparable(item.measurement.value) for item in pool}
+        if safety_critical and len(distinct) > 1:
+            return SelectedMeasurement(
+                MeasuredValue.absent(ValueValidity.INVALID),
+                None,
+                ReadSourceStatus.CONFLICT,
+                "fresh_safety_sources_disagree",
+                tuple(item.transport for item in pool),
+            )
+
+        winner = pool[0]
+        if len(pool) == 1:
+            status = (
+                ReadSourceStatus.FALLBACK
+                if len(candidates) > 1
+                else ReadSourceStatus.SINGLE
+            )
+            reason = (
+                "preferred_sources_not_usable"
+                if status is ReadSourceStatus.FALLBACK
+                else "only_valid_source"
+            )
+        elif len(distinct) == 1:
+            status = ReadSourceStatus.CONSISTENT
+            reason = "equivalent_sources_priority_selected"
+        else:
+            status = ReadSourceStatus.FALLBACK
+            reason = "noncritical_sources_differ_priority_selected"
+        return SelectedMeasurement(
+            winner.measurement,
+            winner.transport,
+            status,
+            reason,
+            tuple(item.transport for item in pool[1:]),
+        )
+
+
+def _comparable(value: object) -> object:
+    """Make common numeric values stable for cross-transport comparisons."""
+
+    if isinstance(value, float):
+        return round(value, 6)
+    return value

--- a/tests/test_native_read_source.py
+++ b/tests/test_native_read_source.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import unittest
+
+from custom_components.battery_smartflow_ai.core.models import (
+    MeasuredValue,
+    ValueValidity,
+    ZendureTransport,
+)
+from custom_components.battery_smartflow_ai.native_read_source import (
+    NativeReadSourceArbiter,
+    ReadSourceStatus,
+    SourceMeasurement,
+)
+
+
+NOW = datetime(2026, 9, 7, 10, 0, tzinfo=timezone.utc)
+
+
+def source(transport, value, *, validity=ValueValidity.VALID, retained=False):
+    measurement = (
+        MeasuredValue.available(value, observed_at=NOW)
+        if validity is ValueValidity.VALID
+        else MeasuredValue.absent(validity, observed_at=NOW)
+    )
+    return SourceMeasurement(transport, measurement, retained)
+
+
+class NativeReadSourceArbiterTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.arbiter = NativeReadSourceArbiter()
+
+    def test_callback_order_does_not_change_equal_source_selection(self) -> None:
+        cloud = source(ZendureTransport.CLOUD_MQTT, 61.0)
+        local = source(ZendureTransport.ZENSDK, 61.0)
+        first = self.arbiter.select("soc_pct", (cloud, local))
+        second = self.arbiter.select("soc_pct", (local, cloud))
+        self.assertEqual(first.transport, ZendureTransport.ZENSDK)
+        self.assertEqual(second.transport, ZendureTransport.ZENSDK)
+        self.assertEqual(first.status, ReadSourceStatus.CONSISTENT)
+
+    def test_valid_fallback_beats_stale_preferred_source(self) -> None:
+        selected = self.arbiter.select(
+            "soc_pct",
+            (
+                source(
+                    ZendureTransport.ZENSDK,
+                    None,
+                    validity=ValueValidity.STALE,
+                ),
+                source(ZendureTransport.CLOUD_MQTT, 55.0),
+            ),
+        )
+        self.assertEqual(selected.transport, ZendureTransport.CLOUD_MQTT)
+        self.assertEqual(selected.measurement.value, 55.0)
+        self.assertEqual(selected.status, ReadSourceStatus.FALLBACK)
+
+    def test_retained_value_cannot_beat_fresh_value(self) -> None:
+        selected = self.arbiter.select(
+            "soc_pct",
+            (
+                source(ZendureTransport.LOCAL_MQTT, 40.0, retained=True),
+                source(ZendureTransport.CLOUD_MQTT, 41.0),
+            ),
+        )
+        self.assertEqual(selected.transport, ZendureTransport.CLOUD_MQTT)
+        self.assertEqual(selected.measurement.value, 41.0)
+
+    def test_fresh_safety_conflict_fails_closed(self) -> None:
+        selected = self.arbiter.select(
+            "hems_active",
+            (
+                source(ZendureTransport.ZENSDK, False),
+                source(ZendureTransport.CLOUD_MQTT, True),
+            ),
+            safety_critical=True,
+        )
+        self.assertIsNone(selected.transport)
+        self.assertFalse(selected.measurement.valid)
+        self.assertEqual(selected.status, ReadSourceStatus.CONFLICT)
+
+    def test_zero_is_a_valid_measurement(self) -> None:
+        selected = self.arbiter.select(
+            "charge_power_w",
+            (source(ZendureTransport.ZENSDK, 0.0),),
+        )
+        self.assertTrue(selected.measurement.valid)
+        self.assertEqual(selected.measurement.value, 0.0)
+
+    def test_no_source_is_never_received(self) -> None:
+        selected = self.arbiter.select("temperature_c", ())
+        self.assertEqual(
+            selected.measurement.validity,
+            ValueValidity.NEVER_RECEIVED,
+        )
+        self.assertEqual(selected.status, ReadSourceStatus.UNAVAILABLE)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a transport-aware measurement envelope that retains native read provenance
- select fresh, valid and non-retained telemetry deterministically instead of depending on callback order
- fail closed when fresh safety-critical sources disagree
- preserve valid zero values and explicit unavailable validity states

## Scope

This is the first bounded implementation block for #349. It establishes and tests the source-selection contract before wiring multi-transport states into `NeutralDeviceState` and `RuntimeSnapshot` in the next block. It does not change the current Beta1 control or telemetry path yet.

## Validation

- `python -m unittest tests.test_native_read_source -v` — 6 passed
- compile check passed
- `git diff --check` passed
- broad unittest discovery ran 626 tests; three pre-existing pytest-based modules could not load because pytest is not installed in the bundled runtime

Closes no issue; progresses #349.