### PR TITLE
Guard the confirmed V4 native-device binding

### DIFF
--- a/custom_components/battery_smartflow_ai/__init__.py
+++ b/custom_components/battery_smartflow_ai/__init__.py
@@ -143,10 +143,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     else:
         from .native_zendure_runtime import NativeZendureRuntime
 
+        migration = entry.data.get("v5_migration", {})
+        migration_bound_device = (
+            migration.get("native_candidate_id")
+            if isinstance(migration, dict)
+            and migration.get("binding_state") == "confirmed"
+            else None
+        )
         coordinator.native_zendure = NativeZendureRuntime(
             hass,
             app_token=entry.options.get(CONF_NATIVE_ZENDURE_APP_TOKEN),
             selected_device=entry.options.get(CONF_NATIVE_ZENDURE_SELECTED_DEVICE),
+            migration_bound_device=migration_bound_device,
             control_enabled=bool(
                 entry.options.get(CONF_NATIVE_ZENDURE_CONTROL_ENABLED, False)
             ),

--- a/custom_components/battery_smartflow_ai/native_device_overview.py
+++ b/custom_components/battery_smartflow_ai/native_device_overview.py
@@ -58,6 +58,7 @@ class MainSystemOverview:
     control_block_reason: str | None
     last_message_at: datetime | None
     packs: tuple[PackOverview, ...]
+    migration_bound: bool = False
 
     def __post_init__(self) -> None:
         object.__setattr__(
@@ -68,6 +69,8 @@ class MainSystemOverview:
 def build_native_device_overview(
     inventory: DeviceInventory,
     states: Mapping[str, NeutralDeviceState],
+    *,
+    migration_bound_device: str | None = None,
 ) -> tuple[MainSystemOverview, ...]:
     """Build an unbounded hierarchy without exposing stable source identities."""
 
@@ -170,6 +173,7 @@ def build_native_device_overview(
                 ),
                 last_message_at=state.last_message_at if state else None,
                 packs=tuple(packs),
+                migration_bound=system_id == migration_bound_device,
             )
         )
     return tuple(result)

--- a/custom_components/battery_smartflow_ai/native_zendure_runtime.py
+++ b/custom_components/battery_smartflow_ai/native_zendure_runtime.py
@@ -110,6 +110,7 @@ class NativeZendureRuntime:
         app_token: str | None,
         selected_device: str | None,
         notify: Callable[[], None],
+        migration_bound_device: str | None = None,
         control_enabled: bool = False,
         local_mqtt_server: str | None = None,
         local_mqtt_port: int = 1883,
@@ -119,6 +120,7 @@ class NativeZendureRuntime:
         self._hass = hass
         self._app_token = app_token
         self._selected_device = selected_device
+        self._migration_bound_device = migration_bound_device
         self._control_enabled = bool(control_enabled)
         self._notify = notify
         self._task: asyncio.Task[None] | None = None
@@ -312,7 +314,11 @@ class NativeZendureRuntime:
 
     def overview_attributes(self) -> dict[str, Any]:
         systems = []
-        overview = build_native_device_overview(self._inventory, self._states)
+        overview = build_native_device_overview(
+            self._inventory,
+            self._states,
+            migration_bound_device=self._migration_bound_device,
+        )
         now = datetime.now(timezone.utc)
         for system_id, item in zip(sorted(self._inventory.devices), overview):
             state = self._states.get(system_id)
@@ -324,6 +330,9 @@ class NativeZendureRuntime:
                     "model": item.model,
                     "profile": item.profile_key,
                     "selected": system_id == self._selected_device,
+                    "migration_binding": (
+                        "confirmed" if item.migration_bound else "not_bound"
+                    ),
                     "online": item.online,
                     "status": item.status_text,
                     "transport": (
@@ -375,7 +384,11 @@ class NativeZendureRuntime:
     def hardware_overview(self):
         """Return the privacy-safe native hierarchy used by HA entities."""
 
-        overview = build_native_device_overview(self._inventory, self._states)
+        overview = build_native_device_overview(
+            self._inventory,
+            self._states,
+            migration_bound_device=self._migration_bound_device,
+        )
         selected_transport = self._selected_local_transport()
         if selected_transport is None or self._selected_device is None:
             return overview
@@ -1037,6 +1050,16 @@ class NativeZendureRuntime:
             self._transport_router.update_readiness(
                 ready=False,
                 reason="native_control_disabled",
+            )
+            return
+        if (
+            self._migration_bound_device is not None
+            and self._migration_bound_device != self._selected_device
+        ):
+            self._transport_router.select(self._selected_device, None)
+            self._transport_router.update_readiness(
+                ready=False,
+                reason="migration_binding_mismatch",
             )
             return
         device = self._inventory.devices.get(self._selected_device)

--- a/custom_components/battery_smartflow_ai/sensor.py
+++ b/custom_components/battery_smartflow_ai/sensor.py
@@ -1638,6 +1638,17 @@ class NativeZendureHardwareSensor(CoordinatorEntity, SensorEntity):
         return None
 
     @property
+    def extra_state_attributes(self):
+        item = self._item()
+        if self._kind != "main" or item is None:
+            return None
+        return {
+            "v4_migration_binding": (
+                "confirmed" if item.migration_bound else "not_bound"
+            )
+        }
+
+    @property
     def available(self) -> bool:
         item = self._item()
         if item is None or not self.coordinator.last_update_success:

--- a/tests/test_native_device_overview.py
+++ b/tests/test_native_device_overview.py
@@ -48,6 +48,20 @@ class NativeDeviceOverviewTests(unittest.TestCase):
         self.assertNotEqual(overview[0].public_id, overview[1].public_id)
         self.assertEqual({item.display_name for item in overview}, {"Battery"})
 
+    def test_only_confirmed_upgrade_device_is_marked_as_bound(self):
+        inventory = DeviceInventory(devices=(
+            MainDevice("native-a", "First"),
+            MainDevice("native-b", "Second"),
+        ))
+        overview = build_native_device_overview(
+            inventory,
+            {},
+            migration_bound_device="native-b",
+        )
+        by_name = {item.display_name: item for item in overview}
+        self.assertFalse(by_name["First"].migration_bound)
+        self.assertTrue(by_name["Second"].migration_bound)
+
     def test_unknown_pack_model_keeps_verified_measurements(self):
         main = MainDevice("main-secret", "Main")
         inventory = DeviceInventory(

--- a/tests/test_native_power_controller.py
+++ b/tests/test_native_power_controller.py
@@ -132,10 +132,11 @@ class FakeLocalTransport:
         )
 
 
-def runtime(*, enabled=True, current_state=None):
+def runtime(*, enabled=True, current_state=None, migration_bound_device=None):
     result = NativeZendureRuntime(
         SimpleNamespace(), app_token="configured", selected_device=DEVICE,
         notify=lambda: None, control_enabled=enabled,
+        migration_bound_device=migration_bound_device,
     )
     identity = NativeDeviceIdentity(
         ZendureTransport.CLOUD_MQTT, device_id="main-1",
@@ -180,6 +181,14 @@ def legacy_runtime(*, current_state=None):
 
 
 class NativePowerControllerTests(unittest.IsolatedAsyncioTestCase):
+    async def test_migration_binding_mismatch_revokes_write_authority(self):
+        target = runtime(migration_bound_device="cloud_mqtt:other-device")
+        target._refresh_write_authority()
+        authority = target._transport_router.snapshot
+        self.assertFalse(authority.synchronized)
+        self.assertIsNone(authority.transport)
+        self.assertEqual(authority.reason, "migration_binding_mismatch")
+
     async def test_hardware_status_separates_enabled_idle_from_active_control(self):
         idle = runtime(current_state=state())
         idle._refresh_write_authority()


### PR DESCRIPTION
## Summary

- propagate the confirmed V4 migration binding into the native runtime and hardware overview
- expose which physical main device is the confirmed migration target without merging it into the existing virtual control device
- revoke native write authority when the selected device and confirmed migration binding disagree, preventing an implicit reassignment or fallback
- retain all established V4 entity unique IDs and the main-device/pack hierarchy

## Validation

- `python -m unittest discover -s tests -p 'test_native_*.py'` (105 tests)
- `python -m unittest discover -s tests -p 'test_v5_migration.py'` (9 tests)
- `python -m unittest discover -s tests -p 'test_v470_backward_compatibility.py'` (4 tests)
- `python -m compileall -q custom_components/battery_smartflow_ai tests`
- `git diff --check`

Progresses #330.