### PR TITLE
Connect full-charge maintenance to charging strategy

### DIFF
--- a/custom_components/battery_smartflow_ai/coordinator.py
+++ b/custom_components/battery_smartflow_ai/coordinator.py
@@ -211,6 +211,7 @@ from .market_price import (
 )
 from .manual_standby import active_power_direction
 from .full_charge_maintenance_runtime import FullChargeMaintenanceRuntime
+from .full_charge_maintenance_control import apply_maintenance_charge_request
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -4606,8 +4607,60 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 self._engine._learned_planning_waits_for_window(ctx)
             )
 
+            maintenance_status = self._full_charge_maintenance.sensor_data()
+            maintenance_decision = None
+            if (
+                native_runtime is not None
+                and hasattr(native_runtime, "full_charge_maintenance_input")
+                and getattr(native_runtime, "selected_device_id", None)
+            ):
+                maintenance_input = native_runtime.full_charge_maintenance_input(
+                    now=now,
+                    enabled=bool(self.entry.options.get(
+                        SETTING_FULL_CHARGE_MAINTENANCE_ENABLED,
+                        DEFAULT_FULL_CHARGE_MAINTENANCE_ENABLED,
+                    )),
+                    pv_window_favorable=bool(
+                        pv_charge_latched
+                        or float(grid_export or 0.0)
+                        >= float(pv_charge_start_export_w)
+                    ),
+                    price_window_favorable=bool(
+                        price_now is not None
+                        and self._engine._is_valley_price_now(ctx)
+                    ),
+                    strategic_charge_active=bool(
+                        self._persist.get("charge_commit_active", False)
+                    ),
+                    automation_allowed=bool(ai_mode != AI_MODE_MANUAL),
+                )
+                if maintenance_input is not None:
+                    maintenance_decision = self._full_charge_maintenance.evaluate(
+                        native_runtime.selected_device_id,
+                        maintenance_input,
+                        interval_days=int(self.entry.options.get(
+                            SETTING_FULL_CHARGE_MAINTENANCE_INTERVAL_DAYS,
+                            DEFAULT_FULL_CHARGE_MAINTENANCE_INTERVAL_DAYS,
+                        )),
+                    )
+                    maintenance_status = self._full_charge_maintenance.sensor_data()
+                    if maintenance_decision.temporary_user_limit_override:
+                        ctx.soc_max = 100.0
+
             decision = self._engine.evaluate(ctx)
             strategy_selection = self._engine.last_strategy_selection
+
+            maintenance_application = apply_maintenance_charge_request(
+                decision,
+                maintenance_decision,
+                configured_soc_max=float(soc_max),
+                max_charge_w=float(max_charge),
+                grid_export_w=float(grid_export or 0.0),
+                automation_allowed=bool(ai_mode != AI_MODE_MANUAL),
+            )
+            decision = maintenance_application.decision
+            if maintenance_application.applied:
+                soc_max = maintenance_application.effective_soc_max
 
             cell_voltage_post_emergency_discharge_locked = (
                 self._update_cell_voltage_post_emergency_discharge_lock(
@@ -6374,41 +6427,6 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             current_valley_threshold = transparency_result.current_valley_threshold
             economic_discharge_threshold = transparency_result.economic_discharge_threshold
             effective_discharge_threshold = transparency_result.effective_discharge_threshold
-
-            maintenance_status = self._full_charge_maintenance.sensor_data()
-            if (
-                native_runtime is not None
-                and hasattr(native_runtime, "full_charge_maintenance_input")
-                and getattr(native_runtime, "selected_device_id", None)
-            ):
-                maintenance_input = native_runtime.full_charge_maintenance_input(
-                    now=now,
-                    enabled=bool(self.entry.options.get(
-                        SETTING_FULL_CHARGE_MAINTENANCE_ENABLED,
-                        DEFAULT_FULL_CHARGE_MAINTENANCE_ENABLED,
-                    )),
-                    pv_window_favorable=bool(
-                        pv_charge_latched
-                        or float(grid_export or 0.0)
-                        >= float(pv_charge_start_export_w)
-                    ),
-                    price_window_favorable=bool(
-                        price_now is not None
-                        and current_valley_threshold is not None
-                        and float(price_now) <= float(current_valley_threshold)
-                    ),
-                    strategic_charge_active=bool(charge_commit_active),
-                )
-                if maintenance_input is not None:
-                    self._full_charge_maintenance.evaluate(
-                        native_runtime.selected_device_id,
-                        maintenance_input,
-                        interval_days=int(self.entry.options.get(
-                            SETTING_FULL_CHARGE_MAINTENANCE_INTERVAL_DAYS,
-                            DEFAULT_FULL_CHARGE_MAINTENANCE_INTERVAL_DAYS,
-                        )),
-                    )
-                    maintenance_status = self._full_charge_maintenance.sensor_data()
 
             self._persist["debug"] = "OK"
             self._persist["last_ts"] = now.isoformat()

--- a/custom_components/battery_smartflow_ai/core/full_charge_maintenance.py
+++ b/custom_components/battery_smartflow_ai/core/full_charge_maintenance.py
@@ -42,6 +42,7 @@ class MaintenanceBlockReason(StrEnum):
     SOC_INVALID_OR_STALE = "soc_invalid_or_stale"
     PROTECTION_ACTIVE = "protection_active"
     PACK_DATA_CONFLICT = "pack_data_conflict"
+    MANUAL_MODE = "manual_mode"
 
 
 class MaintenanceWindow(StrEnum):
@@ -140,6 +141,7 @@ class FullChargeMaintenanceInput:
     price_window_favorable: bool = False
     strategic_charge_active: bool = False
     native_full_state_confirmed: bool = False
+    automation_allowed: bool = True
 
     def __post_init__(self) -> None:
         if self.now.tzinfo is None:
@@ -225,13 +227,6 @@ class FullChargeMaintenancePlanner:
             return _charging_decision(record, MaintenanceWindow.NONE)
         if base_state in {MaintenanceState.NOT_DUE, MaintenanceState.DUE_SOON}:
             return FullChargeMaintenanceDecision(record, base_state)
-        if not data.enabled:
-            return FullChargeMaintenanceDecision(
-                record,
-                MaintenanceState.BLOCKED,
-                block_reason=MaintenanceBlockReason.NOT_ENABLED,
-            )
-
         window = _select_window(data)
         if window is MaintenanceWindow.NONE and next_due is not None:
             if now >= next_due + self._max_postpone:
@@ -270,6 +265,10 @@ def _schedule_state(
 
 
 def _block_reason(data: FullChargeMaintenanceInput) -> MaintenanceBlockReason:
+    if not data.enabled:
+        return MaintenanceBlockReason.NOT_ENABLED
+    if not data.automation_allowed:
+        return MaintenanceBlockReason.MANUAL_MODE
     if data.hems_active:
         return MaintenanceBlockReason.HEMS_ACTIVE
     if data.protection_active:

--- a/custom_components/battery_smartflow_ai/full_charge_maintenance_control.py
+++ b/custom_components/battery_smartflow_ai/full_charge_maintenance_control.py
@@ -1,0 +1,87 @@
+"""Apply a neutral maintenance request to the existing strategy boundary."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .core.full_charge_maintenance import (
+    FullChargeMaintenanceDecision,
+    MaintenanceWindow,
+)
+from .decision_engine import DecisionResult
+
+
+_HARD_SAFETY_REASONS = frozenset({
+    "sensor_invalid",
+    "soc_invalid",
+    "grid_sensor_invalid",
+    "soc_limits_invalid",
+    "power_limits_invalid",
+    "cell_voltage_sensor_invalid",
+    "cell_voltage_emergency_charge",
+    "emergency_latched_charge",
+})
+
+
+@dataclass(frozen=True, slots=True)
+class MaintenanceStrategyApplication:
+    decision: DecisionResult
+    effective_soc_max: float
+    applied: bool = False
+
+
+def apply_maintenance_charge_request(
+    decision: DecisionResult,
+    maintenance: FullChargeMaintenanceDecision | None,
+    *,
+    configured_soc_max: float,
+    max_charge_w: float,
+    grid_export_w: float,
+    automation_allowed: bool,
+) -> MaintenanceStrategyApplication:
+    """Temporarily lift only the strategy target; never mutate stored limits."""
+
+    if (
+        maintenance is None
+        or not maintenance.request_full_charge
+        or not maintenance.temporary_user_limit_override
+        or maintenance.target_soc_pct != 100.0
+        or not automation_allowed
+        or decision.action == "emergency"
+        or str(decision.reason or "") in _HARD_SAFETY_REASONS
+    ):
+        return MaintenanceStrategyApplication(decision, configured_soc_max)
+
+    charge_w = float(max_charge_w)
+    reason = "planning_latest_start"
+    if maintenance.selected_window is MaintenanceWindow.PV_SURPLUS:
+        charge_w = min(
+            float(max_charge_w),
+            max(float(decision.charge_w or 0.0), float(grid_export_w), 0.0),
+        )
+        reason = "pv_surplus_charge"
+    elif maintenance.selected_window is MaintenanceWindow.LOW_PRICE:
+        reason = "valley_opportunity_charge"
+    elif (
+        maintenance.selected_window is MaintenanceWindow.EXISTING_STRATEGIC_CHARGE
+        and decision.action == "charge"
+    ):
+        charge_w = max(float(decision.charge_w or 0.0), 0.0)
+        reason = str(decision.reason or "charge_commit_active")
+
+    return MaintenanceStrategyApplication(
+        DecisionResult(
+            action="charge",
+            ac_mode="input",
+            charge_w=charge_w,
+            discharge_w=0.0,
+            reason=reason,
+            target_soc=100.0,
+            current_peak_threshold=decision.current_peak_threshold,
+            current_valley_threshold=decision.current_valley_threshold,
+            economic_discharge_threshold=decision.economic_discharge_threshold,
+            effective_discharge_threshold=decision.effective_discharge_threshold,
+        ),
+        effective_soc_max=100.0,
+        applied=True,
+    )

--- a/custom_components/battery_smartflow_ai/native_zendure_runtime.py
+++ b/custom_components/battery_smartflow_ai/native_zendure_runtime.py
@@ -207,6 +207,7 @@ class NativeZendureRuntime:
         pv_window_favorable: bool = False,
         price_window_favorable: bool = False,
         strategic_charge_active: bool = False,
+        automation_allowed: bool = True,
     ) -> FullChargeMaintenanceInput | None:
         """Build one native-only maintenance observation for the core planner."""
 
@@ -257,6 +258,7 @@ class NativeZendureRuntime:
             pv_window_favorable=pv_window_favorable,
             price_window_favorable=price_window_favorable,
             strategic_charge_active=strategic_charge_active,
+            automation_allowed=automation_allowed,
         )
 
     def consume_control_baseline(self) -> tuple[str, int, int] | None:

--- a/custom_components/battery_smartflow_ai/strings.json
+++ b/custom_components/battery_smartflow_ai/strings.json
@@ -471,7 +471,7 @@
       "full_charge_maintenance_next_recommended": {"name": "Next recommended full charge"},
       "full_charge_maintenance_last_confirmed": {"name": "Diagnostic: Last confirmed full charge"},
       "full_charge_maintenance_window": {"name": "Diagnostic: Maintenance charging window", "state": {"none": "None", "pv_surplus": "PV surplus", "low_price": "Low price", "existing_strategic_charge": "Existing strategic charge", "overdue_deadline": "Overdue deadline"}},
-      "full_charge_maintenance_block_reason": {"name": "Diagnostic: Full-charge maintenance blocker", "state": {"none": "No blocker", "not_enabled": "Not enabled", "hems_active": "Zendure HEMS active", "device_not_ready": "Device not ready", "transport_unavailable": "Transport unavailable", "soc_invalid_or_stale": "SoC invalid or stale", "protection_active": "Battery protection active", "pack_data_conflict": "Battery-pack data conflict"}},
+      "full_charge_maintenance_block_reason": {"name": "Diagnostic: Full-charge maintenance blocker", "state": {"none": "No blocker", "not_enabled": "Not enabled", "hems_active": "Zendure HEMS active", "device_not_ready": "Device not ready", "transport_unavailable": "Transport unavailable", "soc_invalid_or_stale": "SoC invalid or stale", "protection_active": "Battery protection active", "pack_data_conflict": "Battery-pack data conflict", "manual_mode": "Manual mode active"}},
       "learned_planning_status": {
         "name": "Charge planning: Learning status",
         "state": {

--- a/custom_components/battery_smartflow_ai/translations/de.json
+++ b/custom_components/battery_smartflow_ai/translations/de.json
@@ -416,7 +416,7 @@
       "full_charge_maintenance_next_recommended": {"name": "Nächste empfohlene Volladung"},
       "full_charge_maintenance_last_confirmed": {"name": "Diagnose: Letzte bestätigte Volladung"},
       "full_charge_maintenance_window": {"name": "Diagnose: Wartungs-Ladefenster", "state": {"none": "Keines", "pv_surplus": "PV-Überschuss", "low_price": "Niedriger Preis", "existing_strategic_charge": "Bestehende strategische Ladung", "overdue_deadline": "Überfällige Frist"}},
-      "full_charge_maintenance_block_reason": {"name": "Diagnose: Blockierungsgrund der Volladungswartung", "state": {"none": "Kein Blocker", "not_enabled": "Nicht aktiviert", "hems_active": "Zendure HEMS aktiv", "device_not_ready": "Gerät nicht bereit", "transport_unavailable": "Verbindung nicht verfügbar", "soc_invalid_or_stale": "SoC ungültig oder veraltet", "protection_active": "Batterieschutz aktiv", "pack_data_conflict": "Widersprüchliche Batterie-Pack-Daten"}},
+      "full_charge_maintenance_block_reason": {"name": "Diagnose: Blockierungsgrund der Volladungswartung", "state": {"none": "Kein Blocker", "not_enabled": "Nicht aktiviert", "hems_active": "Zendure HEMS aktiv", "device_not_ready": "Gerät nicht bereit", "transport_unavailable": "Verbindung nicht verfügbar", "soc_invalid_or_stale": "SoC ungültig oder veraltet", "protection_active": "Batterieschutz aktiv", "pack_data_conflict": "Widersprüchliche Batterie-Pack-Daten", "manual_mode": "Manueller Modus aktiv"}},
       "learned_planning_status": {
         "name": "Ladeplanung: Lernstatus",
         "state": {

--- a/custom_components/battery_smartflow_ai/translations/en.json
+++ b/custom_components/battery_smartflow_ai/translations/en.json
@@ -416,7 +416,7 @@
       "full_charge_maintenance_next_recommended": {"name": "Next recommended full charge"},
       "full_charge_maintenance_last_confirmed": {"name": "Diagnostic: Last confirmed full charge"},
       "full_charge_maintenance_window": {"name": "Diagnostic: Maintenance charging window", "state": {"none": "None", "pv_surplus": "PV surplus", "low_price": "Low price", "existing_strategic_charge": "Existing strategic charge", "overdue_deadline": "Overdue deadline"}},
-      "full_charge_maintenance_block_reason": {"name": "Diagnostic: Full-charge maintenance blocker", "state": {"none": "No blocker", "not_enabled": "Not enabled", "hems_active": "Zendure HEMS active", "device_not_ready": "Device not ready", "transport_unavailable": "Transport unavailable", "soc_invalid_or_stale": "SoC invalid or stale", "protection_active": "Battery protection active", "pack_data_conflict": "Battery-pack data conflict"}},
+      "full_charge_maintenance_block_reason": {"name": "Diagnostic: Full-charge maintenance blocker", "state": {"none": "No blocker", "not_enabled": "Not enabled", "hems_active": "Zendure HEMS active", "device_not_ready": "Device not ready", "transport_unavailable": "Transport unavailable", "soc_invalid_or_stale": "SoC invalid or stale", "protection_active": "Battery protection active", "pack_data_conflict": "Battery-pack data conflict", "manual_mode": "Manual mode active"}},
       "learned_planning_status": {
         "name": "Charge planning: Learning status",
         "state": {

--- a/custom_components/battery_smartflow_ai/translations/fr.json
+++ b/custom_components/battery_smartflow_ai/translations/fr.json
@@ -416,7 +416,7 @@
       "full_charge_maintenance_next_recommended": {"name": "Prochaine charge complète recommandée"},
       "full_charge_maintenance_last_confirmed": {"name": "Diagnostic : dernière charge complète confirmée"},
       "full_charge_maintenance_window": {"name": "Diagnostic : fenêtre de charge d’entretien", "state": {"none": "Aucune", "pv_surplus": "Surplus photovoltaïque", "low_price": "Prix bas", "existing_strategic_charge": "Charge stratégique existante", "overdue_deadline": "Échéance dépassée"}},
-      "full_charge_maintenance_block_reason": {"name": "Diagnostic : blocage de l’entretien", "state": {"none": "Aucun blocage", "not_enabled": "Non activé", "hems_active": "Zendure HEMS actif", "device_not_ready": "Appareil non prêt", "transport_unavailable": "Connexion indisponible", "soc_invalid_or_stale": "SoC invalide ou obsolète", "protection_active": "Protection de batterie active", "pack_data_conflict": "Conflit des données des batteries"}},
+      "full_charge_maintenance_block_reason": {"name": "Diagnostic : blocage de l’entretien", "state": {"none": "Aucun blocage", "not_enabled": "Non activé", "hems_active": "Zendure HEMS actif", "device_not_ready": "Appareil non prêt", "transport_unavailable": "Connexion indisponible", "soc_invalid_or_stale": "SoC invalide ou obsolète", "protection_active": "Protection de batterie active", "pack_data_conflict": "Conflit des données des batteries", "manual_mode": "Mode manuel actif"}},
       "learned_planning_status": {
         "name": "Planification de charge : état d’apprentissage",
         "state": {

--- a/custom_components/battery_smartflow_ai/translations/nl.json
+++ b/custom_components/battery_smartflow_ai/translations/nl.json
@@ -416,7 +416,7 @@
       "full_charge_maintenance_next_recommended": {"name": "Volgende aanbevolen volledige lading"},
       "full_charge_maintenance_last_confirmed": {"name": "Diagnose: laatste bevestigde volledige lading"},
       "full_charge_maintenance_window": {"name": "Diagnose: onderhoudslaadvenster", "state": {"none": "Geen", "pv_surplus": "PV-overschot", "low_price": "Lage prijs", "existing_strategic_charge": "Bestaande strategische lading", "overdue_deadline": "Termijn overschreden"}},
-      "full_charge_maintenance_block_reason": {"name": "Diagnose: blokkering volledig-laadonderhoud", "state": {"none": "Geen blokkering", "not_enabled": "Niet ingeschakeld", "hems_active": "Zendure HEMS actief", "device_not_ready": "Apparaat niet gereed", "transport_unavailable": "Verbinding niet beschikbaar", "soc_invalid_or_stale": "SoC ongeldig of verouderd", "protection_active": "Accubeveiliging actief", "pack_data_conflict": "Tegenstrijdige accupakketgegevens"}},
+      "full_charge_maintenance_block_reason": {"name": "Diagnose: blokkering volledig-laadonderhoud", "state": {"none": "Geen blokkering", "not_enabled": "Niet ingeschakeld", "hems_active": "Zendure HEMS actief", "device_not_ready": "Apparaat niet gereed", "transport_unavailable": "Verbinding niet beschikbaar", "soc_invalid_or_stale": "SoC ongeldig of verouderd", "protection_active": "Accubeveiliging actief", "pack_data_conflict": "Tegenstrijdige accupakketgegevens", "manual_mode": "Handmatige modus actief"}},
       "learned_planning_status": {
         "name": "Laadplanning: leerstatus",
         "state": {

--- a/tests/test_full_charge_maintenance.py
+++ b/tests/test_full_charge_maintenance.py
@@ -79,6 +79,21 @@ class FullChargeMaintenanceTests(unittest.TestCase):
             existing.selected_window, MaintenanceWindow.EXISTING_STRATEGIC_CHARGE
         )
 
+    def test_manual_mode_blocks_new_and_running_maintenance(self):
+        for record in (self.record(), self.record(active=True)):
+            decision = self.planner.evaluate(
+                record,
+                observation(
+                    automation_allowed=False,
+                    pv_window_favorable=True,
+                ),
+            )
+            self.assertEqual(decision.state, MaintenanceState.BLOCKED)
+            self.assertEqual(
+                decision.block_reason, MaintenanceBlockReason.MANUAL_MODE
+            )
+            self.assertFalse(decision.request_full_charge)
+
     def test_overdue_deadline_prevents_unbounded_postponement(self):
         result = self.planner.evaluate(self.record(days_ago=38), observation())
         self.assertEqual(result.selected_window, MaintenanceWindow.OVERDUE_DEADLINE)
@@ -95,6 +110,14 @@ class FullChargeMaintenanceTests(unittest.TestCase):
         self.assertEqual(active.target_soc_pct, 100.0)
         self.assertTrue(active.temporary_user_limit_override)
         self.assertTrue(active.record.active)
+        disabled_again = self.planner.evaluate(
+            active.record,
+            observation(enabled=False, price_window_favorable=True),
+        )
+        self.assertEqual(
+            disabled_again.block_reason, MaintenanceBlockReason.NOT_ENABLED
+        )
+        self.assertFalse(disabled_again.request_full_charge)
 
     def test_hems_protection_stale_soc_and_pack_conflict_block(self):
         cases = (

--- a/tests/test_full_charge_maintenance_control.py
+++ b/tests/test_full_charge_maintenance_control.py
@@ -1,0 +1,98 @@
+"""Strategy-boundary tests for full-charge maintenance."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+from support import bootstrap
+
+ROOT = Path(__file__).resolve().parents[1]
+bootstrap()
+
+from custom_components.battery_smartflow_ai.core.full_charge_maintenance import (  # noqa: E402
+    FullChargeMaintenanceDecision,
+    FullChargeMaintenanceRecord,
+    MaintenanceState,
+    MaintenanceWindow,
+)
+from custom_components.battery_smartflow_ai.decision_engine import DecisionResult  # noqa: E402
+from custom_components.battery_smartflow_ai.full_charge_maintenance_control import (  # noqa: E402
+    apply_maintenance_charge_request,
+)
+
+
+def request(window: MaintenanceWindow) -> FullChargeMaintenanceDecision:
+    return FullChargeMaintenanceDecision(
+        record=FullChargeMaintenanceRecord("device", active=True),
+        state=MaintenanceState.CHARGING_TO_FULL,
+        selected_window=window,
+        request_full_charge=True,
+        target_soc_pct=100.0,
+        temporary_user_limit_override=True,
+    )
+
+
+class FullChargeMaintenanceControlTests(unittest.TestCase):
+    def test_price_window_temporarily_targets_full_without_mutating_input(self):
+        normal = DecisionResult("idle", "output", 0.0, 0.0, "soc_limit_upper")
+        result = apply_maintenance_charge_request(
+            normal,
+            request(MaintenanceWindow.LOW_PRICE),
+            configured_soc_max=80.0,
+            max_charge_w=1200.0,
+            grid_export_w=0.0,
+            automation_allowed=True,
+        )
+        self.assertTrue(result.applied)
+        self.assertEqual(result.effective_soc_max, 100.0)
+        self.assertEqual(result.decision.target_soc, 100.0)
+        self.assertEqual(result.decision.charge_w, 1200.0)
+        self.assertEqual(normal.action, "idle")
+
+    def test_pv_window_starts_only_with_available_surplus(self):
+        result = apply_maintenance_charge_request(
+            DecisionResult("idle", "output", 0.0, 0.0, "idle"),
+            request(MaintenanceWindow.PV_SURPLUS),
+            configured_soc_max=80.0,
+            max_charge_w=1200.0,
+            grid_export_w=340.0,
+            automation_allowed=True,
+        )
+        self.assertEqual(result.decision.charge_w, 340.0)
+        self.assertEqual(result.decision.reason, "pv_surplus_charge")
+
+    def test_manual_and_emergency_paths_are_never_overridden(self):
+        emergency = DecisionResult(
+            "emergency", "input", 300.0, 0.0, "emergency_latched_charge"
+        )
+        for allowed in (False, True):
+            result = apply_maintenance_charge_request(
+                emergency,
+                request(MaintenanceWindow.OVERDUE_DEADLINE),
+                configured_soc_max=80.0,
+                max_charge_w=1200.0,
+                grid_export_w=0.0,
+                automation_allowed=allowed,
+            )
+            self.assertFalse(result.applied)
+            self.assertIs(result.decision, emergency)
+            self.assertEqual(result.effective_soc_max, 80.0)
+
+    def test_inactive_request_leaves_normal_strategy_untouched(self):
+        normal = DecisionResult("discharge", "output", 0.0, 500.0, "idle")
+        result = apply_maintenance_charge_request(
+            normal,
+            None,
+            configured_soc_max=75.0,
+            max_charge_w=1200.0,
+            grid_export_w=0.0,
+            automation_allowed=True,
+        )
+        self.assertFalse(result.applied)
+        self.assertIs(result.decision, normal)
+        self.assertEqual(result.effective_soc_max, 75.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_full_charge_maintenance_coordinator.py
+++ b/tests/test_full_charge_maintenance_coordinator.py
@@ -34,7 +34,7 @@ class FullChargeMaintenanceCoordinatorTests(unittest.TestCase):
         self.assertIn("pv_window_favorable=bool(", self.source)
         self.assertIn("price_window_favorable=bool(", self.source)
         self.assertIn(
-            "strategic_charge_active=bool(charge_commit_active)", self.source
+            'self._persist.get("charge_commit_active", False)', self.source
         )
 
     def test_user_setting_is_passed_to_observation_planner(self):
@@ -46,15 +46,28 @@ class FullChargeMaintenanceCoordinatorTests(unittest.TestCase):
         self.assertIn("DEFAULT_FULL_CHARGE_MAINTENANCE_ENABLED", call)
         self.assertIn("SETTING_FULL_CHARGE_MAINTENANCE_INTERVAL_DAYS", self.source)
 
-    def test_status_is_exposed_without_changing_strategy_decision(self):
+    def test_request_crosses_only_the_strategy_adapter(self):
         self.assertIn("**maintenance_status", self.source)
-        maintenance_section = self.source[
-            self.source.index("maintenance_status ="):
-            self.source.index('self._persist["debug"] = "OK"')
-        ]
-        self.assertNotIn("DeviceCommand(", maintenance_section)
-        self.assertNotIn("charge_commit_target_soc =", maintenance_section)
-        self.assertNotIn("display_decision =", maintenance_section)
+        self.assertIn("apply_maintenance_charge_request(", self.source)
+        adapter = (COMPONENT / "full_charge_maintenance_control.py").read_text(
+            encoding="utf-8"
+        )
+        self.assertNotIn("DeviceCommand(", adapter)
+        self.assertNotIn("native_zendure", adapter)
+
+    def test_maintenance_is_evaluated_before_strategy_and_charge_binding(self):
+        maintenance = self.source.index(
+            "maintenance_decision = self._full_charge_maintenance.evaluate("
+        )
+        strategy = self.source.index("decision = self._engine.evaluate(ctx)")
+        binding = self.source.index("decision = self._apply_charge_commit(")
+        self.assertLess(maintenance, strategy)
+        self.assertLess(strategy, binding)
+        self.assertIn("ctx.soc_max = 100.0", self.source[maintenance:strategy])
+        self.assertIn(
+            "soc_max = maintenance_application.effective_soc_max",
+            self.source[strategy:binding],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- evaluate the per-device maintenance planner before normal strategy selection
- temporarily raise only the active strategy target to 100% when an authorized maintenance charge is requested
- route the resulting charge through the existing strategy, charge binding, PowerController, command gate, and selected native transport
- use PV surplus first, then low-price or existing strategic charge windows, with the bounded overdue fallback
- pause maintenance in manual mode and stop hardware requests immediately when the feature is disabled
- retain all HEMS, native freshness, transport, protection, pack-conflict, hardware-limit, and emergency boundaries

## Limit semantics

The configured BSFAI SoC maximum is never persisted or rewritten. The 100% value exists only as the effective target for an active maintenance strategy cycle. After confirmed completion, disabling, or blocking, normal SoC-Max semantics resume automatically. No direct BMS calibration command is introduced.

## Validation

- 29 maintenance planner/runtime/strategy/coordinator/UI tests
- 26 native PowerController and command-routing tests
- 10 translation and enum coverage tests
- 4 V4.7 backward-compatibility and entity-identity tests
- 28 end-to-end Dev9 strategy/fallback regression scenarios
- compile and whitespace validation

Progresses #347
Relates to #152