### PR TITLE
Fuse native telemetry by source

### DIFF
--- a/custom_components/battery_smartflow_ai/native_read_source.py
+++ b/custom_components/battery_smartflow_ai/native_read_source.py
@@ -71,6 +71,7 @@ class NativeReadSourceArbiter:
         candidates: tuple[SourceMeasurement[ValueT], ...],
         *,
         safety_critical: bool = False,
+        conflict_tolerance: float | None = None,
     ) -> SelectedMeasurement[ValueT]:
         """Return a stable property winner with conservative conflict handling."""
 
@@ -116,7 +117,18 @@ class NativeReadSourceArbiter:
         fresh = tuple(item for item in usable if not item.retained)
         pool = fresh or usable
         distinct = {_comparable(item.measurement.value) for item in pool}
-        if safety_critical and len(distinct) > 1:
+        conflict = len(distinct) > 1
+        if conflict and conflict_tolerance is not None:
+            numeric = [item.measurement.value for item in pool]
+            conflict = not (
+                all(
+                    isinstance(value, (int, float))
+                    and not isinstance(value, bool)
+                    for value in numeric
+                )
+                and max(numeric) - min(numeric) <= conflict_tolerance
+            )
+        if safety_critical and conflict:
             return SelectedMeasurement(
                 MeasuredValue.absent(ValueValidity.INVALID),
                 None,

--- a/custom_components/battery_smartflow_ai/native_source_fusion.py
+++ b/custom_components/battery_smartflow_ai/native_source_fusion.py
@@ -1,0 +1,285 @@
+"""Fuse independently normalized Zendure telemetry with source provenance."""
+
+from __future__ import annotations
+
+from dataclasses import fields
+from datetime import datetime
+from typing import Any
+
+from .core.models import (
+    MeasuredValue,
+    NeutralDeviceState,
+    NeutralPackState,
+    ReportedDeviceSetpoints,
+    ZendureTransport,
+)
+from .native_read_source import (
+    NativeReadSourceArbiter,
+    SelectedMeasurement,
+    SourceMeasurement,
+)
+from .zendure_cloud import ZendureCloudBootstrap
+from .zendure_cloud_mqtt import CloudMqttMessage
+from .zendure_hems_activity import HemsActivityDiagnostic
+from .zendure_normalizer import NormalizationResult, ZendureCloudNormalizer
+
+
+_TRANSPORTS = (
+    ZendureTransport.ZENSDK,
+    ZendureTransport.LOCAL_MQTT,
+    ZendureTransport.CLOUD_MQTT,
+)
+_SAFETY_PROPERTIES = frozenset(
+    {"hems_active", "fault_code", "protection_active"}
+)
+
+
+class NativeSourceFusion:
+    """Keep transport histories separate and fuse only neutral snapshots."""
+
+    def __init__(self, bootstrap: ZendureCloudBootstrap) -> None:
+        self._normalizers = {
+            transport: ZendureCloudNormalizer(bootstrap) for transport in _TRANSPORTS
+        }
+        for item in bootstrap.devices:
+            system_id = item.candidate.candidate_id
+            self._normalizers[ZendureTransport.ZENSDK].set_online(system_id, None)
+            self._normalizers[ZendureTransport.LOCAL_MQTT].set_online(
+                system_id, None
+            )
+        self._arbiter = NativeReadSourceArbiter()
+        self._selection: dict[str, dict[str, SelectedMeasurement[Any]]] = {}
+
+    def apply(
+        self, message: CloudMqttMessage, *, now: datetime | None = None
+    ) -> NormalizationResult | None:
+        transport = _transport(message.transport)
+        if transport is None:
+            return None
+        result = self._normalizers[transport].apply(message, now=now)
+        if result is None or message.device_candidate_id is None:
+            return None
+        return self.snapshot(
+            message.device_candidate_id,
+            now=now or message.received_at,
+        )
+
+    def snapshot(
+        self, system_id: str, *, now: datetime | None = None
+    ) -> NormalizationResult:
+        results = {
+            transport: normalizer.snapshot(system_id, now=now)
+            for transport, normalizer in self._normalizers.items()
+        }
+        states = {transport: result.state for transport, result in results.items()}
+        trace: dict[str, SelectedMeasurement[Any]] = {}
+
+        def select(name: str, values: dict[ZendureTransport, MeasuredValue[Any]]):
+            selected = self._arbiter.select(
+                name,
+                tuple(
+                    SourceMeasurement(source, value)
+                    for source, value in values.items()
+                ),
+                safety_critical=name.rsplit(".", 1)[-1] in _SAFETY_PROPERTIES,
+            )
+            trace[name] = selected
+            return selected.measurement
+
+        scalar_names = (
+            "firmware",
+            "online",
+            "soc_pct",
+            "charge_power_w",
+            "discharge_power_w",
+            "ac_input_power_w",
+            "ac_output_power_w",
+            "pv_power_w",
+            "mode",
+            "hems_active",
+            "fault_code",
+            "protection_active",
+            "temperature_c",
+            "battery_voltage_v",
+            "offgrid_power_w",
+        )
+        selected_values = {
+            name: select(
+                name,
+                {
+                    source: getattr(state, name)
+                    for source, state in states.items()
+                },
+            )
+            for name in scalar_names
+        }
+        setpoints = ReportedDeviceSetpoints(
+            **{
+                item.name: select(
+                    f"setpoints.{item.name}",
+                    {
+                        source: getattr(state.setpoints, item.name)
+                        for source, state in states.items()
+                    },
+                )
+                for item in fields(ReportedDeviceSetpoints)
+            }
+        )
+        packs = self._fuse_packs(system_id, states, select)
+        preferred = trace["soc_pct"].transport
+        if preferred is None:
+            preferred = max(
+                states,
+                key=lambda source: states[source].last_message_at
+                or datetime.min.replace(tzinfo=(now.tzinfo if now else None)),
+            )
+        exemplar = states[preferred]
+        state = NeutralDeviceState(
+            system_id=system_id,
+            observed_transport=preferred,
+            model=exemplar.model,
+            setpoints=setpoints,
+            last_message_at=max(
+                (
+                    item.last_message_at
+                    for item in states.values()
+                    if item.last_message_at
+                ),
+                default=None,
+            ),
+            packs=packs,
+            **selected_values,
+        )
+        self._selection[system_id] = trace
+        return NormalizationResult(
+            state,
+            tuple(
+                sorted(
+                    {
+                        name
+                        for result in results.values()
+                        for name in result.unknown_main_properties
+                    }
+                )
+            ),
+            tuple(
+                sorted(
+                    {
+                        name
+                        for result in results.values()
+                        for name in result.unknown_pack_properties
+                    }
+                )
+            ),
+        )
+
+    def _fuse_packs(self, system_id, states, select):
+        by_source = {
+            source: {pack.pack_id: pack for pack in state.packs}
+            for source, state in states.items()
+        }
+        pack_ids = sorted(
+            {pack_id for packs in by_source.values() for pack_id in packs}
+        )
+        result = []
+        measurement_names = tuple(
+            item.name
+            for item in fields(NeutralPackState)
+            if item.name
+            not in {
+                "pack_id",
+                "parent_system_id",
+                "serial_number",
+                "last_message_at",
+            }
+        )
+        for pack_id in pack_ids:
+            available = {
+                source: packs[pack_id]
+                for source, packs in by_source.items()
+                if pack_id in packs
+            }
+            values = {
+                name: select(
+                    f"packs.{pack_id}.{name}",
+                    {
+                        source: getattr(pack, name)
+                        for source, pack in available.items()
+                    },
+                )
+                for name in measurement_names
+            }
+            serial = next(
+                (
+                    available[source].serial_number
+                    for source in _TRANSPORTS
+                    if source in available and available[source].serial_number
+                ),
+                None,
+            )
+            result.append(
+                NeutralPackState(
+                    pack_id=pack_id,
+                    parent_system_id=system_id,
+                    serial_number=serial,
+                    last_message_at=max(
+                        (
+                            pack.last_message_at
+                            for pack in available.values()
+                            if pack.last_message_at
+                        ),
+                        default=None,
+                    ),
+                    **values,
+                )
+            )
+        return tuple(result)
+
+    def set_online(
+        self,
+        system_id: str,
+        online: bool | None,
+        *,
+        transport: ZendureTransport | None = None,
+    ) -> None:
+        targets = (transport,) if transport is not None else _TRANSPORTS
+        for source in targets:
+            self._normalizers[source].set_online(system_id, online)
+
+    def set_hems_monitoring(
+        self, system_id: str, available: bool, *, observed_at: datetime
+    ) -> None:
+        for source in (ZendureTransport.CLOUD_MQTT, ZendureTransport.LOCAL_MQTT):
+            self._normalizers[source].set_hems_monitoring(
+                system_id, available, observed_at=observed_at
+            )
+
+    def hems_diagnostics(
+        self,
+        system_id: str,
+        *,
+        now: datetime,
+    ) -> HemsActivityDiagnostic:
+        values = [
+            self._normalizers[source].hems_diagnostics(system_id, now=now)
+            for source in (ZendureTransport.CLOUD_MQTT, ZendureTransport.LOCAL_MQTT)
+        ]
+        return next((value for value in values if value.monitoring), values[0])
+
+    def source_diagnostics(self, system_id: str) -> dict[str, Any]:
+        return {
+            name: {
+                "transport": selected.transport.value if selected.transport else None,
+                "status": selected.status.value,
+                "reason": selected.reason,
+                "alternatives": [source.value for source in selected.alternatives],
+            }
+            for name, selected in sorted(self._selection.get(system_id, {}).items())
+        }
+
+
+def _transport(value: object) -> ZendureTransport | None:
+    try:
+        return ZendureTransport(str(value))
+    except ValueError:
+        return None

--- a/custom_components/battery_smartflow_ai/native_zendure_runtime.py
+++ b/custom_components/battery_smartflow_ai/native_zendure_runtime.py
@@ -65,7 +65,7 @@ from .zendure_local_mqtt import (
     ZendureLocalMqttTransport,
 )
 from .zendure_local_mqtt_commands import LocalMqttCommandStatus
-from .zendure_normalizer import ZendureCloudNormalizer
+from .native_source_fusion import NativeSourceFusion
 from .zendure_privacy import ZendureDiagnosticSanitizer
 from .zendure_zensdk import (
     ZenSdkReadResult,
@@ -141,7 +141,7 @@ class NativeZendureRuntime:
         self._capture_reason: str | None = None
         self._inventory = DeviceInventory()
         self._states: dict[str, Any] = {}
-        self._normalizer: ZendureCloudNormalizer | None = None
+        self._normalizer: NativeSourceFusion | None = None
         self._processed_messages = 0
         self._last_processed_message: Any | None = None
         self._last_received_at: Any | None = None
@@ -467,6 +467,14 @@ class NativeZendureRuntime:
                 "transport_metrics": self._transport_metrics.export(
                     self._command_verification.measurements()
                 ),
+                "read_source_selection": (
+                    {
+                        system_id: self._normalizer.source_diagnostics(system_id)
+                        for system_id in sorted(self._inventory.devices)
+                    }
+                    if self._normalizer is not None
+                    else {}
+                ),
                 "cloud_command_verification": (
                     self._transport.command_diagnostics
                     if self._transport is not None else {"commands": []}
@@ -749,7 +757,7 @@ class NativeZendureRuntime:
                     candidate_id,
                     system_id=candidate_id,
                 )
-            self._normalizer = ZendureCloudNormalizer(bootstrap)
+            self._normalizer = NativeSourceFusion(bootstrap)
             self._zensdk_command_adapter = ZendureZenSdkCommandAdapter(
                 bootstrap,
                 self._post_json,
@@ -952,7 +960,7 @@ class NativeZendureRuntime:
                 self._zensdk_failures[candidate_id] = 0
                 self._zensdk_last_success[candidate_id] = successful[candidate_id]
                 if self._normalizer is not None:
-                    self._normalizer.set_online(candidate_id, True)
+                    self._set_normalizer_online(candidate_id, True)
                 if candidate_id in self._inventory.devices:
                     self._inventory.mark_available(candidate_id)
                 continue
@@ -960,9 +968,19 @@ class NativeZendureRuntime:
             self._zensdk_failures[candidate_id] = failures
             if failures >= ZENSDK_OFFLINE_AFTER_FAILURES:
                 if self._normalizer is not None:
-                    self._normalizer.set_online(candidate_id, False)
+                    self._set_normalizer_online(candidate_id, False)
                 if candidate_id in self._inventory.devices:
                     self._inventory.mark_unavailable(candidate_id)
+
+    def _set_normalizer_online(self, system_id: str, online: bool) -> None:
+        """Update only ZenSDK health while retaining old test-double support."""
+
+        if isinstance(self._normalizer, NativeSourceFusion):
+            self._normalizer.set_online(
+                system_id, online, transport=ZendureTransport.ZENSDK
+            )
+        elif self._normalizer is not None:
+            self._normalizer.set_online(system_id, online)
 
     def _refresh_snapshots(self) -> None:
         if self._normalizer is None:

--- a/custom_components/battery_smartflow_ai/zendure_normalizer.py
+++ b/custom_components/battery_smartflow_ai/zendure_normalizer.py
@@ -372,7 +372,7 @@ class ZendureCloudNormalizer:
             raise KeyError(system_id)
         return self._hems_activity[system_id].diagnostics(now=now)
 
-    def set_online(self, system_id: str, online: bool) -> None:
+    def set_online(self, system_id: str, online: bool | None) -> None:
         if system_id not in self._models:
             raise KeyError(system_id)
         self._online[system_id] = online

--- a/tests/test_native_source_fusion.py
+++ b/tests/test_native_source_fusion.py
@@ -1,0 +1,143 @@
+"""Source-separated native Zendure normalization tests."""
+
+from __future__ import annotations
+
+from base64 import b64encode
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+import json
+import unittest
+
+from support import bootstrap
+
+bootstrap()
+
+from custom_components.battery_smartflow_ai.core.models import ValueValidity, ZendureTransport  # noqa: E402
+from custom_components.battery_smartflow_ai.native_source_fusion import NativeSourceFusion  # noqa: E402
+from custom_components.battery_smartflow_ai.zendure_cloud import ZendureCloudClient  # noqa: E402
+from custom_components.battery_smartflow_ai.zendure_cloud_mqtt import CloudMqttMessage  # noqa: E402
+
+
+class Response:
+    def __init__(self, value):
+        self.value = value
+
+    async def json(self):
+        return self.value
+
+
+async def make_bootstrap():
+    token = b64encode(b"https://api.example.com.app-secret").decode()
+
+    async def post(*_args, **_kwargs):
+        return Response({
+            "code": 200,
+            "success": True,
+            "data": {
+                "deviceList": [{
+                    "deviceKey": "device-1", "productKey": "product-1",
+                    "productModel": "SolarFlow2400AC", "online": True,
+                }],
+                "mqtt": {
+                    "clientId": "secret", "url": "mqtt://broker:1883",
+                    "username": "secret", "password": "secret",
+                },
+            },
+        })
+
+    return await ZendureCloudClient(post).async_discover(token)
+
+
+def report(at, properties, *, transport="cloud_mqtt", packs=None):
+    payload = {"properties": properties}
+    if packs is not None:
+        payload["packData"] = packs
+    return CloudMqttMessage(
+        received_at=at,
+        topic="/product-1/device-1/properties/report",
+        payload=json.dumps(payload).encode(),
+        parsed_payload=payload,
+        payload_format="json",
+        device_candidate_id="cloud_mqtt:device-1",
+        pack_id=None,
+        known_topic=True,
+        session_number=1,
+        transport=transport,
+    )
+
+
+class NativeSourceFusionTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.now = datetime(2026, 9, 7, 12, 0, tzinfo=timezone.utc)
+        self.fusion = NativeSourceFusion(await make_bootstrap())
+
+    def test_priority_is_independent_of_callback_order(self):
+        cloud = report(self.now, {"electricLevel": 50}, transport="cloud_mqtt")
+        zensdk = report(self.now, {"electricLevel": 51}, transport="zensdk")
+        self.fusion.apply(zensdk)
+        state = self.fusion.apply(cloud).state
+        self.assertEqual(state.soc_pct.value, 51.0)
+        self.assertEqual(state.observed_transport, ZendureTransport.ZENSDK)
+
+    def test_fresh_cloud_value_replaces_stale_zensdk_value(self):
+        self.fusion.apply(report(self.now, {"electricLevel": 40}, transport="zensdk"))
+        later = self.now + timedelta(seconds=31)
+        state = self.fusion.apply(
+            report(later, {"electricLevel": 42}, transport="cloud_mqtt")
+        ).state
+        self.assertEqual(state.soc_pct.value, 42.0)
+        self.assertEqual(state.observed_transport, ZendureTransport.CLOUD_MQTT)
+
+    def test_safety_conflict_is_invalid(self):
+        self.fusion.apply(report(self.now, {"hemsState": 0}, transport="zensdk"))
+        state = self.fusion.apply(
+            report(self.now, {"hemsState": 1}, transport="cloud_mqtt")
+        ).state
+        self.assertEqual(state.hems_active.validity, ValueValidity.INVALID)
+        self.assertIsNone(state.hems_active.value)
+
+    def test_pack_properties_are_fused_and_zero_remains_valid(self):
+        self.fusion.apply(report(
+            self.now,
+            {},
+            transport="cloud_mqtt",
+            packs=[{"sn": "PACK-1", "packType": 5, "socLevel": 75, "power": 0, "state": 0}],
+        ))
+        result = self.fusion.apply(report(
+            self.now,
+            {},
+            transport="zensdk",
+            packs=[{"sn": "PACK-1", "packType": 5, "socLevel": 76, "power": 0, "state": 0}],
+        ))
+        pack = result.state.packs[0]
+        self.assertEqual(pack.serial_number, "PACK-1")
+        self.assertEqual(pack.soc_pct.value, 76.0)
+        self.assertEqual(pack.charge_power_w.value, 0.0)
+        self.assertTrue(pack.charge_power_w.valid)
+
+    def test_diagnostics_contain_selection_not_values(self):
+        self.fusion.apply(report(self.now, {"electricLevel": 50}, transport="zensdk"))
+        diagnostics = self.fusion.source_diagnostics("cloud_mqtt:device-1")
+        self.assertEqual(diagnostics["soc_pct"]["transport"], "zensdk")
+        self.assertNotIn("value", diagnostics["soc_pct"])
+
+
+class NativeReadToleranceTests(unittest.TestCase):
+    def test_numeric_tolerance_avoids_false_safety_conflict(self):
+        from custom_components.battery_smartflow_ai.core.models import MeasuredValue
+        from custom_components.battery_smartflow_ai.native_read_source import NativeReadSourceArbiter, SourceMeasurement
+
+        selected = NativeReadSourceArbiter().select(
+            "soc_pct",
+            (
+                SourceMeasurement(ZendureTransport.ZENSDK, MeasuredValue.available(50.0)),
+                SourceMeasurement(ZendureTransport.CLOUD_MQTT, MeasuredValue.available(51.0)),
+            ),
+            safety_critical=True,
+            conflict_tolerance=2.0,
+        )
+        self.assertTrue(selected.measurement.valid)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- normalize Cloud MQTT, local MQTT, and ZenSDK telemetry in independent source histories
- fuse neutral device, setpoint, and battery-pack properties deterministically instead of relying on callback order
- prefer fresh valid data, fail closed for conflicting safety states, and expose privacy-safe source-selection diagnostics

## Validation

- `python -m unittest discover -s tests -p 'test_native_*.py'` (95 tests)
- `python -m unittest discover -s tests -p 'test_zendure_*.py'` (131 tests)
- `python -m compileall -q custom_components/battery_smartflow_ai tests`
- `git diff --check`

Progresses #349.