### PR TITLE
Bind upgraded V4 systems to confirmed native devices

### DIFF
--- a/custom_components/battery_smartflow_ai/config_flow.py
+++ b/custom_components/battery_smartflow_ai/config_flow.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Mapping
 
 import voluptuous as vol
 from homeassistant import config_entries
@@ -897,6 +897,19 @@ class ZendureSmartFlowOptionsFlow(config_entries.OptionsFlow):
                             CONF_NATIVE_ZENDURE_LOCAL_MQTT_PASSWORD
                         ),
                     )
+                )
+            migration = self.config_entry.data.get("v5_migration")
+            if isinstance(migration, Mapping):
+                from .v5_migration import confirm_native_binding
+
+                data = dict(self.config_entry.data)
+                data["v5_migration"] = confirm_native_binding(
+                    migration,
+                    native_candidate_id=selected,
+                )
+                self.hass.config_entries.async_update_entry(
+                    self.config_entry,
+                    data=data,
                 )
             return self.async_create_entry(title="", data=options)
 

--- a/custom_components/battery_smartflow_ai/coordinator.py
+++ b/custom_components/battery_smartflow_ai/coordinator.py
@@ -588,9 +588,17 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     async def _load(self) -> None:
         load_result = await self._state_store.load()
         if load_result.usable:
+            migration = self.entry.data.get("v5_migration", {})
+            confirmed_native_id = (
+                migration.get("native_candidate_id")
+                if isinstance(migration, dict)
+                and migration.get("binding_state") == "confirmed"
+                else None
+            )
             loaded_data = migrate_persisted_v47_state(
                 load_result.data,
                 legacy_system_id=f"config_entry:{self.entry.entry_id}",
+                native_candidate_id=confirmed_native_id,
             )
             migrate_legacy_price_fields(loaded_data)
             self._persist.update(loaded_data)

--- a/custom_components/battery_smartflow_ai/v5_migration.py
+++ b/custom_components/battery_smartflow_ai/v5_migration.py
@@ -78,8 +78,31 @@ def match_v4_device(
     )
 
 
+def confirm_native_binding(
+    migration: Mapping[str, Any],
+    *,
+    native_candidate_id: str,
+) -> dict[str, Any]:
+    """Bind the user-confirmed V4 system without granting write authority."""
+
+    candidate_id = str(native_candidate_id).strip()
+    if not candidate_id:
+        raise ValueError("native_candidate_id is required")
+    if not str(migration.get("legacy_system_id", "")).strip():
+        raise ValueError("legacy_system_id is required")
+    confirmed = deepcopy(dict(migration))
+    confirmed["schema_version"] = V5_MIGRATION_SCHEMA
+    confirmed["phase"] = MigrationPhase.SHADOW_READY.value
+    confirmed["binding_state"] = BindingState.CONFIRMED.value
+    confirmed["native_candidate_id"] = candidate_id
+    confirmed["native_control_enabled"] = False
+    confirmed["legacy_zha_enabled"] = True
+    return confirmed
+
+
 def migrate_persisted_v47_state(
     state: Mapping[str, Any], *, legacy_system_id: str,
+    native_candidate_id: str | None = None,
 ) -> dict[str, Any]:
     """Preserve the flat V4 document and add restart-safe ownership metadata."""
 
@@ -87,10 +110,15 @@ def migrate_persisted_v47_state(
     migrated.setdefault("v5_migration_schema", V5_MIGRATION_SCHEMA)
     migrated.setdefault("v5_legacy_system_id", legacy_system_id)
     migrated["v5_native_control_enabled"] = False
-    migrated.setdefault("v5_native_candidate_id", None)
-    migrated.setdefault("v5_binding_state", BindingState.UNMATCHED.value)
+    if native_candidate_id:
+        migrated["v5_native_candidate_id"] = native_candidate_id
+        migrated["v5_binding_state"] = BindingState.CONFIRMED.value
+    else:
+        migrated.setdefault("v5_native_candidate_id", None)
+        migrated.setdefault("v5_binding_state", BindingState.UNMATCHED.value)
     migrated["v5_legacy_zha_enabled"] = True
-    migrated.setdefault("v5_economics_owner", legacy_system_id)
+    owner = native_candidate_id or legacy_system_id
+    migrated["v5_economics_owner"] = owner
     if migrated.get("charge_commit_active"):
-        migrated.setdefault("v5_charge_commit_owner", legacy_system_id)
+        migrated["v5_charge_commit_owner"] = owner
     return migrated

--- a/tests/test_v5_migration.py
+++ b/tests/test_v5_migration.py
@@ -10,7 +10,8 @@ from custom_components.battery_smartflow_ai.core.models import (  # noqa: E402
     DiscoveryCandidate, NativeDeviceIdentity, ZendureTransport,
 )
 from custom_components.battery_smartflow_ai.v5_migration import (  # noqa: E402
-    initial_v5_migration_state, match_v4_device, migrate_persisted_v47_state,
+    confirm_native_binding, initial_v5_migration_state, match_v4_device,
+    migrate_persisted_v47_state,
 )
 
 
@@ -62,6 +63,51 @@ class V5MigrationTests(unittest.TestCase):
         )
         twice = migrate_persisted_v47_state(
             once, legacy_system_id="config_entry:entry-1"
+        )
+        self.assertEqual(once, twice)
+
+    def test_confirmed_binding_keeps_zha_and_native_writes_separate(self):
+        initial = initial_v5_migration_state("entry-1")
+        confirmed = confirm_native_binding(
+            initial.as_dict(),
+            native_candidate_id="cloud_mqtt:device-1",
+        )
+        self.assertEqual(confirmed["binding_state"], "confirmed")
+        self.assertEqual(confirmed["phase"], "shadow_ready")
+        self.assertEqual(
+            confirmed["native_candidate_id"],
+            "cloud_mqtt:device-1",
+        )
+        self.assertFalse(confirmed["native_control_enabled"])
+        self.assertTrue(confirmed["legacy_zha_enabled"])
+
+    def test_confirmed_device_owns_persisted_economics_and_commitment(self):
+        native_id = "cloud_mqtt:device-1"
+        migrated = migrate_persisted_v47_state(
+            {
+                "charge_commit_active": True,
+                "v5_economics_owner": "config_entry:entry-1",
+                "v5_charge_commit_owner": "config_entry:entry-1",
+            },
+            legacy_system_id="config_entry:entry-1",
+            native_candidate_id=native_id,
+        )
+        self.assertEqual(migrated["v5_binding_state"], "confirmed")
+        self.assertEqual(migrated["v5_economics_owner"], native_id)
+        self.assertEqual(migrated["v5_charge_commit_owner"], native_id)
+        self.assertFalse(migrated["v5_native_control_enabled"])
+
+    def test_confirmed_persistence_binding_is_idempotent(self):
+        native_id = "cloud_mqtt:device-1"
+        once = migrate_persisted_v47_state(
+            {"charge_commit_active": True},
+            legacy_system_id="config_entry:entry-1",
+            native_candidate_id=native_id,
+        )
+        twice = migrate_persisted_v47_state(
+            once,
+            legacy_system_id="config_entry:entry-1",
+            native_candidate_id=native_id,
         )
         self.assertEqual(once, twice)
 


### PR DESCRIPTION
## Summary

- turn the explicit native-device selection into a restart-safe V4-to-V5 system binding for upgraded config entries
- transfer persisted Economics and active charge-commitment ownership to the confirmed native device without resetting their data
- keep the Z-HA transition path and native write consent separate, idempotent, and disabled by migration alone

## Validation

- `python -m unittest discover -s tests -p 'test_native_*.py'` (103 tests)
- `python -m unittest discover -s tests -p 'test_v5_migration.py'` (9 tests)
- `python -m unittest discover -s tests -p 'test_v470_backward_compatibility.py'` (4 tests)
- `python -m compileall -q custom_components/battery_smartflow_ai tests`
- `git diff --check`

Progresses #330.