### PR TITLE
Lock in V4-to-V5 upgrade registry continuity

### DIFF
--- a/custom_components/battery_smartflow_ai/native_registry_identity.py
+++ b/custom_components/battery_smartflow_ai/native_registry_identity.py
@@ -1,0 +1,32 @@
+"""Stable Home Assistant registry identities for native Zendure hardware."""
+
+from __future__ import annotations
+
+from .const import DOMAIN
+
+
+def native_hardware_unique_id(
+    entry_id: str,
+    kind: str,
+    public_id: str,
+    entity_key: str,
+) -> str:
+    """Return the established native entity identity without raw device IDs."""
+
+    if kind not in {"main", "pack"}:
+        raise ValueError("unsupported native hardware kind")
+    if not all((entry_id, public_id, entity_key)):
+        raise ValueError("native registry identity parts must not be empty")
+    return f"{DOMAIN}_{entry_id}_native_{kind}_{public_id}_{entity_key}"
+
+
+def native_main_device_identifier(public_id: str) -> tuple[str, str]:
+    if not public_id:
+        raise ValueError("public_id must not be empty")
+    return DOMAIN, f"native_zendure_{public_id}"
+
+
+def native_pack_device_identifier(public_id: str) -> tuple[str, str]:
+    if not public_id:
+        raise ValueError("public_id must not be empty")
+    return DOMAIN, f"native_zendure_pack_{public_id}"

--- a/custom_components/battery_smartflow_ai/sensor.py
+++ b/custom_components/battery_smartflow_ai/sensor.py
@@ -54,6 +54,11 @@ from .const import (
 )
 from .device_profiles import DEVICE_PROFILES
 from .diagnostic_values import safe_diagnostic_sensor_value
+from .native_registry_identity import (
+    native_hardware_unique_id,
+    native_main_device_identifier,
+    native_pack_device_identifier,
+)
 from .price_currency import price_input_profile
 
 _LOGGER = logging.getLogger(__name__)
@@ -1578,14 +1583,17 @@ class NativeZendureHardwareSensor(CoordinatorEntity, SensorEntity):
         self._kind = kind
         self._public_id = public_id
         self._parent_public_id = parent_public_id
-        self._attr_unique_id = (
-            f"{DOMAIN}_{entry.entry_id}_native_{kind}_{public_id}_{description.key}"
+        self._attr_unique_id = native_hardware_unique_id(
+            entry.entry_id,
+            kind,
+            public_id,
+            description.key,
         )
         item = self._item()
         if kind == "main":
             firmware = _measured_value(getattr(item, "firmware", None))
             self._attr_device_info = DeviceInfo(
-                identifiers={(DOMAIN, f"native_zendure_{public_id}")},
+                identifiers={native_main_device_identifier(public_id)},
                 name=item.display_name if item else "Zendure system",
                 manufacturer="Zendure",
                 model=(item.model or "Unknown Zendure system") if item else None,
@@ -1612,13 +1620,13 @@ class NativeZendureHardwareSensor(CoordinatorEntity, SensorEntity):
                 parent.display_name if parent is not None else "Zendure"
             )
             self._attr_device_info = DeviceInfo(
-                identifiers={(DOMAIN, f"native_zendure_pack_{public_id}")},
+                identifiers={native_pack_device_identifier(public_id)},
                 name=f"{parent_name} {_battery_pack_label(coordinator.hass.config.language)} {pack_number}",
                 manufacturer="Zendure",
                 model=(item.pack_model or "Unknown battery pack") if item else None,
                 serial_number=item.serial_number if item else None,
                 sw_version=str(firmware) if firmware is not None else None,
-                via_device=(DOMAIN, f"native_zendure_{parent_public_id}"),
+                via_device=native_main_device_identifier(parent_public_id),
             )
 
     def _parent_system(self):

--- a/tests/test_native_zendure_ha_integration.py
+++ b/tests/test_native_zendure_ha_integration.py
@@ -87,9 +87,15 @@ class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
 
     def test_native_hardware_is_exposed_as_child_devices_not_config_inputs(self) -> None:
         sensor = (COMPONENT / "sensor.py").read_text(encoding="utf-8")
+        identity = (COMPONENT / "native_registry_identity.py").read_text(
+            encoding="utf-8"
+        )
         config = (COMPONENT / "config_flow.py").read_text(encoding="utf-8")
         self.assertIn("class NativeZendureHardwareSensor", sensor)
-        self.assertIn('via_device=(DOMAIN, f"native_zendure_{parent_public_id}")', sensor)
+        self.assertIn(
+            "via_device=native_main_device_identifier(parent_public_id)", sensor
+        )
+        self.assertIn('return DOMAIN, f"native_zendure_{public_id}"', identity)
         self.assertIn("coordinator.native_zendure.hardware_overview()", sensor)
         self.assertIn("coordinator.async_add_listener", sensor)
         self.assertNotIn("native_hardware_soc_pct", config)
@@ -100,8 +106,8 @@ class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
         entity = sensor[sensor.index("class NativeZendureHardwareSensor"):]
         self.assertIn("public_id", entity)
         self.assertIn("serial_number=item.serial_number", entity)
-        self.assertNotIn("device_id", entity)
-        self.assertNotIn("pack_id", entity)
+        self.assertNotIn("item.device_id", entity)
+        self.assertNotIn("item.pack_id", entity)
 
     def test_pack_device_name_uses_parent_name_and_stable_position(self) -> None:
         sensor = (COMPONENT / "sensor.py").read_text(encoding="utf-8")

--- a/tests/test_v5_upgrade_regression.py
+++ b/tests/test_v5_upgrade_regression.py
@@ -1,0 +1,102 @@
+"""End-to-end contracts for an existing V4.7 installation entering V5."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import unittest
+
+from support import bootstrap
+
+bootstrap()
+
+from custom_components.battery_smartflow_ai.native_registry_identity import (  # noqa: E402
+    native_hardware_unique_id,
+    native_main_device_identifier,
+    native_pack_device_identifier,
+)
+from custom_components.battery_smartflow_ai.v5_migration import (  # noqa: E402
+    confirm_native_binding,
+    initial_v5_migration_state,
+    migrate_persisted_v47_state,
+)
+
+
+class V5UpgradeRegressionTests(unittest.TestCase):
+    def test_v47_binding_restart_preserves_data_and_registry_identity(self):
+        entry_id = "existing-entry"
+        native_id = "cloud_mqtt:physical-device"
+        public_main = "ZD_DEVICE_123456789abc"
+        public_pack = "ZD_PACK_abcdef123456"
+        v47 = {
+            "learned_load_slots": {"12:00": 1.25},
+            "economics_money_state": {"grid_charge_cost": 12.34},
+            "economics_energy_state": {"pv_charge_kwh": 56.7},
+            "charge_commit_active": True,
+            "charge_commit_target_soc": 80,
+            "custom_future_value": [1, 2, 3],
+        }
+        migration = confirm_native_binding(
+            initial_v5_migration_state(entry_id).as_dict(),
+            native_candidate_id=native_id,
+        )
+        first_start = migrate_persisted_v47_state(
+            v47,
+            legacy_system_id=f"config_entry:{entry_id}",
+            native_candidate_id=migration["native_candidate_id"],
+        )
+
+        second_start = migrate_persisted_v47_state(
+            deepcopy(first_start),
+            legacy_system_id=f"config_entry:{entry_id}",
+            native_candidate_id=migration["native_candidate_id"],
+        )
+
+        self.assertEqual(first_start, second_start)
+        for key, value in v47.items():
+            self.assertEqual(second_start[key], value)
+        self.assertEqual(second_start["v5_economics_owner"], native_id)
+        self.assertEqual(second_start["v5_charge_commit_owner"], native_id)
+        self.assertFalse(second_start["v5_native_control_enabled"])
+        self.assertTrue(second_start["v5_legacy_zha_enabled"])
+
+        before_restart = (
+            native_hardware_unique_id(
+                entry_id, "main", public_main, "soc_pct"
+            ),
+            native_hardware_unique_id(
+                entry_id, "pack", public_pack, "soc_pct"
+            ),
+            native_main_device_identifier(public_main),
+            native_pack_device_identifier(public_pack),
+        )
+        after_restart = (
+            native_hardware_unique_id(
+                entry_id, "main", public_main, "soc_pct"
+            ),
+            native_hardware_unique_id(
+                entry_id, "pack", public_pack, "soc_pct"
+            ),
+            native_main_device_identifier(public_main),
+            native_pack_device_identifier(public_pack),
+        )
+        self.assertEqual(before_restart, after_restart)
+        self.assertEqual(len(set(before_restart)), len(before_restart))
+
+    def test_existing_v4_entity_identity_is_not_reused_by_native_hardware(self):
+        entry_id = "existing-entry"
+        legacy_unique_id = f"battery_smartflow_ai_{entry_id}_soc"
+        native_unique_id = native_hardware_unique_id(
+            entry_id,
+            "main",
+            "ZD_DEVICE_123456789abc",
+            "soc_pct",
+        )
+        self.assertNotEqual(legacy_unique_id, native_unique_id)
+        self.assertEqual(
+            legacy_unique_id,
+            "battery_smartflow_ai_existing-entry_soc",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- centralize the already-established native entity and device registry identifiers without changing their values
- add an end-to-end V4.7-to-V5 regression scenario covering confirmed hardware binding, persistence ownership transfer, restart idempotence, and legacy writer retention
- prove that existing V4 entities and new native hardware entities remain collision-free across restarts

## Safety guarantees
- existing entity unique IDs remain unchanged
- existing native main-device, pack-device, and parent-device identifiers remain unchanged
- native control stays disabled after migration
- the legacy Z-HA path stays enabled during the transition
- learned planning data, economics totals, active commitments, and unknown future persistence fields survive unchanged

## Validation
- 105 native integration tests
- 9 V5 migration tests
- 2 new upgrade regression tests
- 4 V4.7 backward-compatibility tests
- full unittest discovery: 645 tests passed; three pytest-based modules require the CI test environment because pytest is not installed in the local bundled runtime
- compileall
- git diff --check

Closes #330
Progresses #346