### PR TITLE
Complete native full-charge maintenance assistant

### DIFF
--- a/custom_components/battery_smartflow_ai/coordinator.py
+++ b/custom_components/battery_smartflow_ai/coordinator.py
@@ -4609,6 +4609,10 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
             maintenance_status = self._full_charge_maintenance.sensor_data()
             maintenance_decision = None
+            maintenance_enabled = bool(self.entry.options.get(
+                SETTING_FULL_CHARGE_MAINTENANCE_ENABLED,
+                DEFAULT_FULL_CHARGE_MAINTENANCE_ENABLED,
+            ))
             if (
                 native_runtime is not None
                 and hasattr(native_runtime, "full_charge_maintenance_input")
@@ -4616,10 +4620,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             ):
                 maintenance_input = native_runtime.full_charge_maintenance_input(
                     now=now,
-                    enabled=bool(self.entry.options.get(
-                        SETTING_FULL_CHARGE_MAINTENANCE_ENABLED,
-                        DEFAULT_FULL_CHARGE_MAINTENANCE_ENABLED,
-                    )),
+                    enabled=maintenance_enabled,
                     pv_window_favorable=bool(
                         pv_charge_latched
                         or float(grid_export or 0.0)
@@ -4656,7 +4657,9 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 configured_soc_max=float(soc_max),
                 max_charge_w=float(max_charge),
                 grid_export_w=float(grid_export or 0.0),
-                automation_allowed=bool(ai_mode != AI_MODE_MANUAL),
+                automation_allowed=bool(
+                    ai_mode != AI_MODE_MANUAL and maintenance_enabled
+                ),
             )
             decision = maintenance_application.decision
             if maintenance_application.applied:

--- a/custom_components/battery_smartflow_ai/core/full_charge_maintenance.py
+++ b/custom_components/battery_smartflow_ai/core/full_charge_maintenance.py
@@ -223,10 +223,22 @@ class FullChargeMaintenancePlanner:
             )
 
         record = replace(record, full_candidate_since=None)
+        if record.active and not data.enabled:
+            return FullChargeMaintenanceDecision(
+                record,
+                MaintenanceState.BLOCKED,
+                block_reason=MaintenanceBlockReason.NOT_ENABLED,
+            )
         if record.active:
             return _charging_decision(record, MaintenanceWindow.NONE)
         if base_state in {MaintenanceState.NOT_DUE, MaintenanceState.DUE_SOON}:
             return FullChargeMaintenanceDecision(record, base_state)
+        if not data.enabled:
+            return FullChargeMaintenanceDecision(
+                record,
+                MaintenanceState.BLOCKED,
+                block_reason=MaintenanceBlockReason.NOT_ENABLED,
+            )
         window = _select_window(data)
         if window is MaintenanceWindow.NONE and next_due is not None:
             if now >= next_due + self._max_postpone:
@@ -265,8 +277,6 @@ def _schedule_state(
 
 
 def _block_reason(data: FullChargeMaintenanceInput) -> MaintenanceBlockReason:
-    if not data.enabled:
-        return MaintenanceBlockReason.NOT_ENABLED
     if not data.automation_allowed:
         return MaintenanceBlockReason.MANUAL_MODE
     if data.hems_active:

--- a/custom_components/battery_smartflow_ai/debug_sample_builder.py
+++ b/custom_components/battery_smartflow_ai/debug_sample_builder.py
@@ -185,6 +185,9 @@ def build_debug_sample(
         "learned": _prefixed(details, "learned_planning_"),
         "forecast": _prefixed(details, "forecast_"),
         "charge_commit": _prefixed(details, "charge_commit_"),
+        "full_charge_maintenance": _prefixed(
+            details, "full_charge_maintenance_"
+        ),
     }
     if "pv_outlook" in details:
         planning["forecast"]["pv_outlook"] = details["pv_outlook"]

--- a/custom_components/battery_smartflow_ai/diagnostics.py
+++ b/custom_components/battery_smartflow_ai/diagnostics.py
@@ -39,6 +39,12 @@ async def async_get_config_entry_diagnostics(
 
     coordinator = hass.data.get(DOMAIN, {}).get(entry.entry_id)
     native = getattr(coordinator, "native_zendure", None)
+    maintenance = getattr(coordinator, "_full_charge_maintenance", None)
+    maintenance_data = (
+        redact_secrets(maintenance.sensor_data())
+        if maintenance is not None
+        else None
+    )
     native_path = native.capture_path if native is not None else None
     debug_path = (
         coordinator.debug_last_package_path if coordinator is not None else None
@@ -51,6 +57,7 @@ async def async_get_config_entry_diagnostics(
             "native_zendure": (
                 native.diagnostic_data() if native is not None else None
             ),
+            "full_charge_maintenance": maintenance_data,
         }
     package = await hass.async_add_executor_job(
         partial(
@@ -62,6 +69,7 @@ async def async_get_config_entry_diagnostics(
     if native_path:
         return {
             "native_zendure": native.diagnostic_data(),
+            "full_charge_maintenance": maintenance_data,
             "package": package,
         }
     return package

--- a/custom_components/battery_smartflow_ai/native_zendure_runtime.py
+++ b/custom_components/battery_smartflow_ai/native_zendure_runtime.py
@@ -527,6 +527,7 @@ class NativeZendureRuntime:
                     else None
                 ),
                 "selected_device": self._selected_device,
+                "calibration_information": self._calibration_diagnostics(),
                 "message_count": self._processed_messages,
                 "capture_complete": self._capture_complete,
                 "capture_reason": self._capture_reason,
@@ -567,6 +568,35 @@ class NativeZendureRuntime:
                 "overview": self.overview_attributes(),
             }
         )
+
+    def _calibration_diagnostics(self) -> dict[str, Any]:
+        """Describe verified capability without exporting physical identity."""
+
+        source = self._inventory.devices.get(self._selected_device or "")
+        identity = source.native_identities[0] if (
+            source is not None and source.native_identities
+        ) else None
+        matrix = resolve_zendure_device(identity) if identity is not None else None
+        if matrix is None:
+            return {
+                "native_status_capability": VerificationLevel.UNKNOWN.value,
+                "native_next_due_capability": VerificationLevel.UNKNOWN.value,
+                "information_source": "bsfai_derived",
+                "native_calibration_command": "unsupported",
+            }
+        calibration = matrix.calibration
+        verified_native = bool(
+            calibration.raw_status is VerificationLevel.VERIFIED
+            or calibration.next_due_from_device is VerificationLevel.VERIFIED
+        )
+        return {
+            "native_status_capability": calibration.raw_status.value,
+            "native_next_due_capability": calibration.next_due_from_device.value,
+            "information_source": (
+                "verified_native" if verified_native else "bsfai_derived"
+            ),
+            "native_calibration_command": "unsupported",
+        }
 
     async def async_run_first_write_test(self) -> NativeWriteVerification:
         """Run the explicit SF2400AC ZenSDK +1 W write and restore test."""

--- a/tests/test_debug_sample_builder.py
+++ b/tests/test_debug_sample_builder.py
@@ -50,6 +50,9 @@ class DebugSampleBuilderTests(unittest.TestCase):
             "pv_outlook": "high",
             "charge_commit_active": True,
             "charge_commit_reason": "learned_window",
+            "full_charge_maintenance_state": "charging_to_full",
+            "full_charge_maintenance_block_reason": "none",
+            "full_charge_maintenance_active": True,
             "set_mode": "input",
             "set_input_w": 500,
             "mode_write_requested": "input",
@@ -70,6 +73,10 @@ class DebugSampleBuilderTests(unittest.TestCase):
         self.assertEqual(result["strategy"]["decision_action"], "charge")
         self.assertEqual(result["strategy"]["season_mode"], "summer")
         self.assertTrue(result["strategy"]["automatic"]["strategy_active"])
+        self.assertEqual(
+            result["planning"]["full_charge_maintenance"]["state"],
+            "charging_to_full",
+        )
         self.assertEqual(result["strategy"]["intent"]["intent"], "charge")
         allocation = result["strategy"]["charge_source_allocation"]
         self.assertTrue(allocation["active"])

--- a/tests/test_full_charge_maintenance_coordinator.py
+++ b/tests/test_full_charge_maintenance_coordinator.py
@@ -42,8 +42,12 @@ class FullChargeMaintenanceCoordinatorTests(unittest.TestCase):
             self.source.index("native_runtime.full_charge_maintenance_input("):
         ]
         call = call[:call.index(")\n                if maintenance_input")]
-        self.assertIn("SETTING_FULL_CHARGE_MAINTENANCE_ENABLED", call)
-        self.assertIn("DEFAULT_FULL_CHARGE_MAINTENANCE_ENABLED", call)
+        self.assertIn("enabled=maintenance_enabled", call)
+        before_call = self.source[:self.source.index(
+            "native_runtime.full_charge_maintenance_input("
+        )]
+        self.assertIn("SETTING_FULL_CHARGE_MAINTENANCE_ENABLED", before_call)
+        self.assertIn("DEFAULT_FULL_CHARGE_MAINTENANCE_ENABLED", before_call)
         self.assertIn("SETTING_FULL_CHARGE_MAINTENANCE_INTERVAL_DAYS", self.source)
 
     def test_request_crosses_only_the_strategy_adapter(self):

--- a/tests/test_native_power_controller.py
+++ b/tests/test_native_power_controller.py
@@ -183,6 +183,12 @@ def legacy_runtime(*, current_state=None):
 
 
 class NativePowerControllerTests(unittest.IsolatedAsyncioTestCase):
+    def test_calibration_diagnostics_never_claim_unverified_native_truth(self):
+        diagnostic = runtime().diagnostic_data()["calibration_information"]
+        self.assertEqual(diagnostic["information_source"], "bsfai_derived")
+        self.assertEqual(diagnostic["native_calibration_command"], "unsupported")
+        self.assertNotIn(DEVICE, str(diagnostic))
+
     def test_pack_soc_only_conflicts_with_a_reported_full_system(self):
         pack = SimpleNamespace(
             soc_pct=measured(80), protection_active=measured(False)


### PR DESCRIPTION
## Summary

- complete the native full-charge maintenance assistant and its remaining diagnostics
- keep disabled, not-due, due-soon, due, active, blocked, confirming, and completed semantics distinct
- stop an active maintenance request immediately when the user disables the feature, while preserving passive schedule visibility when maintenance is not due
- include bounded maintenance state in debug recordings and Home Assistant diagnostics
- report the selected device's calibration evidence level and clearly distinguish verified native information from BSFAI-derived maintenance dates
- explicitly report native calibration commands as unsupported until a real capability is verified

## Safety and compatibility

- no direct BMS calibration command
- no deep discharge
- no hardware-limit or protection bypass
- HEMS, stale data, transport loss, pack conflicts, manual mode, and emergency paths remain fail-closed
- no serial numbers, credentials, physical device IDs, or other identity data are added to maintenance diagnostics
- existing V4.6/V4.7 entity identities remain unchanged

## Validation

118 focused tests passed across maintenance planning/control/runtime/UI, native PowerController routing, debug and diagnostics pipelines, translations, V4.7 compatibility, and Dev9 regulation scenarios. Compilation and diff validation also passed.

Closes #347
Closes #152