### PR TITLE
Add native full-charge maintenance core

### DIFF
--- a/custom_components/battery_smartflow_ai/core/full_charge_maintenance.py
+++ b/custom_components/battery_smartflow_ai/core/full_charge_maintenance.py
@@ -1,0 +1,308 @@
+"""Transport-neutral full-charge maintenance planning.
+
+This module deliberately does not claim to trigger BMS calibration.  It only
+plans and confirms a user-authorized, protective full charge when no verified
+native calibration capability exists.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from datetime import datetime, timedelta, timezone
+from enum import StrEnum
+from typing import Any, Mapping
+
+
+DEFAULT_INTERVAL_DAYS = 30
+DEFAULT_DUE_SOON_DAYS = 3
+DEFAULT_MAX_POSTPONE_DAYS = 7
+DEFAULT_FULL_CONFIRM_SECONDS = 300
+FULL_SOC_PCT = 100.0
+FULL_POWER_THRESHOLD_W = 50.0
+
+
+class MaintenanceState(StrEnum):
+    UNKNOWN = "unknown"
+    NOT_DUE = "not_due"
+    DUE_SOON = "due_soon"
+    DUE = "due"
+    WAITING_FOR_FAVORABLE_WINDOW = "waiting_for_favorable_window"
+    CHARGING_TO_FULL = "charging_to_full"
+    CONFIRMING_FULL = "confirming_full"
+    COMPLETED = "completed"
+    BLOCKED = "blocked"
+
+
+class MaintenanceBlockReason(StrEnum):
+    NONE = "none"
+    NOT_ENABLED = "not_enabled"
+    HEMS_ACTIVE = "hems_active"
+    DEVICE_NOT_READY = "device_not_ready"
+    TRANSPORT_UNAVAILABLE = "transport_unavailable"
+    SOC_INVALID_OR_STALE = "soc_invalid_or_stale"
+    PROTECTION_ACTIVE = "protection_active"
+    PACK_DATA_CONFLICT = "pack_data_conflict"
+
+
+class MaintenanceWindow(StrEnum):
+    NONE = "none"
+    PV_SURPLUS = "pv_surplus"
+    LOW_PRICE = "low_price"
+    EXISTING_STRATEGIC_CHARGE = "existing_strategic_charge"
+    OVERDUE_DEADLINE = "overdue_deadline"
+
+
+class CalibrationInformationSource(StrEnum):
+    UNSUPPORTED = "unsupported"
+    UNKNOWN = "unknown"
+    VERIFIED_NATIVE = "verified_native"
+    BSFAI_DERIVED = "bsfai_derived"
+
+
+@dataclass(frozen=True, slots=True)
+class NativeCalibrationInformation:
+    """Calibration information exposed only after semantic verification."""
+
+    source: CalibrationInformationSource = CalibrationInformationSource.UNKNOWN
+    status: str | None = None
+    last_calibration_at: datetime | None = None
+    next_calibration_at: datetime | None = None
+
+    def __post_init__(self) -> None:
+        if self.source is not CalibrationInformationSource.VERIFIED_NATIVE and any(
+            (self.status, self.last_calibration_at, self.next_calibration_at)
+        ):
+            raise ValueError("unverified values must not be exposed as native calibration")
+
+
+@dataclass(frozen=True, slots=True)
+class FullChargeMaintenanceRecord:
+    """Persistable per-device maintenance state, never a low-level command."""
+
+    device_id: str
+    interval_days: int = DEFAULT_INTERVAL_DAYS
+    last_confirmed_full_at: datetime | None = None
+    last_completed_maintenance_at: datetime | None = None
+    active: bool = False
+    full_candidate_since: datetime | None = None
+
+    def __post_init__(self) -> None:
+        if not self.device_id.strip():
+            raise ValueError("device_id is required")
+        if self.interval_days < 1:
+            raise ValueError("interval_days must be positive")
+
+    @property
+    def next_recommended_full_at(self) -> datetime | None:
+        if self.last_confirmed_full_at is None:
+            return None
+        return self.last_confirmed_full_at + timedelta(days=self.interval_days)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "device_id": self.device_id,
+            "interval_days": self.interval_days,
+            "last_confirmed_full_at": _format_time(self.last_confirmed_full_at),
+            "last_completed_maintenance_at": _format_time(
+                self.last_completed_maintenance_at
+            ),
+            "active": self.active,
+            "full_candidate_since": _format_time(self.full_candidate_since),
+        }
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any]) -> FullChargeMaintenanceRecord:
+        return cls(
+            device_id=str(value["device_id"]),
+            interval_days=int(value.get("interval_days", DEFAULT_INTERVAL_DAYS)),
+            last_confirmed_full_at=_parse_time(value.get("last_confirmed_full_at")),
+            last_completed_maintenance_at=_parse_time(
+                value.get("last_completed_maintenance_at")
+            ),
+            active=bool(value.get("active", False)),
+            full_candidate_since=_parse_time(value.get("full_candidate_since")),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class FullChargeMaintenanceInput:
+    now: datetime
+    enabled: bool
+    soc_pct: float | None
+    soc_fresh: bool
+    charge_power_w: float | None = None
+    device_ready: bool = True
+    transport_available: bool = True
+    hems_active: bool = False
+    protection_active: bool = False
+    pack_data_conflict: bool = False
+    pv_window_favorable: bool = False
+    price_window_favorable: bool = False
+    strategic_charge_active: bool = False
+    native_full_state_confirmed: bool = False
+
+    def __post_init__(self) -> None:
+        if self.now.tzinfo is None:
+            raise ValueError("now must be timezone-aware")
+
+
+@dataclass(frozen=True, slots=True)
+class FullChargeMaintenanceDecision:
+    record: FullChargeMaintenanceRecord
+    state: MaintenanceState
+    block_reason: MaintenanceBlockReason = MaintenanceBlockReason.NONE
+    selected_window: MaintenanceWindow = MaintenanceWindow.NONE
+    request_full_charge: bool = False
+    target_soc_pct: float | None = None
+    temporary_user_limit_override: bool = False
+
+
+class FullChargeMaintenancePlanner:
+    """Evaluate one device without transport or Home Assistant dependencies."""
+
+    def __init__(
+        self,
+        *,
+        due_soon_days: int = DEFAULT_DUE_SOON_DAYS,
+        max_postpone_days: int = DEFAULT_MAX_POSTPONE_DAYS,
+        full_confirm_seconds: int = DEFAULT_FULL_CONFIRM_SECONDS,
+    ) -> None:
+        if min(due_soon_days, max_postpone_days, full_confirm_seconds) < 0:
+            raise ValueError("maintenance timing values must not be negative")
+        self._due_soon = timedelta(days=due_soon_days)
+        self._max_postpone = timedelta(days=max_postpone_days)
+        self._full_confirm = timedelta(seconds=full_confirm_seconds)
+
+    def evaluate(
+        self,
+        record: FullChargeMaintenanceRecord,
+        data: FullChargeMaintenanceInput,
+    ) -> FullChargeMaintenanceDecision:
+        now = data.now.astimezone(timezone.utc)
+        next_due = record.next_recommended_full_at
+        base_state = _schedule_state(next_due, now, self._due_soon)
+
+        invalid_reason = _block_reason(data)
+        if invalid_reason is not MaintenanceBlockReason.NONE:
+            return FullChargeMaintenanceDecision(
+                replace(record, full_candidate_since=None),
+                MaintenanceState.BLOCKED,
+                block_reason=invalid_reason,
+            )
+
+        at_full = data.soc_pct is not None and data.soc_pct >= FULL_SOC_PCT
+        if at_full:
+            candidate_since = record.full_candidate_since or now
+            confirming = replace(record, full_candidate_since=candidate_since)
+            full_is_plausible = (
+                data.native_full_state_confirmed
+                or data.charge_power_w is not None
+                and abs(data.charge_power_w) <= FULL_POWER_THRESHOLD_W
+            )
+            if now - candidate_since >= self._full_confirm and full_is_plausible:
+                completed = replace(
+                    confirming,
+                    last_confirmed_full_at=now,
+                    last_completed_maintenance_at=now if record.active else (
+                        record.last_completed_maintenance_at
+                    ),
+                    active=False,
+                    full_candidate_since=None,
+                )
+                return FullChargeMaintenanceDecision(
+                    completed, MaintenanceState.COMPLETED
+                )
+            return FullChargeMaintenanceDecision(
+                confirming,
+                MaintenanceState.CONFIRMING_FULL,
+                request_full_charge=record.active,
+                target_soc_pct=FULL_SOC_PCT if record.active else None,
+                temporary_user_limit_override=record.active,
+            )
+
+        record = replace(record, full_candidate_since=None)
+        if record.active:
+            return _charging_decision(record, MaintenanceWindow.NONE)
+        if base_state in {MaintenanceState.NOT_DUE, MaintenanceState.DUE_SOON}:
+            return FullChargeMaintenanceDecision(record, base_state)
+        if not data.enabled:
+            return FullChargeMaintenanceDecision(
+                record,
+                MaintenanceState.BLOCKED,
+                block_reason=MaintenanceBlockReason.NOT_ENABLED,
+            )
+
+        window = _select_window(data)
+        if window is MaintenanceWindow.NONE and next_due is not None:
+            if now >= next_due + self._max_postpone:
+                window = MaintenanceWindow.OVERDUE_DEADLINE
+        if window is MaintenanceWindow.NONE:
+            return FullChargeMaintenanceDecision(
+                record, MaintenanceState.WAITING_FOR_FAVORABLE_WINDOW
+            )
+        return _charging_decision(replace(record, active=True), window)
+
+
+def _charging_decision(
+    record: FullChargeMaintenanceRecord, window: MaintenanceWindow
+) -> FullChargeMaintenanceDecision:
+    return FullChargeMaintenanceDecision(
+        record,
+        MaintenanceState.CHARGING_TO_FULL,
+        selected_window=window,
+        request_full_charge=True,
+        target_soc_pct=FULL_SOC_PCT,
+        temporary_user_limit_override=True,
+    )
+
+
+def _schedule_state(
+    next_due: datetime | None, now: datetime, due_soon: timedelta
+) -> MaintenanceState:
+    if next_due is None:
+        return MaintenanceState.DUE
+    due = next_due.astimezone(timezone.utc)
+    if now >= due:
+        return MaintenanceState.DUE
+    if now >= due - due_soon:
+        return MaintenanceState.DUE_SOON
+    return MaintenanceState.NOT_DUE
+
+
+def _block_reason(data: FullChargeMaintenanceInput) -> MaintenanceBlockReason:
+    if data.hems_active:
+        return MaintenanceBlockReason.HEMS_ACTIVE
+    if data.protection_active:
+        return MaintenanceBlockReason.PROTECTION_ACTIVE
+    if data.pack_data_conflict:
+        return MaintenanceBlockReason.PACK_DATA_CONFLICT
+    if not data.device_ready:
+        return MaintenanceBlockReason.DEVICE_NOT_READY
+    if not data.transport_available:
+        return MaintenanceBlockReason.TRANSPORT_UNAVAILABLE
+    if not data.soc_fresh or data.soc_pct is None:
+        return MaintenanceBlockReason.SOC_INVALID_OR_STALE
+    return MaintenanceBlockReason.NONE
+
+
+def _select_window(data: FullChargeMaintenanceInput) -> MaintenanceWindow:
+    if data.pv_window_favorable:
+        return MaintenanceWindow.PV_SURPLUS
+    if data.price_window_favorable:
+        return MaintenanceWindow.LOW_PRICE
+    if data.strategic_charge_active:
+        return MaintenanceWindow.EXISTING_STRATEGIC_CHARGE
+    return MaintenanceWindow.NONE
+
+
+def _format_time(value: datetime | None) -> str | None:
+    return value.astimezone(timezone.utc).isoformat() if value is not None else None
+
+
+def _parse_time(value: Any) -> datetime | None:
+    if value in (None, ""):
+        return None
+    parsed = datetime.fromisoformat(str(value))
+    if parsed.tzinfo is None:
+        raise ValueError("persisted maintenance timestamps must be timezone-aware")
+    return parsed.astimezone(timezone.utc)

--- a/tests/test_full_charge_maintenance.py
+++ b/tests/test_full_charge_maintenance.py
@@ -1,0 +1,194 @@
+"""Contracts for the native per-device full-charge maintenance planner."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import unittest
+
+from support import bootstrap
+
+bootstrap()
+
+from custom_components.battery_smartflow_ai.core.full_charge_maintenance import (  # noqa: E402
+    CalibrationInformationSource,
+    FullChargeMaintenanceInput,
+    FullChargeMaintenancePlanner,
+    FullChargeMaintenanceRecord,
+    MaintenanceBlockReason,
+    MaintenanceState,
+    MaintenanceWindow,
+    NativeCalibrationInformation,
+)
+
+
+NOW = datetime(2026, 9, 7, 12, tzinfo=timezone.utc)
+
+
+def observation(**changes):
+    values = {
+        "now": NOW,
+        "enabled": True,
+        "soc_pct": 80.0,
+        "soc_fresh": True,
+        "charge_power_w": 500.0,
+    }
+    values.update(changes)
+    return FullChargeMaintenanceInput(**values)
+
+
+class FullChargeMaintenanceTests(unittest.TestCase):
+    def setUp(self):
+        self.planner = FullChargeMaintenancePlanner()
+
+    def record(self, device="device-a", *, days_ago=31, **changes):
+        values = {
+            "device_id": device,
+            "last_confirmed_full_at": NOW - timedelta(days=days_ago),
+        }
+        values.update(changes)
+        return FullChargeMaintenanceRecord(**values)
+
+    def test_not_due_due_soon_and_due_are_distinct(self):
+        self.assertEqual(
+            self.planner.evaluate(self.record(days_ago=1), observation()).state,
+            MaintenanceState.NOT_DUE,
+        )
+        self.assertEqual(
+            self.planner.evaluate(self.record(days_ago=28), observation()).state,
+            MaintenanceState.DUE_SOON,
+        )
+        self.assertEqual(
+            self.planner.evaluate(self.record(days_ago=31), observation()).state,
+            MaintenanceState.WAITING_FOR_FAVORABLE_WINDOW,
+        )
+
+    def test_pv_then_price_then_existing_charge_window_priority(self):
+        record = self.record()
+        both = self.planner.evaluate(
+            record, observation(pv_window_favorable=True, price_window_favorable=True)
+        )
+        self.assertEqual(both.selected_window, MaintenanceWindow.PV_SURPLUS)
+        price = self.planner.evaluate(
+            record, observation(price_window_favorable=True)
+        )
+        self.assertEqual(price.selected_window, MaintenanceWindow.LOW_PRICE)
+        existing = self.planner.evaluate(
+            record, observation(strategic_charge_active=True)
+        )
+        self.assertEqual(
+            existing.selected_window, MaintenanceWindow.EXISTING_STRATEGIC_CHARGE
+        )
+
+    def test_overdue_deadline_prevents_unbounded_postponement(self):
+        result = self.planner.evaluate(self.record(days_ago=38), observation())
+        self.assertEqual(result.selected_window, MaintenanceWindow.OVERDUE_DEADLINE)
+        self.assertTrue(result.request_full_charge)
+
+    def test_user_authorization_is_required_and_limit_override_is_temporary(self):
+        blocked = self.planner.evaluate(
+            self.record(), observation(enabled=False, price_window_favorable=True)
+        )
+        self.assertEqual(blocked.block_reason, MaintenanceBlockReason.NOT_ENABLED)
+        active = self.planner.evaluate(
+            self.record(), observation(price_window_favorable=True)
+        )
+        self.assertEqual(active.target_soc_pct, 100.0)
+        self.assertTrue(active.temporary_user_limit_override)
+        self.assertTrue(active.record.active)
+
+    def test_hems_protection_stale_soc_and_pack_conflict_block(self):
+        cases = (
+            ({"hems_active": True}, MaintenanceBlockReason.HEMS_ACTIVE),
+            ({"protection_active": True}, MaintenanceBlockReason.PROTECTION_ACTIVE),
+            ({"soc_fresh": False}, MaintenanceBlockReason.SOC_INVALID_OR_STALE),
+            ({"pack_data_conflict": True}, MaintenanceBlockReason.PACK_DATA_CONFLICT),
+            ({"transport_available": False}, MaintenanceBlockReason.TRANSPORT_UNAVAILABLE),
+        )
+        for changes, reason in cases:
+            with self.subTest(reason=reason):
+                result = self.planner.evaluate(self.record(), observation(**changes))
+                self.assertEqual(result.state, MaintenanceState.BLOCKED)
+                self.assertEqual(result.block_reason, reason)
+                self.assertFalse(result.request_full_charge)
+
+    def test_short_or_unconvincing_100_percent_does_not_complete(self):
+        active = self.record(active=True)
+        first = self.planner.evaluate(active, observation(soc_pct=100.0))
+        self.assertEqual(first.state, MaintenanceState.CONFIRMING_FULL)
+        early = self.planner.evaluate(
+            first.record,
+            observation(now=NOW + timedelta(minutes=4), soc_pct=100.0),
+        )
+        self.assertEqual(early.state, MaintenanceState.CONFIRMING_FULL)
+        high_power = self.planner.evaluate(
+            first.record,
+            observation(now=NOW + timedelta(minutes=6), soc_pct=100.0),
+        )
+        self.assertEqual(high_power.state, MaintenanceState.CONFIRMING_FULL)
+
+    def test_confirmed_full_completes_and_restores_normal_limit_semantics(self):
+        active = self.record(active=True)
+        first = self.planner.evaluate(active, observation(soc_pct=100.0))
+        completed = self.planner.evaluate(
+            first.record,
+            observation(
+                now=NOW + timedelta(minutes=5),
+                soc_pct=100.0,
+                charge_power_w=25.0,
+            ),
+        )
+        self.assertEqual(completed.state, MaintenanceState.COMPLETED)
+        self.assertFalse(completed.record.active)
+        self.assertFalse(completed.temporary_user_limit_override)
+        self.assertEqual(
+            completed.record.last_confirmed_full_at, NOW + timedelta(minutes=5)
+        )
+
+    def test_restart_preserves_per_device_commit_without_commands(self):
+        first = self.planner.evaluate(
+            self.record("device-a"), observation(price_window_favorable=True)
+        )
+        restored = FullChargeMaintenanceRecord.from_dict(first.record.as_dict())
+        self.assertEqual(restored, first.record)
+        self.assertEqual(set(restored.as_dict()), {
+            "device_id", "interval_days", "last_confirmed_full_at",
+            "last_completed_maintenance_at", "active", "full_candidate_since",
+        })
+        resumed = self.planner.evaluate(
+            restored, observation(now=NOW + timedelta(minutes=1))
+        )
+        self.assertEqual(resumed.state, MaintenanceState.CHARGING_TO_FULL)
+        self.assertTrue(resumed.request_full_charge)
+
+    def test_multiple_devices_are_independent(self):
+        first = self.planner.evaluate(
+            self.record("device-a"), observation(pv_window_favorable=True)
+        )
+        second = self.planner.evaluate(self.record("device-b", days_ago=1), observation())
+        self.assertTrue(first.record.active)
+        self.assertFalse(second.record.active)
+        self.assertNotEqual(first.record.device_id, second.record.device_id)
+
+    def test_unverified_fields_cannot_masquerade_as_native_calibration(self):
+        with self.assertRaisesRegex(ValueError, "unverified"):
+            NativeCalibrationInformation(
+                source=CalibrationInformationSource.BSFAI_DERIVED,
+                next_calibration_at=NOW,
+            )
+        verified = NativeCalibrationInformation(
+            source=CalibrationInformationSource.VERIFIED_NATIVE,
+            status="required",
+            next_calibration_at=NOW,
+        )
+        self.assertEqual(verified.status, "required")
+
+    def test_planner_has_no_discharge_or_transport_command_surface(self):
+        decision = self.planner.evaluate(
+            self.record(), observation(pv_window_favorable=True)
+        )
+        self.assertFalse(hasattr(decision, "request_discharge"))
+        self.assertFalse(hasattr(decision, "transport"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a transport-neutral, per-device full-charge maintenance planner for the native V5 architecture
- distinguish verified native calibration information from BSFAI-derived full-charge maintenance
- persist only semantic maintenance state, never transport commands
- select PV surplus, low-price, existing strategic-charge, or overdue deadline windows in a deterministic order
- require a stable five-minute 100% observation plus plausible low charge power or a verified native full-state before completion

## Safety
- no discharge request or calibration-write surface exists
- HEMS, protection, unavailable transport, stale/invalid SoC, device readiness, and conflicting pack data block maintenance charging
- a normal user SoC maximum is represented only by an explicit temporary maintenance override and is not persistently changed
- native-looking calibration timestamps are rejected unless their source semantics are verified
- active maintenance survives restart per stable device identity without replaying low-level commands

## Validation
- 11 full-charge maintenance tests
- 10 core model tests
- 13 V5 migration and upgrade tests
- compileall
- git diff --check

Progresses #347
Relates to #152