### PR TITLE
Track native telemetry freshness and provenance

### DIFF
--- a/custom_components/battery_smartflow_ai/native_read_source.py
+++ b/custom_components/battery_smartflow_ai/native_read_source.py
@@ -138,6 +138,18 @@ class NativeReadSourceArbiter:
             )
 
         winner = pool[0]
+        if not fresh and winner.retained:
+            return SelectedMeasurement(
+                MeasuredValue(
+                    value=winner.measurement.value,
+                    validity=ValueValidity.STALE,
+                    observed_at=winner.measurement.observed_at,
+                ),
+                winner.transport,
+                ReadSourceStatus.FALLBACK,
+                "retained_value_not_fresh",
+                tuple(item.transport for item in pool[1:]),
+            )
         if len(pool) == 1:
             status = (
                 ReadSourceStatus.FALLBACK

--- a/custom_components/battery_smartflow_ai/native_source_fusion.py
+++ b/custom_components/battery_smartflow_ai/native_source_fusion.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import fields
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 from .core.models import (
@@ -21,7 +21,12 @@ from .native_read_source import (
 from .zendure_cloud import ZendureCloudBootstrap
 from .zendure_cloud_mqtt import CloudMqttMessage
 from .zendure_hems_activity import HemsActivityDiagnostic
-from .zendure_normalizer import NormalizationResult, ZendureCloudNormalizer
+from .zendure_normalizer import (
+    MAIN_PROPERTY_MAPPINGS,
+    PACK_PROPERTY_MAPPINGS,
+    NormalizationResult,
+    ZendureCloudNormalizer,
+)
 
 
 _TRANSPORTS = (
@@ -49,6 +54,13 @@ class NativeSourceFusion:
             )
         self._arbiter = NativeReadSourceArbiter()
         self._selection: dict[str, dict[str, SelectedMeasurement[Any]]] = {}
+        self._selection_changed_at: dict[str, dict[str, datetime]] = {}
+        self._retained_main: dict[
+            tuple[ZendureTransport, str], dict[str, bool]
+        ] = {}
+        self._retained_packs: dict[
+            tuple[ZendureTransport, str, str], dict[str, bool]
+        ] = {}
 
     def apply(
         self, message: CloudMqttMessage, *, now: datetime | None = None
@@ -59,6 +71,7 @@ class NativeSourceFusion:
         result = self._normalizers[transport].apply(message, now=now)
         if result is None or message.device_candidate_id is None:
             return None
+        self._record_retained(transport, message)
         return self.snapshot(
             message.device_candidate_id,
             now=now or message.received_at,
@@ -73,17 +86,29 @@ class NativeSourceFusion:
         }
         states = {transport: result.state for transport, result in results.items()}
         trace: dict[str, SelectedMeasurement[Any]] = {}
+        current = now or datetime.now(timezone.utc)
 
-        def select(name: str, values: dict[ZendureTransport, MeasuredValue[Any]]):
+        def select(
+            name: str,
+            values: dict[ZendureTransport, MeasuredValue[Any]],
+            retained: dict[ZendureTransport, bool] | None = None,
+        ):
             selected = self._arbiter.select(
                 name,
                 tuple(
-                    SourceMeasurement(source, value)
+                    SourceMeasurement(
+                        source,
+                        value,
+                        (retained or {}).get(source, False),
+                    )
                     for source, value in values.items()
                 ),
                 safety_critical=name.rsplit(".", 1)[-1] in _SAFETY_PROPERTIES,
             )
             trace[name] = selected
+            previous = self._selection.get(system_id, {}).get(name)
+            if previous is None or previous.transport != selected.transport:
+                self._selection_changed_at.setdefault(system_id, {})[name] = current
             return selected.measurement
 
         scalar_names = (
@@ -110,6 +135,12 @@ class NativeSourceFusion:
                     source: getattr(state, name)
                     for source, state in states.items()
                 },
+                {
+                    source: self._retained_main.get((source, system_id), {}).get(
+                        name, False
+                    )
+                    for source in states
+                },
             )
             for name in scalar_names
         }
@@ -120,6 +151,12 @@ class NativeSourceFusion:
                     {
                         source: getattr(state.setpoints, item.name)
                         for source, state in states.items()
+                    },
+                    {
+                        source: self._retained_main.get(
+                            (source, system_id), {}
+                        ).get(item.name, False)
+                        for source in states
                     },
                 )
                 for item in fields(ReportedDeviceSetpoints)
@@ -206,6 +243,12 @@ class NativeSourceFusion:
                         source: getattr(pack, name)
                         for source, pack in available.items()
                     },
+                    {
+                        source: self._retained_packs.get(
+                            (source, system_id, pack_id), {}
+                        ).get(name, False)
+                        for source in available
+                    },
                 )
                 for name in measurement_names
             }
@@ -266,16 +309,112 @@ class NativeSourceFusion:
         ]
         return next((value for value in values if value.monitoring), values[0])
 
-    def source_diagnostics(self, system_id: str) -> dict[str, Any]:
+    def source_diagnostics(
+        self,
+        system_id: str,
+        *,
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        current = now or datetime.now(timezone.utc)
         return {
             name: {
                 "transport": selected.transport.value if selected.transport else None,
                 "status": selected.status.value,
                 "reason": selected.reason,
                 "alternatives": [source.value for source in selected.alternatives],
+                "selected_at": self._selection_changed_at.get(
+                    system_id, {}
+                ).get(name),
+                "sources": self._source_quality(
+                    system_id,
+                    name,
+                    current,
+                ),
             }
             for name, selected in sorted(self._selection.get(system_id, {}).items())
         }
+
+    def _record_retained(
+        self,
+        transport: ZendureTransport,
+        message: CloudMqttMessage,
+    ) -> None:
+        system_id = message.device_candidate_id
+        payload = message.parsed_payload
+        if system_id is None or not isinstance(payload, dict):
+            return
+        properties = payload.get("properties")
+        if isinstance(properties, dict):
+            destination = self._retained_main.setdefault(
+                (transport, system_id), {}
+            )
+            for raw_name in properties:
+                mapping = MAIN_PROPERTY_MAPPINGS.get(str(raw_name))
+                if mapping is not None:
+                    destination[mapping.target] = message.retained
+        packs = payload.get("packData")
+        if not isinstance(packs, list):
+            return
+        for pack in packs:
+            if not isinstance(pack, dict):
+                continue
+            pack_id = _pack_id(pack)
+            if pack_id is None:
+                continue
+            destination = self._retained_packs.setdefault(
+                (transport, system_id, pack_id), {}
+            )
+            for raw_name in pack:
+                mapping = PACK_PROPERTY_MAPPINGS.get(str(raw_name))
+                if mapping is not None:
+                    destination[mapping.target] = message.retained
+            if "power" in pack:
+                destination["charge_power_w"] = message.retained
+                destination["discharge_power_w"] = message.retained
+
+    def _source_quality(
+        self,
+        system_id: str,
+        property_name: str,
+        now: datetime,
+    ) -> list[dict[str, Any]]:
+        values = []
+        for source, normalizer in self._normalizers.items():
+            state = normalizer.snapshot(system_id, now=now).state
+            measurement = _measurement(state, property_name)
+            if measurement is None:
+                continue
+            observed = measurement.observed_at
+            values.append({
+                "transport": source.value,
+                "validity": measurement.validity.value,
+                "observed_at": observed,
+                "age_seconds": (
+                    max(0.0, (now - observed).total_seconds())
+                    if observed is not None
+                    else None
+                ),
+                "retained": self._property_retained(
+                    source, system_id, property_name
+                ),
+            })
+        return values
+
+    def _property_retained(
+        self,
+        source: ZendureTransport,
+        system_id: str,
+        name: str,
+    ) -> bool:
+        if name.startswith("packs."):
+            _, pack_id, target = name.split(".", 2)
+            return self._retained_packs.get(
+                (source, system_id, pack_id), {}
+            ).get(target, False)
+        target = name.split(".", 1)[-1]
+        return self._retained_main.get((source, system_id), {}).get(
+            target, False
+        )
 
 
 def _transport(value: object) -> ZendureTransport | None:
@@ -283,3 +422,26 @@ def _transport(value: object) -> ZendureTransport | None:
         return ZendureTransport(str(value))
     except ValueError:
         return None
+
+
+def _pack_id(pack: dict[str, Any]) -> str | None:
+    for key in ("sn", "packId", "packKey"):
+        value = pack.get(key)
+        if isinstance(value, (str, int)) and not isinstance(value, bool):
+            text = str(value).strip()
+            if text:
+                return text
+    return None
+
+
+def _measurement(
+    state: NeutralDeviceState,
+    property_name: str,
+) -> MeasuredValue[Any] | None:
+    if property_name.startswith("setpoints."):
+        return getattr(state.setpoints, property_name.split(".", 1)[1], None)
+    if property_name.startswith("packs."):
+        _, pack_id, target = property_name.split(".", 2)
+        pack = next((item for item in state.packs if item.pack_id == pack_id), None)
+        return getattr(pack, target, None) if pack is not None else None
+    return getattr(state, property_name, None)

--- a/custom_components/battery_smartflow_ai/native_zendure_runtime.py
+++ b/custom_components/battery_smartflow_ai/native_zendure_runtime.py
@@ -1169,6 +1169,7 @@ class NativeZendureRuntime:
                     device_id=device_id,
                     transport=message_transport,
                     observed_at=message.received_at,
+                    retained=bool(getattr(message, "retained", False)),
                 )
             if (
                 message.transport == "zensdk"

--- a/custom_components/battery_smartflow_ai/zendure_cloud_mqtt.py
+++ b/custom_components/battery_smartflow_ai/zendure_cloud_mqtt.py
@@ -71,6 +71,7 @@ class CloudMqttMessage:
     known_topic: bool
     session_number: int
     transport: str = "cloud_mqtt"
+    retained: bool = False
 
 
 @dataclass(slots=True)
@@ -82,7 +83,7 @@ class CloudMqttDeviceState:
     property_updated_at: dict[str, datetime] = field(default_factory=dict)
 
 
-MessageCallback = Callable[[str, bytes], None]
+MessageCallback = Callable[[str, bytes, bool], None]
 ConnectCallback = Callable[[bool, str | None], None]
 DisconnectCallback = Callable[[str | None], None]
 
@@ -442,10 +443,20 @@ class ZendureCloudMqttTransport:
                 _LOGGER.warning("Zendure Cloud MQTT reconnect failed: %s", safe)
                 attempt += 1
 
-    def _on_message(self, topic: str, payload: bytes) -> None:
-        self._threadsafe(self._handle_message, topic, bytes(payload))
+    def _on_message(
+        self,
+        topic: str,
+        payload: bytes,
+        retained: bool = False,
+    ) -> None:
+        self._threadsafe(self._handle_message, topic, bytes(payload), retained)
 
-    def _handle_message(self, topic: str, payload: bytes) -> None:
+    def _handle_message(
+        self,
+        topic: str,
+        payload: bytes,
+        retained: bool = False,
+    ) -> None:
         received_at = self._clock()
         parsed, payload_format = _parse_payload(payload)
         candidate_id, pack_id = self._route_message(topic, parsed)
@@ -464,6 +475,7 @@ class ZendureCloudMqttTransport:
             pack_id=pack_id,
             known_topic=known_topic,
             session_number=self._session_number,
+            retained=retained,
         )
         self._messages.append(message)
         self._last_message_at = received_at
@@ -733,7 +745,11 @@ class PahoReadOnlyMqttSession:
 
     def _paho_message(self, _client: Any, _userdata: Any, message: Any) -> None:
         if self._on_message is not None:
-            self._on_message(str(message.topic), bytes(message.payload))
+            self._on_message(
+                str(message.topic),
+                bytes(message.payload),
+                bool(getattr(message, "retain", False)),
+            )
 
 
 def _safe_socket_family(mqtt_socket: Any) -> str:

--- a/custom_components/battery_smartflow_ai/zendure_local_mqtt.py
+++ b/custom_components/battery_smartflow_ai/zendure_local_mqtt.py
@@ -147,8 +147,13 @@ class ZendureLocalMqttTransport(ZendureCloudMqttTransport):
                 self._schedule_command_timeout(command_id)
             return result
 
-    def _handle_message(self, topic: str, payload: bytes) -> None:
-        super()._handle_message(topic, payload)
+    def _handle_message(
+        self,
+        topic: str,
+        payload: bytes,
+        retained: bool = False,
+    ) -> None:
+        super()._handle_message(topic, payload, retained)
         if not self._messages:
             return
         message = self._messages[-1]

--- a/custom_components/battery_smartflow_ai/zendure_normalizer.py
+++ b/custom_components/battery_smartflow_ai/zendure_normalizer.py
@@ -342,7 +342,10 @@ class ZendureCloudNormalizer:
                     observed_at,
                 )
             self._apply_packs(system_id, payload.get("packData"), observed_at)
-        if message.topic.endswith("/properties/energy"):
+        if (
+            message.topic.endswith("/properties/energy")
+            and not message.retained
+        ):
             self._hems_activity[system_id].observe_energy(observed_at=observed_at)
         return self.snapshot(system_id, now=now or observed_at)
 

--- a/tests/test_native_read_source.py
+++ b/tests/test_native_read_source.py
@@ -67,6 +67,15 @@ class NativeReadSourceArbiterTests(unittest.TestCase):
         self.assertEqual(selected.transport, ZendureTransport.CLOUD_MQTT)
         self.assertEqual(selected.measurement.value, 41.0)
 
+    def test_retained_only_value_is_not_reported_as_fresh(self) -> None:
+        selected = self.arbiter.select(
+            "soc_pct",
+            (source(ZendureTransport.LOCAL_MQTT, 40.0, retained=True),),
+        )
+        self.assertEqual(selected.measurement.value, 40.0)
+        self.assertEqual(selected.measurement.validity, ValueValidity.STALE)
+        self.assertEqual(selected.reason, "retained_value_not_fresh")
+
     def test_fresh_safety_conflict_fails_closed(self) -> None:
         selected = self.arbiter.select(
             "hems_active",

--- a/tests/test_native_source_fusion.py
+++ b/tests/test_native_source_fusion.py
@@ -48,7 +48,14 @@ async def make_bootstrap():
     return await ZendureCloudClient(post).async_discover(token)
 
 
-def report(at, properties, *, transport="cloud_mqtt", packs=None):
+def report(
+    at,
+    properties,
+    *,
+    transport="cloud_mqtt",
+    packs=None,
+    retained=False,
+):
     payload = {"properties": properties}
     if packs is not None:
         payload["packData"] = packs
@@ -63,6 +70,7 @@ def report(at, properties, *, transport="cloud_mqtt", packs=None):
         known_topic=True,
         session_number=1,
         transport=transport,
+        retained=retained,
     )
 
 
@@ -120,6 +128,57 @@ class NativeSourceFusionTests(unittest.IsolatedAsyncioTestCase):
         diagnostics = self.fusion.source_diagnostics("cloud_mqtt:device-1")
         self.assertEqual(diagnostics["soc_pct"]["transport"], "zensdk")
         self.assertNotIn("value", diagnostics["soc_pct"])
+
+    def test_retained_message_cannot_override_fresh_cloud_value(self):
+        self.fusion.apply(
+            report(self.now, {"electricLevel": 44}, transport="cloud_mqtt")
+        )
+        result = self.fusion.apply(
+            report(
+                self.now + timedelta(seconds=1),
+                {"electricLevel": 99},
+                transport="zensdk",
+                retained=True,
+            )
+        )
+        self.assertEqual(result.state.soc_pct.value, 44.0)
+        diagnostics = self.fusion.source_diagnostics(
+            "cloud_mqtt:device-1",
+            now=self.now + timedelta(seconds=1),
+        )["soc_pct"]
+        self.assertEqual(diagnostics["transport"], "cloud_mqtt")
+        zensdk = next(
+            item for item in diagnostics["sources"]
+            if item["transport"] == "zensdk"
+        )
+        self.assertTrue(zensdk["retained"])
+        self.assertEqual(zensdk["age_seconds"], 0.0)
+
+    def test_selected_at_changes_only_when_selected_source_changes(self):
+        self.fusion.apply(
+            report(self.now, {"electricLevel": 40}, transport="cloud_mqtt")
+        )
+        first = self.fusion.source_diagnostics(
+            "cloud_mqtt:device-1", now=self.now
+        )["soc_pct"]["selected_at"]
+        self.fusion.snapshot(
+            "cloud_mqtt:device-1", now=self.now + timedelta(seconds=1)
+        )
+        unchanged = self.fusion.source_diagnostics(
+            "cloud_mqtt:device-1", now=self.now + timedelta(seconds=1)
+        )["soc_pct"]["selected_at"]
+        self.fusion.apply(
+            report(
+                self.now + timedelta(seconds=2),
+                {"electricLevel": 41},
+                transport="zensdk",
+            )
+        )
+        changed = self.fusion.source_diagnostics(
+            "cloud_mqtt:device-1", now=self.now + timedelta(seconds=2)
+        )["soc_pct"]["selected_at"]
+        self.assertEqual(first, unchanged)
+        self.assertGreater(changed, unchanged)
 
 
 class NativeReadToleranceTests(unittest.TestCase):

--- a/tests/test_zendure_cloud_mqtt.py
+++ b/tests/test_zendure_cloud_mqtt.py
@@ -61,7 +61,8 @@ class FakeSession:
         self.property_writes.append((product_id, device_id, writes))
         return True
     def disconnect(self): self.disconnected = True
-    def emit(self, topic, payload): self.on_message(topic, payload)
+    def emit(self, topic, payload, retained=False):
+        self.on_message(topic, payload, retained)
     def drop(self): self.on_disconnect("network lost")
 
 
@@ -153,6 +154,21 @@ class CloudMqttTransportTests(unittest.IsolatedAsyncioTestCase):
         message = transport.messages[0]
         self.assertEqual(message.device_candidate_id, "cloud_mqtt:main-1")
         self.assertEqual(message.pack_id, "pack-77")
+
+    async def test_mqtt_retained_flag_is_preserved_on_message(self):
+        transport = ZendureCloudMqttTransport(
+            self.data,
+            session_factory=self.factory,
+            clock=lambda: self.now,
+        )
+        await transport.async_start()
+        self.sessions[0].emit(
+            "/product-a/main-1/properties/report",
+            json.dumps({"properties": {"socLevel": 55}}).encode(),
+            retained=True,
+        )
+        await asyncio.sleep(0)
+        self.assertTrue(transport.messages[0].retained)
 
     async def test_properties_energy_is_known_and_routed_per_device(self):
         transport = ZendureCloudMqttTransport(


### PR DESCRIPTION
## Summary

- preserve the MQTT retained flag from the broker through Cloud and Local MQTT telemetry
- prevent retained-only telemetry and retained energy messages from being treated as fresh runtime or HEMS activity
- expose per-property source validity, observation time, age, retained state, and source-switch time in privacy-safe diagnostics

## Validation

- `python -m unittest discover -s tests -p 'test_native_*.py'` (98 tests)
- `python -m unittest discover -s tests -p 'test_zendure_*.py'` (132 tests)
- `python -m compileall -q custom_components/battery_smartflow_ai tests`
- `git diff --check`

Progresses #349.