### PR TITLE
V5: Feed native battery telemetry into the coordinator

### DIFF
--- a/custom_components/battery_smartflow_ai/coordinator.py
+++ b/custom_components/battery_smartflow_ai/coordinator.py
@@ -3842,7 +3842,24 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 self._persist["native_handover_baseline_input_w"] = baseline_input_w
                 self._persist["native_handover_baseline_output_w"] = baseline_output_w
 
-            soc = _to_float(self._state(self.entities.soc), None)
+            native_state = (
+                native_runtime.selected_device_state()
+                if native_runtime is not None
+                and native_runtime.control_enabled
+                and hasattr(native_runtime, "selected_device_state")
+                else None
+            )
+            native_soc = native_state.soc_pct if native_state is not None else None
+            soc = (
+                float(native_soc.value)
+                if native_soc is not None and native_soc.valid
+                else _to_float(self._state(self.entities.soc), None)
+            )
+            soc_source = (
+                "native_zendure"
+                if native_soc is not None and native_soc.valid
+                else "home_assistant_entity"
+            )
             pv = _to_float(self._state(self.entities.pv), None)
             native_pv = _to_float(self._state(self.entities.native_pv), None)
 
@@ -4110,16 +4127,29 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
             battery_raw = self._state(self.entities.battery_ac_power)
             battery_power_value = _to_float(battery_raw, None)
-            battery_ac_power_sensor_valid = battery_power_value is not None
-            battery_power = (
-                float(battery_power_value)
-                if battery_power_value is not None
-                else 0.0
+            native_charge = (
+                native_state.charge_power_w if native_state is not None else None
             )
-            battery_power = float(battery_power or 0.0)
-
-            battery_discharge_w = max(0.0, battery_power)
-            battery_charge_w = max(0.0, -battery_power)
+            native_discharge = (
+                native_state.discharge_power_w if native_state is not None else None
+            )
+            if (
+                native_charge is not None
+                and native_charge.valid
+                and native_discharge is not None
+                and native_discharge.valid
+            ):
+                battery_charge_w = max(0.0, float(native_charge.value))
+                battery_discharge_w = max(0.0, float(native_discharge.value))
+                battery_power = battery_discharge_w - battery_charge_w
+                battery_ac_power_sensor_valid = True
+                battery_power_source = "native_zendure"
+            else:
+                battery_ac_power_sensor_valid = battery_power_value is not None
+                battery_power = float(battery_power_value or 0.0)
+                battery_discharge_w = max(0.0, battery_power)
+                battery_charge_w = max(0.0, -battery_power)
+                battery_power_source = "home_assistant_entity"
 
             pv_attributable_export_w = compute_pv_attributable_export_w(
                 grid_export_w=float(grid_export or 0.0),
@@ -6417,7 +6447,9 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 "economics_daily": economics_daily_snapshot.as_dict(),
                 "economics_total": economics_total_snapshot.as_dict(),
                 **economics_runtime_values,
+                "soc_source": soc_source,
                 "battery_ac_power_raw": battery_power,
+                "battery_power_source": battery_power_source,
                 "battery_ac_power_sensor_valid": bool(
                     battery_ac_power_sensor_valid
                 ),

--- a/custom_components/battery_smartflow_ai/native_zendure_runtime.py
+++ b/custom_components/battery_smartflow_ai/native_zendure_runtime.py
@@ -180,6 +180,16 @@ class NativeZendureRuntime:
     def status(self) -> str:
         return self._status
 
+    def selected_device_state(self):
+        """Return the fresh selected native state intended for core input."""
+
+        if self._selected_device is None:
+            return None
+        state = self._states.get(self._selected_device)
+        if state is None or not _fresh_native_state(state):
+            return None
+        return state
+
     def consume_control_baseline(self) -> tuple[str, int, int] | None:
         """Return one fresh device baseline when native control takes ownership."""
 


### PR DESCRIPTION
## Summary

- expose the fresh selected native device state as a core input
- use native Zendure SoC when native control owns the selected device
- use native charge and discharge telemetry instead of reading the configured Z-HA battery-power entity
- retain the existing Home Assistant input as a transitional fallback when native telemetry has not become valid yet
- expose the selected SoC and battery-power source in runtime diagnostics

## Boundaries

External grid, house PV, prices and forecast sources remain Home Assistant inputs. Hardware SoC limits are not written or synchronized by this change. The user-facing hardware controls and their final names remain a separate follow-up.

This is the second bounded implementation block for #349. Multi-transport property fusion through the arbiter from PR #440 follows before the transitional fallback can be removed.

## Validation

- 28 Dev9 strategy/regulation scenarios passed
- 10 Zendure normalizer tests passed
- 6 native read-source arbitration tests passed
- broad unittest discovery executed 626 tests; only three pre-existing pytest-based modules failed to import because pytest is absent from the bundled runtime
- `git diff --check` passed

Progresses #349.