### PR TITLE
Observe full-charge maintenance in coordinator

### DIFF
--- a/custom_components/battery_smartflow_ai/coordinator.py
+++ b/custom_components/battery_smartflow_ai/coordinator.py
@@ -206,6 +206,7 @@ from .market_price import (
     NumericPriceNormalizer,
 )
 from .manual_standby import active_power_direction
+from .full_charge_maintenance_runtime import FullChargeMaintenanceRuntime
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -400,6 +401,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._debug_last_error: str | None = None
         self._automatic_strategy = AutomaticStrategy()
         self._charge_source_allocator = ChargeSourceAllocator()
+        self._full_charge_maintenance = FullChargeMaintenanceRuntime()
         self._energy_accumulator = EnergyAccumulator()
         self._economics_engine = EconomicsEngine(
             currency=self.price_currency.code
@@ -471,6 +473,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "economics_energy_state": None,
             "economics_money_state": None,
             "economics_money_day": None,
+            "full_charge_maintenance": None,
 
             # season detection
             "season_mode": "winter",
@@ -602,6 +605,14 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             )
             migrate_legacy_price_fields(loaded_data)
             self._persist.update(loaded_data)
+            invalid_maintenance = self._full_charge_maintenance.restore(
+                self._persist.get("full_charge_maintenance")
+            )
+            if invalid_maintenance:
+                _LOGGER.warning(
+                    "Skipped invalid full-charge maintenance records: %s",
+                    ", ".join(invalid_maintenance),
+                )
 
             # V4.2.2:
             # Normalize old persisted extreme values. Previous versions could let
@@ -647,6 +658,9 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def _save(self) -> None:
         self._persist["runtime_mode"] = dict(self.runtime_mode)
+        self._persist["full_charge_maintenance"] = (
+            self._full_charge_maintenance.persisted_state()
+        )
         save_result = await self._state_store.save(self._persist)
         if not save_result.saved:
             _LOGGER.warning(
@@ -6357,12 +6371,41 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             economic_discharge_threshold = transparency_result.economic_discharge_threshold
             effective_discharge_threshold = transparency_result.effective_discharge_threshold
 
+            maintenance_status = self._full_charge_maintenance.sensor_data()
+            if (
+                native_runtime is not None
+                and hasattr(native_runtime, "full_charge_maintenance_input")
+                and getattr(native_runtime, "selected_device_id", None)
+            ):
+                maintenance_input = native_runtime.full_charge_maintenance_input(
+                    now=now,
+                    enabled=False,
+                    pv_window_favorable=bool(
+                        pv_charge_latched
+                        or float(grid_export or 0.0)
+                        >= float(pv_charge_start_export_w)
+                    ),
+                    price_window_favorable=bool(
+                        price_now is not None
+                        and current_valley_threshold is not None
+                        and float(price_now) <= float(current_valley_threshold)
+                    ),
+                    strategic_charge_active=bool(charge_commit_active),
+                )
+                if maintenance_input is not None:
+                    self._full_charge_maintenance.evaluate(
+                        native_runtime.selected_device_id,
+                        maintenance_input,
+                    )
+                    maintenance_status = self._full_charge_maintenance.sensor_data()
+
             self._persist["debug"] = "OK"
             self._persist["last_ts"] = now.isoformat()
 
             await self._save()
 
             details = {
+                **maintenance_status,
                 "soc": soc,
                 "pv_w": pv_w,
                 "pv_sensor_valid": bool(pv_sensor_valid),

--- a/tests/test_full_charge_maintenance_coordinator.py
+++ b/tests/test_full_charge_maintenance_coordinator.py
@@ -1,0 +1,58 @@
+"""Coordinator integration contracts for observed full-charge maintenance."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
+
+
+class FullChargeMaintenanceCoordinatorTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.source = (COMPONENT / "coordinator.py").read_text(encoding="utf-8")
+
+    def test_runtime_is_restored_and_saved_in_existing_state_document(self):
+        self.assertIn("FullChargeMaintenanceRuntime()", self.source)
+        self.assertIn(
+            'self._full_charge_maintenance.restore(\n'
+            '                self._persist.get("full_charge_maintenance")',
+            self.source,
+        )
+        self.assertIn(
+            'self._persist["full_charge_maintenance"] = (', self.source
+        )
+        self.assertIn(
+            "self._full_charge_maintenance.persisted_state()", self.source
+        )
+
+    def test_coordinator_passes_real_planning_windows_to_native_observation(self):
+        self.assertIn("native_runtime.full_charge_maintenance_input(", self.source)
+        self.assertIn("pv_window_favorable=bool(", self.source)
+        self.assertIn("price_window_favorable=bool(", self.source)
+        self.assertIn(
+            "strategic_charge_active=bool(charge_commit_active)", self.source
+        )
+
+    def test_observation_mode_cannot_request_maintenance_charge(self):
+        call = self.source[
+            self.source.index("native_runtime.full_charge_maintenance_input("):
+        ]
+        call = call[:call.index(")\n                if maintenance_input")]
+        self.assertIn("enabled=False", call)
+
+    def test_status_is_exposed_without_changing_strategy_decision(self):
+        self.assertIn("**maintenance_status", self.source)
+        maintenance_section = self.source[
+            self.source.index("maintenance_status ="):
+            self.source.index('self._persist["debug"] = "OK"')
+        ]
+        self.assertNotIn("DeviceCommand(", maintenance_section)
+        self.assertNotIn("charge_commit_target_soc =", maintenance_section)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- restore and save versioned per-device full-charge maintenance state through the existing BSFAI StateStore document
- evaluate the selected native device during each normal coordinator cycle
- feed real PV-surplus, valley-price, and active strategic-charge window signals into the maintenance planner
- expose the bounded maintenance status in coordinator details for the upcoming entity layer

## Safe observation stage
- maintenance authorization is deliberately hard-disabled in this step
- the new coordinator section creates no DeviceCommand and changes no strategy decision, charge commitment, target SoC, or user limit
- invalid persisted device records are skipped and logged without discarding valid records
- normal V4/V5 regulation behavior is unchanged

## Validation
- 20 full-charge maintenance tests
- 110 native Zendure tests
- 13 V5 migration and upgrade tests
- 6 StateStore tests
- 4 V4.7 backward-compatibility tests
- compileall
- git diff --check

Progresses #347
Relates to #152