### PR TITLE
Complete native telemetry provenance and readback tracking

### DIFF
--- a/custom_components/battery_smartflow_ai/native_command_verification.py
+++ b/custom_components/battery_smartflow_ai/native_command_verification.py
@@ -70,6 +70,7 @@ class CommandVerification:
     transport_at: datetime | None = None
     readback_at: datetime | None = None
     readback_value: float | None = None
+    readback_transport: ZendureTransport | None = None
     effect_at: datetime | None = None
     effect_status: EffectStatus = EffectStatus.PENDING
     reason: str | None = None
@@ -116,6 +117,11 @@ class CommandVerification:
             "max_attempts": self.max_attempts,
             "transport_status": self.transport_status,
             "readback_value": self.readback_value,
+            "readback_transport": (
+                self.readback_transport.value
+                if self.readback_transport is not None
+                else None
+            ),
             "prepared_at": self.prepared_at,
             "gate_at": self.gate_at,
             "sent_at": self.sent_at,
@@ -212,11 +218,15 @@ class NativeCommandVerificationManager:
 
     def observe_readback(self, command_id: str, *, device_id: str,
                          property_name: str, value: float,
-                         observed_at: datetime) -> bool:
+                         observed_at: datetime,
+                         source_transport: ZendureTransport | None = None,
+                         retained: bool = False) -> bool:
         command = self._commands[command_id]
         if command.status is CommandVerificationStatus.SUPERSEDED:
             return False
         if device_id != command.device_id or property_name != command.readback.property_name:
+            return False
+        if retained:
             return False
         observed = _aware(observed_at)
         if command.sent_at is None or observed <= command.sent_at:
@@ -227,6 +237,7 @@ class NativeCommandVerificationManager:
         if command.readback.matches(numeric):
             command.readback_at = observed
             command.readback_value = numeric
+            command.readback_transport = source_transport
             if command.status is CommandVerificationStatus.TRANSPORT_ERROR:
                 command.status = CommandVerificationStatus.CONTRADICTORY_RESPONSE
                 command.reason = "transport_error_but_readback_confirmed"
@@ -237,6 +248,7 @@ class NativeCommandVerificationManager:
             return True
         command.readback_value = numeric
         command.readback_at = observed
+        command.readback_transport = source_transport
         command.status = (
             CommandVerificationStatus.CONTRADICTORY_RESPONSE
             if previously_confirmed or len(set(command.readback_values)) > 1

--- a/custom_components/battery_smartflow_ai/native_source_fusion.py
+++ b/custom_components/battery_smartflow_ai/native_source_fusion.py
@@ -35,8 +35,23 @@ _TRANSPORTS = (
     ZendureTransport.CLOUD_MQTT,
 )
 _SAFETY_PROPERTIES = frozenset(
-    {"hems_active", "fault_code", "protection_active"}
+    {
+        "hems_active",
+        "fault_code",
+        "protection_active",
+        "mode",
+        "soc_pct",
+        "cell_min_v",
+        "cell_max_v",
+        "temperature_c",
+    }
 )
+_SAFETY_TOLERANCES = {
+    "soc_pct": 5.0,
+    "cell_min_v": 0.15,
+    "cell_max_v": 0.15,
+    "temperature_c": 10.0,
+}
 
 
 class NativeSourceFusion:
@@ -93,6 +108,7 @@ class NativeSourceFusion:
             values: dict[ZendureTransport, MeasuredValue[Any]],
             retained: dict[ZendureTransport, bool] | None = None,
         ):
+            target = name.rsplit(".", 1)[-1]
             selected = self._arbiter.select(
                 name,
                 tuple(
@@ -103,7 +119,8 @@ class NativeSourceFusion:
                     )
                     for source, value in values.items()
                 ),
-                safety_critical=name.rsplit(".", 1)[-1] in _SAFETY_PROPERTIES,
+                safety_critical=target in _SAFETY_PROPERTIES,
+                conflict_tolerance=_SAFETY_TOLERANCES.get(target),
             )
             trace[name] = selected
             previous = self._selection.get(system_id, {}).get(name)

--- a/custom_components/battery_smartflow_ai/zendure_cloud_mqtt.py
+++ b/custom_components/battery_smartflow_ai/zendure_cloud_mqtt.py
@@ -493,6 +493,7 @@ class ZendureCloudMqttTransport:
                     device_id=candidate_id,
                     properties=properties,
                     observed_at=received_at,
+                    retained=retained,
                 )
 
     def _route_message(self, topic: str, parsed: Any) -> tuple[str | None, str | None]:

--- a/custom_components/battery_smartflow_ai/zendure_cloud_mqtt_commands.py
+++ b/custom_components/battery_smartflow_ai/zendure_cloud_mqtt_commands.py
@@ -180,7 +180,14 @@ class ZendureCloudCommandAdapter:
         sent = len(writes)
         return CloudCommandResult(CloudCommandStatus.SENT, "awaiting_readback", tuple(verification_ids), sent)
 
-    def observe_properties(self, *, device_id: str, properties: Mapping[str, object], observed_at: datetime) -> int:
+    def observe_properties(
+        self,
+        *,
+        device_id: str,
+        properties: Mapping[str, object],
+        observed_at: datetime,
+        retained: bool = False,
+    ) -> int:
         """Attach fresh reports only to the currently active matching target."""
 
         confirmed = 0
@@ -195,6 +202,8 @@ class ZendureCloudCommandAdapter:
             if self._verification.observe_readback(
                 active.command_id, device_id=device_id, property_name=property_name,
                 value=value, observed_at=observed_at,
+                source_transport=ZendureTransport.CLOUD_MQTT,
+                retained=retained,
             ):
                 confirmed += 1
         return confirmed

--- a/custom_components/battery_smartflow_ai/zendure_local_mqtt.py
+++ b/custom_components/battery_smartflow_ai/zendure_local_mqtt.py
@@ -170,4 +170,5 @@ class ZendureLocalMqttTransport(ZendureCloudMqttTransport):
                     device_id=local_message.device_candidate_id,
                     properties=properties,
                     observed_at=local_message.received_at,
+                    retained=local_message.retained,
                 )

--- a/custom_components/battery_smartflow_ai/zendure_local_mqtt_commands.py
+++ b/custom_components/battery_smartflow_ai/zendure_local_mqtt_commands.py
@@ -228,6 +228,7 @@ class ZendureLocalMqttCommandAdapter:
         device_id: str,
         properties: Mapping[str, object],
         observed_at: datetime,
+        retained: bool = False,
     ) -> int:
         confirmed = 0
         for property_name, raw_value in properties.items():
@@ -244,6 +245,8 @@ class ZendureLocalMqttCommandAdapter:
                 property_name=property_name,
                 value=value,
                 observed_at=observed_at,
+                source_transport=ZendureTransport.LOCAL_MQTT,
+                retained=retained,
             ):
                 confirmed += 1
         return confirmed

--- a/custom_components/battery_smartflow_ai/zendure_zensdk_commands.py
+++ b/custom_components/battery_smartflow_ai/zendure_zensdk_commands.py
@@ -231,6 +231,7 @@ class ZendureZenSdkCommandAdapter:
                 property_name=property_name,
                 value=value,
                 observed_at=observed_at,
+                source_transport=ZendureTransport.ZENSDK,
             ):
                 confirmed += 1
         return confirmed

--- a/tests/test_native_command_verification.py
+++ b/tests/test_native_command_verification.py
@@ -86,6 +86,44 @@ class NativeCommandVerificationTests(unittest.TestCase):
             observed_at=NOW + timedelta(seconds=1),
         ))
 
+    def test_readback_records_actual_source_not_write_transport(self):
+        manager = NativeCommandVerificationManager()
+        command = prepared(manager)
+        sent(manager, command)
+        self.assertTrue(manager.observe_readback(
+            command.command_id,
+            device_id="private-device-a",
+            property_name="outputLimit",
+            value=100,
+            observed_at=NOW + timedelta(seconds=1),
+            source_transport=ZendureTransport.CLOUD_MQTT,
+        ))
+        self.assertEqual(command.transport, ZendureTransport.ZENSDK)
+        self.assertEqual(
+            command.readback_transport,
+            ZendureTransport.CLOUD_MQTT,
+        )
+        self.assertEqual(
+            command.diagnostics()["readback_transport"],
+            "cloud_mqtt",
+        )
+
+    def test_retained_readback_never_confirms_command(self):
+        manager = NativeCommandVerificationManager()
+        command = prepared(manager)
+        sent(manager, command)
+        self.assertFalse(manager.observe_readback(
+            command.command_id,
+            device_id="private-device-a",
+            property_name="outputLimit",
+            value=100,
+            observed_at=NOW + timedelta(seconds=1),
+            source_transport=ZendureTransport.LOCAL_MQTT,
+            retained=True,
+        ))
+        self.assertEqual(command.status, CommandVerificationStatus.TRANSPORT_OK)
+        self.assertIsNone(command.readback_transport)
+
     def test_mismatch_contradiction_and_timeouts_are_distinct(self):
         manager = NativeCommandVerificationManager()
         mismatch = prepared(manager)

--- a/tests/test_native_economics_dedup.py
+++ b/tests/test_native_economics_dedup.py
@@ -1,0 +1,44 @@
+"""Economics invariants for parallel native telemetry sources."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import unittest
+
+from support import bootstrap
+
+bootstrap()
+
+from custom_components.battery_smartflow_ai.economics import (  # noqa: E402
+    EconomicPowerFlows,
+    EnergyAccumulator,
+)
+
+
+class NativeEconomicsDeduplicationTests(unittest.TestCase):
+    def test_same_arbitrated_runtime_cycle_is_accounted_once(self) -> None:
+        now = datetime(2026, 9, 7, 12, 0, tzinfo=timezone.utc)
+        power = EconomicPowerFlows(grid_to_battery_w=1800)
+        accumulator = EnergyAccumulator(max_interval_seconds=300)
+        accumulator.add_sample(sampled_at=now, power=power)
+
+        first = accumulator.add_sample(
+            sampled_at=now + timedelta(seconds=20),
+            power=power,
+        )
+        duplicate = accumulator.add_sample(
+            sampled_at=now + timedelta(seconds=20),
+            power=power,
+        )
+
+        self.assertEqual(first.status, "accounted")
+        self.assertEqual(duplicate.status, "duplicate_or_out_of_order")
+        self.assertEqual(duplicate.accounted_seconds, 0.0)
+        self.assertAlmostEqual(
+            accumulator.snapshot().total.grid_to_battery_kwh,
+            0.01,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_native_source_fusion.py
+++ b/tests/test_native_source_fusion.py
@@ -104,6 +104,32 @@ class NativeSourceFusionTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(state.hems_active.validity, ValueValidity.INVALID)
         self.assertIsNone(state.hems_active.value)
 
+    def test_small_soc_difference_is_allowed_but_large_conflict_blocks(self):
+        self.fusion.apply(
+            report(self.now, {"electricLevel": 50}, transport="cloud_mqtt")
+        )
+        plausible = self.fusion.apply(
+            report(self.now, {"electricLevel": 52}, transport="zensdk")
+        ).state
+        self.assertTrue(plausible.soc_pct.valid)
+        conflicting = self.fusion.apply(
+            report(
+                self.now + timedelta(seconds=1),
+                {"electricLevel": 70},
+                transport="zensdk",
+            )
+        ).state
+        self.assertEqual(conflicting.soc_pct.validity, ValueValidity.INVALID)
+
+    def test_conflicting_fresh_modes_block_selection(self):
+        self.fusion.apply(
+            report(self.now, {"acMode": 1}, transport="cloud_mqtt")
+        )
+        state = self.fusion.apply(
+            report(self.now, {"acMode": 2}, transport="zensdk")
+        ).state
+        self.assertEqual(state.mode.validity, ValueValidity.INVALID)
+
     def test_pack_properties_are_fused_and_zero_remains_valid(self):
         self.fusion.apply(report(
             self.now,

--- a/tests/test_v460_economics_scenarios.py
+++ b/tests/test_v460_economics_scenarios.py
@@ -208,6 +208,25 @@ def test_restart_preserves_totals_without_booking_offline_gap_twice() -> None:
     assert restored_engine.total_snapshot().grid_charge_cost == pytest.approx(0.003)
 
 
+def test_same_runtime_cycle_cannot_book_parallel_sources_twice() -> None:
+    """One arbitrated state timestamp remains one physical accounting sample."""
+
+    power = EconomicPowerFlows(grid_to_battery_w=1800)
+    accumulator = EnergyAccumulator(max_interval_seconds=300)
+    accumulator.add_sample(sampled_at=NOW, power=power)
+    first = accumulator.add_sample(
+        sampled_at=NOW + timedelta(seconds=20), power=power
+    )
+    duplicate = accumulator.add_sample(
+        sampled_at=NOW + timedelta(seconds=20), power=power
+    )
+
+    assert first.status == "accounted"
+    assert duplicate.status == "duplicate_or_out_of_order"
+    assert duplicate.accounted_seconds == 0.0
+    assert accumulator.snapshot().total.grid_to_battery_kwh == pytest.approx(0.01)
+
+
 def test_midnight_keeps_total_and_books_only_new_day_share_as_daily() -> None:
     accumulator = EnergyAccumulator(max_interval_seconds=300)
     engine = EconomicsEngine(currency="EUR")


### PR DESCRIPTION
## Summary

- record the actual transport that confirmed each native command readback, independently from the write transport
- reject retained MQTT messages as command confirmation
- fail closed for strongly conflicting SoC, cell-voltage, temperature, and operating-mode sources while allowing small defined measurement differences
- lock in the single-accounting invariant for parallel native telemetry reaching one arbitrated runtime cycle

## Validation

- `python -m unittest discover -s tests -p 'test_native_*.py'` (103 tests)
- `python -m unittest discover -s tests -p 'test_zendure_*.py'` (132 tests)
- `python -m compileall -q custom_components/battery_smartflow_ai tests`
- `git diff --check`

Closes #349.