### PR TITLE
Persist per-device full-charge maintenance state

### DIFF
--- a/custom_components/battery_smartflow_ai/full_charge_maintenance_runtime.py
+++ b/custom_components/battery_smartflow_ai/full_charge_maintenance_runtime.py
@@ -1,0 +1,112 @@
+"""Restart-safe runtime ownership for per-device full-charge maintenance."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Mapping
+
+from .core.full_charge_maintenance import (
+    FullChargeMaintenanceDecision,
+    FullChargeMaintenanceInput,
+    FullChargeMaintenancePlanner,
+    FullChargeMaintenanceRecord,
+    MaintenanceBlockReason,
+    MaintenanceState,
+    MaintenanceWindow,
+)
+
+
+class FullChargeMaintenanceRuntime:
+    """Own maintenance records without owning transports or device commands."""
+
+    def __init__(self, planner: FullChargeMaintenancePlanner | None = None) -> None:
+        self._planner = planner or FullChargeMaintenancePlanner()
+        self._records: dict[str, FullChargeMaintenanceRecord] = {}
+        self._last_decision: FullChargeMaintenanceDecision | None = None
+
+    def restore(self, payload: Mapping[str, Any] | None) -> tuple[str, ...]:
+        """Restore valid records independently and report invalid opaque keys."""
+
+        self._records.clear()
+        invalid: list[str] = []
+        if not isinstance(payload, Mapping):
+            return () if payload is None else ("invalid_document",)
+        raw_records = payload.get("records", {})
+        if not isinstance(raw_records, Mapping):
+            return ("invalid_records",)
+        for opaque_key, raw in raw_records.items():
+            try:
+                if not isinstance(raw, Mapping):
+                    raise ValueError("record must be a mapping")
+                record = FullChargeMaintenanceRecord.from_dict(raw)
+                self._records[record.device_id] = record
+            except (KeyError, TypeError, ValueError):
+                invalid.append(str(opaque_key))
+        return tuple(sorted(invalid))
+
+    def evaluate(
+        self,
+        device_id: str,
+        data: FullChargeMaintenanceInput,
+        *,
+        interval_days: int = 30,
+    ) -> FullChargeMaintenanceDecision:
+        """Evaluate and retain one selected device only."""
+
+        record = self._records.get(device_id)
+        if record is None:
+            record = FullChargeMaintenanceRecord(
+                device_id=device_id,
+                interval_days=interval_days,
+            )
+        elif record.interval_days != interval_days and not record.active:
+            record = FullChargeMaintenanceRecord(
+                device_id=record.device_id,
+                interval_days=interval_days,
+                last_confirmed_full_at=record.last_confirmed_full_at,
+                last_completed_maintenance_at=record.last_completed_maintenance_at,
+                active=record.active,
+                full_candidate_since=record.full_candidate_since,
+            )
+        decision = self._planner.evaluate(record, data)
+        self._records[device_id] = decision.record
+        self._last_decision = decision
+        return decision
+
+    def persisted_state(self) -> dict[str, Any]:
+        """Return detached semantic state without queued commands."""
+
+        return deepcopy({
+            "schema_version": 1,
+            "records": {
+                device_id: record.as_dict()
+                for device_id, record in sorted(self._records.items())
+            },
+        })
+
+    def sensor_data(self) -> dict[str, Any]:
+        """Expose the latest selected-device decision without physical identity."""
+
+        decision = self._last_decision
+        if decision is None:
+            return {
+                "full_charge_maintenance_state": MaintenanceState.UNKNOWN.value,
+                "full_charge_maintenance_block_reason": (
+                    MaintenanceBlockReason.NONE.value
+                ),
+                "full_charge_maintenance_window": MaintenanceWindow.NONE.value,
+                "full_charge_maintenance_last_confirmed": None,
+                "full_charge_maintenance_next_recommended": None,
+                "full_charge_maintenance_active": False,
+            }
+        record = decision.record
+        return {
+            "full_charge_maintenance_state": decision.state.value,
+            "full_charge_maintenance_block_reason": decision.block_reason.value,
+            "full_charge_maintenance_window": decision.selected_window.value,
+            "full_charge_maintenance_last_confirmed": record.last_confirmed_full_at,
+            "full_charge_maintenance_next_recommended": (
+                record.next_recommended_full_at
+            ),
+            "full_charge_maintenance_active": record.active,
+        }

--- a/tests/test_full_charge_maintenance_runtime.py
+++ b/tests/test_full_charge_maintenance_runtime.py
@@ -1,0 +1,117 @@
+"""Restart and persistence contracts for full-charge maintenance runtime."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import unittest
+
+from support import bootstrap
+
+bootstrap()
+
+from custom_components.battery_smartflow_ai.core.full_charge_maintenance import (  # noqa: E402
+    FullChargeMaintenanceInput,
+    MaintenanceState,
+)
+from custom_components.battery_smartflow_ai.full_charge_maintenance_runtime import (  # noqa: E402
+    FullChargeMaintenanceRuntime,
+)
+
+
+NOW = datetime(2026, 9, 7, 12, tzinfo=timezone.utc)
+
+
+def input_data(**changes):
+    values = {
+        "now": NOW,
+        "enabled": True,
+        "soc_pct": 70.0,
+        "soc_fresh": True,
+        "charge_power_w": 0.0,
+        "price_window_favorable": True,
+    }
+    values.update(changes)
+    return FullChargeMaintenanceInput(**values)
+
+
+class FullChargeMaintenanceRuntimeTests(unittest.TestCase):
+    def test_active_semantic_commit_survives_restart_without_command(self):
+        runtime = FullChargeMaintenanceRuntime()
+        first = runtime.evaluate("device-a", input_data())
+        self.assertEqual(first.state, MaintenanceState.CHARGING_TO_FULL)
+
+        persisted = runtime.persisted_state()
+        restored = FullChargeMaintenanceRuntime()
+        self.assertEqual(restored.restore(persisted), ())
+        resumed = restored.evaluate(
+            "device-a",
+            input_data(
+                now=NOW + timedelta(minutes=1),
+                price_window_favorable=False,
+            ),
+        )
+        self.assertEqual(resumed.state, MaintenanceState.CHARGING_TO_FULL)
+        self.assertNotIn("command", str(persisted).lower())
+        self.assertNotIn("transport", str(persisted).lower())
+
+    def test_records_remain_separate_per_device(self):
+        runtime = FullChargeMaintenanceRuntime()
+        runtime.evaluate("device-a", input_data())
+        runtime.evaluate(
+            "device-b",
+            input_data(
+                enabled=False,
+                price_window_favorable=False,
+                soc_pct=60.0,
+            ),
+        )
+        records = runtime.persisted_state()["records"]
+        self.assertEqual(set(records), {"device-a", "device-b"})
+        self.assertTrue(records["device-a"]["active"])
+        self.assertFalse(records["device-b"]["active"])
+
+    def test_one_corrupt_record_does_not_destroy_valid_device_history(self):
+        runtime = FullChargeMaintenanceRuntime()
+        invalid = runtime.restore({
+            "records": {
+                "valid": {
+                    "device_id": "device-a",
+                    "interval_days": 30,
+                    "last_confirmed_full_at": NOW.isoformat(),
+                    "active": False,
+                },
+                "broken": {"device_id": "", "interval_days": 0},
+            }
+        })
+        self.assertEqual(invalid, ("broken",))
+        self.assertIn("device-a", runtime.persisted_state()["records"])
+
+    def test_interval_change_preserves_history_and_never_changes_active_commit(self):
+        runtime = FullChargeMaintenanceRuntime()
+        runtime.restore({
+            "records": {
+                "device-a": {
+                    "device_id": "device-a",
+                    "interval_days": 30,
+                    "last_confirmed_full_at": NOW.isoformat(),
+                    "active": False,
+                }
+            }
+        })
+        runtime.evaluate("device-a", input_data(enabled=False), interval_days=45)
+        record = runtime.persisted_state()["records"]["device-a"]
+        self.assertEqual(record["interval_days"], 45)
+        self.assertEqual(record["last_confirmed_full_at"], NOW.isoformat())
+
+    def test_sensor_surface_contains_no_device_identity(self):
+        runtime = FullChargeMaintenanceRuntime()
+        runtime.evaluate("secret-device-id", input_data())
+        data = runtime.sensor_data()
+        self.assertNotIn("secret-device-id", str(data))
+        self.assertEqual(
+            data["full_charge_maintenance_state"], "charging_to_full"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add restart-safe runtime ownership for per-device full-charge maintenance records
- restore valid device records independently so one corrupt entry cannot discard other maintenance history
- preserve active semantic maintenance commitments without persisting or replaying transport commands
- support interval changes while retaining confirmed-full history
- expose a bounded selected-device status surface without physical device identity

## Safety
- persistence contains only semantic state and UTC timestamps
- no command, transport, token, serial number, or credential is stored
- records remain isolated by stable device identity for future multi-device support
- invalid persisted records are reported and skipped rather than partially trusted
- returned persistence data is detached from live runtime state

## Validation
- 16 full-charge maintenance core/runtime tests
- 26 native PowerController/runtime tests
- compileall
- git diff --check

Progresses #347
Relates to #152