### PR TITLE
Connect full-charge maintenance to native runtime

### DIFF
--- a/custom_components/battery_smartflow_ai/native_zendure_runtime.py
+++ b/custom_components/battery_smartflow_ai/native_zendure_runtime.py
@@ -25,6 +25,7 @@ from .core.models import (
     ValueValidity,
     ZendureTransport,
 )
+from .core.full_charge_maintenance import FullChargeMaintenanceInput
 from .native_command_verification import (
     EffectStatus,
     NativeCommandVerificationManager,
@@ -191,6 +192,72 @@ class NativeZendureRuntime:
         if state is None or not _fresh_native_state(state):
             return None
         return state
+
+    @property
+    def selected_device_id(self) -> str | None:
+        """Return the explicitly selected main-system identity."""
+
+        return self._selected_device
+
+    def full_charge_maintenance_input(
+        self,
+        *,
+        now: datetime,
+        enabled: bool,
+        pv_window_favorable: bool = False,
+        price_window_favorable: bool = False,
+        strategic_charge_active: bool = False,
+    ) -> FullChargeMaintenanceInput | None:
+        """Build one native-only maintenance observation for the core planner."""
+
+        if self._selected_device is None:
+            return None
+        state = self._states.get(self._selected_device)
+        if state is None:
+            return FullChargeMaintenanceInput(
+                now=now,
+                enabled=enabled,
+                soc_pct=None,
+                soc_fresh=False,
+                device_ready=False,
+                transport_available=False,
+            )
+
+        soc = state.soc_pct
+        charge_power = state.charge_power_w
+        online = state.online
+        protection = state.protection_active
+        hems = state.hems_active
+        authority = self._transport_router.snapshot
+        return FullChargeMaintenanceInput(
+            now=now,
+            enabled=enabled,
+            soc_pct=float(soc.value) if _fresh_at(soc, now=now) else None,
+            soc_fresh=_fresh_at(soc, now=now),
+            charge_power_w=(
+                float(charge_power.value)
+                if _fresh_at(charge_power, now=now)
+                else None
+            ),
+            device_ready=bool(
+                self._control_enabled
+                and _fresh_at(online, now=now)
+                and online.value
+            ),
+            transport_available=bool(
+                authority.device_id == self._selected_device
+                and authority.transport is not None
+                and authority.synchronized
+            ),
+            hems_active=bool(_fresh_at(hems, now=now) and hems.value),
+            protection_active=bool(
+                _fresh_at(protection, now=now) and protection.value
+            ),
+            pack_data_conflict=_maintenance_pack_conflict(state, now=now),
+            pv_window_favorable=pv_window_favorable,
+            price_window_favorable=price_window_favorable,
+            strategic_charge_active=strategic_charge_active,
+        )
 
     def consume_control_baseline(self) -> tuple[str, int, int] | None:
         """Return one fresh device baseline when native control takes ownership."""
@@ -1355,6 +1422,40 @@ def _fresh_measured_value(
         return False
     age = (datetime.now(timezone.utc) - measured.observed_at).total_seconds()
     return 0 <= age <= maximum_age_seconds
+
+
+def _fresh_at(
+    measured: Any,
+    *,
+    now: datetime,
+    maximum_age_seconds: float = 30.0,
+) -> bool:
+    """Evaluate measurement freshness against the coordinator cycle clock."""
+
+    if not measured.valid or measured.observed_at is None:
+        return False
+    age = (now.astimezone(timezone.utc) - measured.observed_at).total_seconds()
+    return 0 <= age <= maximum_age_seconds
+
+
+def _maintenance_pack_conflict(state: Any, *, now: datetime) -> bool:
+    """Reject pack protection or a contradiction to a reported full system."""
+
+    main_soc = state.soc_pct
+    main_value = float(main_soc.value) if _fresh_at(main_soc, now=now) else None
+    for pack in state.packs:
+        protection = pack.protection_active
+        if _fresh_at(protection, now=now) and protection.value:
+            return True
+        pack_soc = pack.soc_pct
+        if (
+            main_value is not None
+            and main_value >= 100.0
+            and _fresh_at(pack_soc, now=now)
+            and float(pack_soc.value) < 99.0
+        ):
+            return True
+    return False
 
 
 def _native_power_control_active(state: Any) -> bool:

--- a/tests/test_native_power_controller.py
+++ b/tests/test_native_power_controller.py
@@ -36,6 +36,7 @@ from custom_components.battery_smartflow_ai.native_command_verification import (
 from custom_components.battery_smartflow_ai.native_zendure_runtime import (  # noqa: E402
     STATUS_OBSERVING,
     NativeZendureRuntime,
+    _maintenance_pack_conflict,
 )
 from custom_components.battery_smartflow_ai.zendure_cloud_mqtt import (
     ConnectionState,  # noqa: E402
@@ -67,6 +68,7 @@ def measured(value):
 def state(*, input_w=0, output_w=0, charge_w=0, discharge_w=0, hems=False):
     return SimpleNamespace(
         online=measured(True),
+        soc_pct=measured(80),
         protection_active=measured(False),
         hems_active=measured(hems),
         charge_power_w=measured(charge_w),
@@ -181,6 +183,50 @@ def legacy_runtime(*, current_state=None):
 
 
 class NativePowerControllerTests(unittest.IsolatedAsyncioTestCase):
+    def test_pack_soc_only_conflicts_with_a_reported_full_system(self):
+        pack = SimpleNamespace(
+            soc_pct=measured(80), protection_active=measured(False)
+        )
+        charging = state()
+        charging.soc_pct = measured(90)
+        charging.packs = (pack,)
+        self.assertFalse(_maintenance_pack_conflict(charging, now=NOW))
+
+        full = state()
+        full.soc_pct = measured(100)
+        full.packs = (pack,)
+        self.assertTrue(_maintenance_pack_conflict(full, now=NOW))
+
+    def test_maintenance_input_uses_only_selected_native_device(self):
+        target = runtime()
+        target._refresh_write_authority()
+
+        result = target.full_charge_maintenance_input(
+            now=NOW,
+            enabled=True,
+            pv_window_favorable=True,
+        )
+
+        self.assertEqual(target.selected_device_id, DEVICE)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.soc_pct, 80.0)
+        self.assertTrue(result.soc_fresh)
+        self.assertTrue(result.device_ready)
+        self.assertTrue(result.transport_available)
+        self.assertTrue(result.pv_window_favorable)
+
+    def test_maintenance_input_fails_closed_without_native_state(self):
+        target = runtime()
+        target._states.clear()
+
+        result = target.full_charge_maintenance_input(now=NOW, enabled=True)
+
+        self.assertIsNotNone(result)
+        self.assertIsNone(result.soc_pct)
+        self.assertFalse(result.soc_fresh)
+        self.assertFalse(result.device_ready)
+        self.assertFalse(result.transport_available)
+
     async def test_fresh_install_operates_natively_without_zha(self):
         target = runtime(migration_bound_device=None)
         target._refresh_write_authority()


### PR DESCRIPTION
## Summary
- expose the explicitly selected native main-system identity to the maintenance layer
- build a transport-neutral full-charge maintenance observation directly from native Zendure state
- carry fresh SoC, charge power, HEMS, protection, device readiness, writer synchronization, and favorable-window inputs into the core planner
- detect pack protection and full-state contradictions without assuming a general pack-balancing tolerance

## Safety
- no Home Assistant/Z-HA entity is consulted by the maintenance bridge
- missing native state fails closed with invalid SoC, unavailable device, and unavailable transport
- only the selected device and its synchronized native writer can become maintenance-ready
- differing pack SoCs during normal charging are allowed; a conflict is raised only for active pack protection or when the main system reports 100% while a fresh pack remains below 99%

## Validation
- 110 native Zendure tests
- 11 full-charge maintenance tests
- 10 core model tests
- compileall
- git diff --check

Progresses #347
Relates to #152