### PR TITLE
V5 beta2: native hardware configuration and inventory

### DIFF
--- a/custom_components/battery_smartflow_ai/config_flow.py
+++ b/custom_components/battery_smartflow_ai/config_flow.py
@@ -79,7 +79,7 @@ from .native_config_ui import (
 )
 from .price_currency import price_input_profile, resolve_price_currency
 from .zendure_cloud import ZendureCloudClient, ZendureCloudError
-from .zendure_device_matrix import preferred_local_transport
+from .zendure_device_matrix import preferred_local_transport, resolve_zendure_device
 
 EMPTY_ENTITY_VALUES = {
     "",
@@ -169,13 +169,89 @@ class ZendureSmartFlowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 4
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None):
+        return self.async_show_menu(step_id="user", menu_options=["native_login", "legacy"])
+
+    async def async_step_legacy(self, user_input: dict[str, Any] | None = None):
         if user_input is not None:
             self._user_input = dict(user_input)
             return await self.async_step_grid()
 
         return self.async_show_form(
-            step_id="user",
+            step_id="legacy",
             data_schema=self._base_schema(),
+        )
+
+    async def async_step_native_login(self, user_input=None):
+        """Discover first; native setup never requires entities from another integration."""
+        errors = {}
+        if user_input is not None:
+            token = resolve_app_token_input(user_input.get(CONF_NATIVE_ZENDURE_APP_TOKEN), None)
+            try:
+                from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+                session = async_get_clientsession(self.hass)
+
+                async def post_json(url, **kwargs):
+                    async with session.post(url, **kwargs) as response:
+                        payload = await response.json(content_type=None)
+
+                    class Response:
+                        async def json(self):
+                            return payload
+
+                    return Response()
+
+                self._native_bootstrap = await ZendureCloudClient(post_json).async_discover(token)
+                self._native_options = {CONF_NATIVE_ZENDURE_APP_TOKEN: token}
+                return await self.async_step_native_device()
+            except ZendureCloudError as error:
+                errors["base"] = error.reason
+            except Exception:
+                errors["base"] = "cannot_connect"
+        return self.async_show_form(
+            step_id="native_login", errors=errors,
+            data_schema=vol.Schema({
+                vol.Required(CONF_NATIVE_ZENDURE_APP_TOKEN): selector.TextSelector(
+                    selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD)
+                ),
+            }),
+        )
+
+    async def async_step_native_device(self, user_input=None):
+        devices = self._native_bootstrap.devices
+        errors = {}
+        if user_input is not None:
+            selected = next((item for item in devices if item.candidate.candidate_id ==
+                             user_input.get(CONF_NATIVE_ZENDURE_SELECTED_DEVICE)), None)
+            profile = resolve_zendure_device(selected.candidate.identity) if selected else None
+            if selected is None:
+                errors["base"] = "device_not_found"
+            elif profile is None:
+                errors["base"] = "unsupported_device"
+            elif (preferred_local_transport(selected.candidate.identity) is ZendureTransport.LOCAL_MQTT
+                  and not str(user_input.get(CONF_NATIVE_ZENDURE_LOCAL_MQTT_SERVER, "")).strip()):
+                errors["base"] = "local_mqtt_required"
+            else:
+                self._native_options.update(user_input)
+                self._user_input = {
+                    "connection_type": "native",
+                    CONF_DEVICE_PROFILE: profile.profile_key,
+                }
+                return await self.async_step_native_external()
+        return self.async_show_form(
+            step_id="native_device", errors=errors,
+            data_schema=ZendureSmartFlowOptionsFlow._native_device_schema(devices),
+            description_placeholders={
+                "device_summary": ZendureSmartFlowOptionsFlow._native_device_summary(devices),
+            },
+        )
+
+    async def async_step_native_external(self, user_input=None):
+        if user_input is not None:
+            self._user_input.update(user_input)
+            return await self.async_step_grid()
+        return self.async_show_form(
+            step_id="native_external", data_schema=self._base_schema(native=True),
         )
 
     async def async_step_grid(self, user_input: dict[str, Any] | None = None):
@@ -210,6 +286,7 @@ class ZendureSmartFlowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return self.async_create_entry(
                     title="Battery SmartFlow AI",
                     data=self._user_input,
+                    options=getattr(self, "_native_options", {}),
                 )
 
         return self.async_show_form(
@@ -285,6 +362,7 @@ class ZendureSmartFlowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     def _base_schema(
         self,
         entry: config_entries.ConfigEntry | None = None,
+        *, native: bool = False,
     ) -> vol.Schema:
         def _val(key: str):
             if not entry:
@@ -602,6 +680,18 @@ class ZendureSmartFlowConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
         )
 
+        if native or (entry and (
+            entry.data.get("connection_type") == "native"
+            or entry.options.get(CONF_NATIVE_ZENDURE_CONTROL_ENABLED, False)
+        )):
+            hardware_keys = {
+                CONF_DEVICE_PROFILE, CONF_SOC_ENTITY, CONF_SOC_LIMIT_ENTITY,
+                CONF_PACK_CAPACITY_KWH, CONF_NATIVE_PV_ENTITY,
+                CONF_BATTERY_AC_POWER_ENTITY, CONF_AC_MODE_ENTITY,
+                CONF_INPUT_LIMIT_ENTITY, CONF_OUTPUT_LIMIT_ENTITY,
+                CONF_OFFGRID_POWER_ENTITY, CONF_OFFGRID_MODE_ENTITY,
+            }
+            schema = {key: value for key, value in schema.items() if key.schema not in hardware_keys}
         return vol.Schema(schema)
 
     def _grid_schema(
@@ -1183,6 +1273,18 @@ class ZendureSmartFlowOptionsFlow(config_entries.OptionsFlow):
             }
         )
 
+        coordinator = self.hass.data.get(DOMAIN, {}).get(self.config_entry.entry_id)
+        runtime = getattr(coordinator, "native_zendure", None)
+        if (runtime is not None and hasattr(runtime, "selected_capacity")
+            and runtime.selected_capacity().reason == "unknown_pack_profile"):
+            options_schema = options_schema.extend({
+                vol.Optional("native_capacity_override_kwh", default=preview.get("native_capacity_override_kwh", 0)):
+                    selector.NumberSelector(selector.NumberSelectorConfig(
+                        min=0, step=0.01, mode=selector.NumberSelectorMode.BOX,
+                        unit_of_measurement="kWh",
+                    )),
+            })
+
         suggested_values = {
             CONF_EXPERT_MODE_ENABLED: preview.get(
                 CONF_EXPERT_MODE_ENABLED,
@@ -1252,6 +1354,9 @@ class ZendureSmartFlowOptionsFlow(config_entries.OptionsFlow):
         user_input: dict[str, Any] | None = None,
     ):
         packs = self._get_battery_packs()
+        if (self.config_entry.data.get("connection_type") == "native"
+            or self.config_entry.options.get(CONF_NATIVE_ZENDURE_CONTROL_ENABLED, False)):
+            packs = 0  # Native pack measurements are inputs, not entity selectors.
         preview = self._merged_preview()
 
         if user_input is not None:

--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -38,7 +38,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "5.0.0.beta1"
+INTEGRATION_VERSION = "5.0.0-beta2"
 
 # V5 native Zendure discovery is observation-only in the first development
 # build. The App Token is account discovery material and must never be copied

--- a/custom_components/battery_smartflow_ai/coordinator.py
+++ b/custom_components/battery_smartflow_ai/coordinator.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import math
 
 import logging
 from functools import partial
@@ -364,7 +365,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.runtime_settings: dict[str, float] = dict(entry.options)
 
         self.entities = SelectedEntities(
-            soc=str(entry.data[CONF_SOC_ENTITY]),
+            soc=str(entry.data.get(CONF_SOC_ENTITY, "")),
             pv=str(entry.data[CONF_PV_ENTITY]),
             native_pv=entry.data.get(CONF_NATIVE_PV_ENTITY),
             pv_forecast_today=entry.data.get(CONF_PV_FORECAST_TODAY_ENTITY),
@@ -380,9 +381,9 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             dynamic_feed_in_price=entry.data.get(
                 CONF_DYNAMIC_FEED_IN_PRICE_ENTITY
             ),
-            ac_mode=str(entry.data[CONF_AC_MODE_ENTITY]),
-            input_limit=str(entry.data[CONF_INPUT_LIMIT_ENTITY]),
-            output_limit=str(entry.data[CONF_OUTPUT_LIMIT_ENTITY]),
+            ac_mode=str(entry.data.get(CONF_AC_MODE_ENTITY, "")),
+            input_limit=str(entry.data.get(CONF_INPUT_LIMIT_ENTITY, "")),
+            output_limit=str(entry.data.get(CONF_OUTPUT_LIMIT_ENTITY, "")),
             soc_limit=entry.data.get(CONF_SOC_LIMIT_ENTITY),
             grid_mode=str(entry.data.get(CONF_GRID_MODE, GRID_MODE_NONE)),
             grid_power=entry.data.get(CONF_GRID_POWER_ENTITY),
@@ -1954,6 +1955,13 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if not self._cell_voltage_protection_enabled():
             return values
 
+        native = getattr(self, "native_zendure", None)
+        if native is not None and native.control_enabled:
+            state = native.selected_device_state()
+            if state is None:
+                return []
+            return [float(pack.cell_min_v.value) for pack in state.packs if pack.cell_min_v.valid]
+
         for entity_id in self.entities.lowest_cell_voltage_entities:
             val = _to_float(self._state(entity_id), None)
             if val is not None:
@@ -2432,6 +2440,18 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         return "unknown"
 
     def _get_soc_limit(self) -> int | None:
+        native = getattr(self, "native_zendure", None)
+        if native is not None and native.control_enabled:
+            state = native.selected_device_state()
+            if state is None or not state.soc_pct.valid:
+                return None
+            lower = state.setpoints.min_soc_pct
+            upper = state.setpoints.max_soc_pct
+            if upper.valid and state.soc_pct.value >= upper.value:
+                return 1
+            if lower.valid and state.soc_pct.value <= lower.value:
+                return 2
+            return 0 if lower.valid and upper.valid else None
         if not self.entities.soc_limit:
             return None
         raw = self._state(self.entities.soc_limit)
@@ -2444,6 +2464,16 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             return None
 
     def _get_battery_capacity(self) -> float:
+        native = getattr(self, "native_zendure", None)
+        if native is not None and (
+            native.control_enabled or self.entry.data.get("connection_type") == "native"
+        ):
+            capacity = native.selected_capacity()
+            if capacity.reason == "unknown_pack_profile":
+                override = _to_float(self.entry.options.get("native_capacity_override_kwh"), None)
+                if override is not None and math.isfinite(override) and override > 0:
+                    return override
+            return capacity.capacity_kwh or 0.0
         pack_capacity = float(self.entry.data.get(CONF_PACK_CAPACITY_KWH, 0))
 
         packs = self._get_setting(
@@ -3872,7 +3902,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             native_state = (
                 native_runtime.selected_device_state()
                 if native_runtime is not None
-                and native_runtime.control_enabled
+                and (native_runtime.control_enabled or self.entry.data.get("connection_type") == "native")
                 and hasattr(native_runtime, "selected_device_state")
                 else None
             )
@@ -3889,6 +3919,8 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             )
             pv = _to_float(self._state(self.entities.pv), None)
             native_pv = _to_float(self._state(self.entities.native_pv), None)
+            if native_state is not None:
+                native_pv = float(native_state.pv_power_w.value) if native_state.pv_power_w.valid else None
 
             if soc is None or not 0.0 <= float(soc) <= 100.0:
                 return await self._enter_safe_idle(
@@ -3902,11 +3934,16 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             soc = float(soc)
             pv_sensor_valid = pv is not None
             pv_w = float(pv or 0.0)
-            native_pv_configured = bool(self.entities.native_pv)
+            native_pv_configured = native_state is not None or bool(self.entities.native_pv)
             native_pv_sensor_valid = native_pv is not None
             native_pv_w = float(native_pv or 0.0)
 
             battery_capacity_kwh = self._get_battery_capacity()
+            if native_runtime is not None and native_runtime.control_enabled and battery_capacity_kwh <= 0:
+                return await self._enter_safe_idle(
+                    reason="native_capacity_unavailable",
+                    raw_values={"capacity_status": native_runtime.selected_capacity().reason},
+                )
 
             prev_soc = self._persist.get("prev_soc")
             delta_kwh = 0.0
@@ -3931,6 +3968,8 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 self._state(self.entities.offgrid_power),
                 None,
             )
+            if native_state is not None:
+                offgrid_raw = float(native_state.offgrid_power_w.value) if native_state.offgrid_power_w.valid else None
 
             offgrid_mode_raw = self._state(self.entities.offgrid_mode)
             offgrid_mode = self._normalize_offgrid_mode(offgrid_mode_raw)
@@ -3947,7 +3986,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
             offgrid_available = bool(
                 supports_offgrid_socket
-                and self.entities.offgrid_power
+                and (native_state is not None or self.entities.offgrid_power)
                 and offgrid_raw is not None
             )
 
@@ -5041,34 +5080,35 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 
             # The strategic AC charge binding runs before power tracking and
             # StrategyIntent creation so the unified regulation sees it.
-            decision = self._apply_charge_commit(
-                now=now,
-                decision=decision,
-                learned_charge_plan=learned_charge_plan,
-                soc=float(soc),
-                soc_max=float(soc_max),
-                max_charge_w=float(max_charge),
-                ai_mode=str(ai_mode),
-                manual_action=str(manual_action),
-                additional_battery_discharge_w=float(
-                    additional_battery_discharge_w or 0.0
-                ),
-                offgrid_load_active=bool(offgrid_load_active),
-                cell_voltage_emergency_active=bool(
-                    cell_voltage_emergency_active
-                ),
-                price_now=price_now,
-                effective_discharge_threshold=(
-                    decision.effective_discharge_threshold
-                ),
-                automatic_peak_reserve_allowed=bool(
-                    automatic_strategy_context.metadata.get(
-                        "automatic_peak_reserve_allowed",
-                        False,
-                    )
-                ),
-                battery_charge_w=float(battery_charge_w or 0.0),
-            )
+            if not maintenance_application.applied:
+                decision = self._apply_charge_commit(
+                    now=now,
+                    decision=decision,
+                    learned_charge_plan=learned_charge_plan,
+                    soc=float(soc),
+                    soc_max=float(soc_max),
+                    max_charge_w=float(max_charge),
+                    ai_mode=str(ai_mode),
+                    manual_action=str(manual_action),
+                    additional_battery_discharge_w=float(
+                        additional_battery_discharge_w or 0.0
+                    ),
+                    offgrid_load_active=bool(offgrid_load_active),
+                    cell_voltage_emergency_active=bool(
+                        cell_voltage_emergency_active
+                    ),
+                    price_now=price_now,
+                    effective_discharge_threshold=(
+                        decision.effective_discharge_threshold
+                    ),
+                    automatic_peak_reserve_allowed=bool(
+                        automatic_strategy_context.metadata.get(
+                            "automatic_peak_reserve_allowed",
+                            False,
+                        )
+                    ),
+                    battery_charge_w=float(battery_charge_w or 0.0),
+                )
 
             # V4.3.0-dev5.6.3:
             # Charge source classification, economic accounting and diagnostics

--- a/custom_components/battery_smartflow_ai/core/full_charge_maintenance.py
+++ b/custom_components/battery_smartflow_ai/core/full_charge_maintenance.py
@@ -181,6 +181,8 @@ class FullChargeMaintenancePlanner:
         data: FullChargeMaintenanceInput,
     ) -> FullChargeMaintenanceDecision:
         now = data.now.astimezone(timezone.utc)
+        if not data.enabled:
+            record = replace(record, active=False)
         next_due = record.next_recommended_full_at
         base_state = _schedule_state(next_due, now, self._due_soon)
 
@@ -194,6 +196,10 @@ class FullChargeMaintenancePlanner:
 
         at_full = data.soc_pct is not None and data.soc_pct >= FULL_SOC_PCT
         if at_full:
+            if (record.full_candidate_since is not None
+                and record.last_confirmed_full_at is not None
+                and record.last_confirmed_full_at >= record.full_candidate_since):
+                return FullChargeMaintenanceDecision(record, base_state)
             candidate_since = record.full_candidate_since or now
             confirming = replace(record, full_candidate_since=candidate_since)
             full_is_plausible = (
@@ -209,7 +215,7 @@ class FullChargeMaintenancePlanner:
                         record.last_completed_maintenance_at
                     ),
                     active=False,
-                    full_candidate_since=None,
+                    full_candidate_since=candidate_since,
                 )
                 return FullChargeMaintenanceDecision(
                     completed, MaintenanceState.COMPLETED
@@ -217,21 +223,14 @@ class FullChargeMaintenancePlanner:
             return FullChargeMaintenanceDecision(
                 confirming,
                 MaintenanceState.CONFIRMING_FULL,
-                request_full_charge=record.active,
-                target_soc_pct=FULL_SOC_PCT if record.active else None,
-                temporary_user_limit_override=record.active,
+                selected_window=_select_window(data),
+                request_full_charge=record.active and _select_window(data) is not MaintenanceWindow.NONE,
+                target_soc_pct=FULL_SOC_PCT if record.active and _select_window(data) is not MaintenanceWindow.NONE else None,
+                temporary_user_limit_override=record.active and _select_window(data) is not MaintenanceWindow.NONE,
             )
 
         record = replace(record, full_candidate_since=None)
-        if record.active and not data.enabled:
-            return FullChargeMaintenanceDecision(
-                record,
-                MaintenanceState.BLOCKED,
-                block_reason=MaintenanceBlockReason.NOT_ENABLED,
-            )
-        if record.active:
-            return _charging_decision(record, MaintenanceWindow.NONE)
-        if base_state in {MaintenanceState.NOT_DUE, MaintenanceState.DUE_SOON}:
+        if not record.active and base_state in {MaintenanceState.NOT_DUE, MaintenanceState.DUE_SOON}:
             return FullChargeMaintenanceDecision(record, base_state)
         if not data.enabled:
             return FullChargeMaintenanceDecision(

--- a/custom_components/battery_smartflow_ai/core/models/native_device_state.py
+++ b/custom_components/battery_smartflow_ai/core/models/native_device_state.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from typing import Mapping
 from datetime import datetime
 from enum import StrEnum
 
 from .inventory import ZendureTransport
-from .states import MeasuredValue
+from .states import MeasuredValue, ValueValidity
 
 
 class DeviceOperatingMode(StrEnum):
@@ -52,6 +53,7 @@ class NeutralPackState:
     fault_code: MeasuredValue[int]
     protection_active: MeasuredValue[bool]
     last_message_at: datetime | None
+    heating_active: MeasuredValue[bool] = field(default_factory=lambda: MeasuredValue.absent(ValueValidity.MISSING))
 
 
 @dataclass(frozen=True, slots=True)
@@ -79,3 +81,5 @@ class NeutralDeviceState:
     last_message_at: datetime | None
     packs: tuple[NeutralPackState, ...]
     offgrid_power_w: MeasuredValue[float]
+    diagnostics: Mapping[str, MeasuredValue] = field(default_factory=dict)
+    heating_active: MeasuredValue[bool] = field(default_factory=lambda: MeasuredValue.absent(ValueValidity.MISSING))

--- a/custom_components/battery_smartflow_ai/full_charge_maintenance_control.py
+++ b/custom_components/battery_smartflow_ai/full_charge_maintenance_control.py
@@ -57,7 +57,8 @@ def apply_maintenance_charge_request(
     if maintenance.selected_window is MaintenanceWindow.PV_SURPLUS:
         charge_w = min(
             float(max_charge_w),
-            max(float(decision.charge_w or 0.0), float(grid_export_w), 0.0),
+            max(float(decision.charge_w or 0.0) if decision.reason == "pv_surplus_charge" else 0.0,
+                float(grid_export_w), 0.0),
         )
         reason = "pv_surplus_charge"
     elif maintenance.selected_window is MaintenanceWindow.LOW_PRICE:

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": ["paho-mqtt==2.1.0"],
-  "version": "5.0.0.beta1"
+  "version": "5.0.0-beta2"
 }

--- a/custom_components/battery_smartflow_ai/native_capacity.py
+++ b/custom_components/battery_smartflow_ai/native_capacity.py
@@ -1,0 +1,45 @@
+"""Conservative pack profiles and inventory-derived nominal capacity.
+
+Serial families follow Zendure-HA's battery profiles (device.py).
+Unknown families never inherit the main device's or another pack's capacity.
+"""
+
+from dataclasses import dataclass
+
+from .core.models import NeutralDeviceState
+
+
+@dataclass(frozen=True)
+class NativeCapacity:
+    pack_count: int | None
+    capacity_kwh: float | None
+    reason: str
+
+
+def pack_capacity_kwh(serial: str | None, pack_type: str | None) -> float | None:
+    if not serial or len(serial) < 4:
+        return None
+    if serial[0] == "A":
+        return 2.4 if serial[3] == "3" else 0.96
+    if serial[0] == "B":
+        return 8.0 if str(pack_type) == "70" else 0.96
+    return {"C": 1.92, "F": 2.88, "G": 2.88, "J": 2.4}.get(serial[0])
+
+
+def native_capacity(state: NeutralDeviceState | None, expected_count: int | None = None) -> NativeCapacity:
+    if state is None or not state.packs:
+        return NativeCapacity(expected_count, None, "inventory_pending")
+    packs = {pack.pack_id: pack for pack in state.packs}
+    if expected_count is not None and expected_count != len(packs):
+        return NativeCapacity(expected_count, None, "inventory_incomplete")
+    total = 0.0
+    for pack in packs.values():
+        if not pack.soc_pct.valid:
+            return NativeCapacity(len(packs), None, "pack_data_unavailable")
+        capacity = pack_capacity_kwh(
+            pack.serial_number, pack.pack_type.value if pack.pack_type.valid else None,
+        )
+        if capacity is None:
+            return NativeCapacity(len(packs), None, "unknown_pack_profile")
+        total += capacity
+    return NativeCapacity(len(packs), round(total, 3), "pack_profiles")

--- a/custom_components/battery_smartflow_ai/native_device_overview.py
+++ b/custom_components/battery_smartflow_ai/native_device_overview.py
@@ -7,6 +7,7 @@ from datetime import datetime
 import hashlib
 from types import MappingProxyType
 from typing import Mapping
+from .native_capacity import native_capacity, pack_capacity_kwh
 
 from .core.models import (
     DeviceControlState,
@@ -108,6 +109,14 @@ def build_native_device_overview(
                             "fault_code": observed.fault_code,
                             "protection_active": observed.protection_active,
                             "pack_type": observed.pack_type,
+                            "cell_delta_v": _difference(observed.cell_max_v, observed.cell_min_v),
+                            "power_w": _difference(observed.discharge_power_w, observed.charge_power_w),
+                            "capacity_kwh": _optional_value(pack_capacity_kwh(
+                                observed.serial_number,
+                                observed.pack_type.value if observed.pack_type.valid else None,
+                            )),
+                            "status": _pack_status(observed.state_code),
+                            "heating_active": _boolean_status(_measurement(observed, "heating_active")),
                         }
                     ),
                     last_message_at=observed.last_message_at,
@@ -128,7 +137,7 @@ def build_native_device_overview(
                 ),
                 firmware=_measurement(state, "firmware"),
                 measurements=MappingProxyType(
-                    {
+                    {**{
                         key: _measurement(state, key)
                         for key in (
                             "soc_pct",
@@ -142,7 +151,15 @@ def build_native_device_overview(
                             "protection_active",
                             "temperature_c",
                             "battery_voltage_v",
+                            "offgrid_power_w",
                         )
+                    }, **dict(getattr(state, "diagnostics", {})),
+                     "pack_count": _optional_value(native_capacity(state).pack_count),
+                     "capacity_kwh": _optional_value(native_capacity(state).capacity_kwh),
+                     "power_w": _difference(_measurement(state, "discharge_power_w"), _measurement(state, "charge_power_w")),
+                     "hardware_soc_min": _measurement(getattr(state, "setpoints", None), "min_soc_pct"),
+                     "hardware_soc_max": _measurement(getattr(state, "setpoints", None), "max_soc_pct"),
+                     "heating_active": _boolean_status(_measurement(state, "heating_active")),
                     }
                     if state
                     else {}
@@ -183,6 +200,24 @@ def _measurement(state: object | None, key: str) -> MeasuredValue:
     if state is None:
         return MeasuredValue.absent(ValueValidity.MISSING)
     return getattr(state, key, MeasuredValue.absent(ValueValidity.MISSING))
+
+
+def _optional_value(value):
+    return MeasuredValue.available(value) if value is not None else MeasuredValue.absent(ValueValidity.UNKNOWN)
+
+
+def _difference(left, right):
+    if not left.valid or not right.valid:
+        return MeasuredValue.absent(ValueValidity.UNAVAILABLE)
+    return MeasuredValue.available(round(float(left.value) - float(right.value), 3))
+
+
+def _pack_status(value):
+    return _optional_value({0: "idle", 1: "charge", 2: "discharge"}.get(value.value) if value.valid else None)
+
+
+def _boolean_status(value):
+    return _optional_value(("on" if value.value else "off") if value.valid else None)
 
 
 def _pack_model(value: str | None, parent_model: str | None) -> str | None:

--- a/custom_components/battery_smartflow_ai/native_source_fusion.py
+++ b/custom_components/battery_smartflow_ai/native_source_fusion.py
@@ -141,6 +141,7 @@ class NativeSourceFusion:
             "hems_active",
             "fault_code",
             "protection_active",
+            "heating_active",
             "temperature_c",
             "battery_voltage_v",
             "offgrid_power_w",
@@ -202,6 +203,13 @@ class NativeSourceFusion:
                 default=None,
             ),
             packs=packs,
+            diagnostics={
+                name: select(
+                    f"diagnostics.{name}",
+                    {source: item.diagnostics[name] for source, item in states.items() if name in item.diagnostics},
+                    {source: self._retained_main.get((source, system_id), {}).get(name, False) for source in states},
+                ) for name in sorted({key for item in states.values() for key in item.diagnostics})
+            },
             **selected_values,
         )
         self._selection[system_id] = trace
@@ -369,6 +377,10 @@ class NativeSourceFusion:
                 mapping = MAIN_PROPERTY_MAPPINGS.get(str(raw_name))
                 if mapping is not None:
                     destination[mapping.target] = message.retained
+            if "faultLevel" in properties or "is_error" in properties:
+                destination["protection_active"] = any(
+                    destination.get(key, False) for key in ("fault_code", "is_error")
+                )
         packs = payload.get("packData")
         if not isinstance(packs, list):
             return
@@ -388,6 +400,8 @@ class NativeSourceFusion:
             if "power" in pack:
                 destination["charge_power_w"] = message.retained
                 destination["discharge_power_w"] = message.retained
+            if "faultLevel" in pack:
+                destination["protection_active"] = message.retained
 
     def _source_quality(
         self,
@@ -455,6 +469,8 @@ def _measurement(
     state: NeutralDeviceState,
     property_name: str,
 ) -> MeasuredValue[Any] | None:
+    if property_name.startswith("diagnostics."):
+        return state.diagnostics.get(property_name.split(".", 1)[1])
     if property_name.startswith("setpoints."):
         return getattr(state.setpoints, property_name.split(".", 1)[1], None)
     if property_name.startswith("packs."):

--- a/custom_components/battery_smartflow_ai/native_zendure_runtime.py
+++ b/custom_components/battery_smartflow_ai/native_zendure_runtime.py
@@ -199,6 +199,14 @@ class NativeZendureRuntime:
 
         return self._selected_device
 
+    def selected_capacity(self):
+        """Use only packs of the selected system, never a legacy setting."""
+        from .native_capacity import native_capacity
+
+        expected = next((item.pack_count for item in self._bootstrap.devices
+                         if item.candidate.candidate_id == self._selected_device), None) if self._bootstrap else None
+        return native_capacity(self.selected_device_state(), expected)
+
     def full_charge_maintenance_input(
         self,
         *,
@@ -244,6 +252,8 @@ class NativeZendureRuntime:
                 self._control_enabled
                 and _fresh_at(online, now=now)
                 and online.value
+                and _fresh_at(protection, now=now)
+                and _fresh_at(hems, now=now)
             ),
             transport_available=bool(
                 authority.device_id == self._selected_device

--- a/custom_components/battery_smartflow_ai/number.py
+++ b/custom_components/battery_smartflow_ai/number.py
@@ -6,6 +6,7 @@ from homeassistant.components.number import NumberEntity, NumberEntityDescriptio
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers import entity_registry as er
 
 from .const import (
     DOMAIN,
@@ -241,10 +242,20 @@ async def async_setup_entry(
     add_entities: AddEntitiesCallback,
 ) -> None:
     coordinator = hass.data[DOMAIN][entry.entry_id]
+    native = entry.data.get("connection_type") == "native" or entry.options.get("native_zendure_control_enabled", False)
+    registry = er.async_get(hass)
+    pack_entity = registry.async_get_entity_id("number", DOMAIN, f"{entry.entry_id}_{SETTING_BATTERY_PACKS}")
+    if pack_entity:
+        registered = registry.async_get(pack_entity)
+        if native and registered.disabled_by is None:
+            registry.async_update_entity(pack_entity, disabled_by=er.RegistryEntryDisabler.INTEGRATION)
+        elif not native and registered.disabled_by is er.RegistryEntryDisabler.INTEGRATION:
+            registry.async_update_entity(pack_entity, disabled_by=None)
 
     entities = [
         ZendureSmartFlowNumber(entry, coordinator, description)
         for description in NUMBERS
+        if not (native and description.runtime_key == SETTING_BATTERY_PACKS)
     ]
 
     add_entities(entities)

--- a/custom_components/battery_smartflow_ai/sensor.py
+++ b/custom_components/battery_smartflow_ai/sensor.py
@@ -294,7 +294,64 @@ NATIVE_MAIN_SENSORS = (
     ),
 )
 
+NATIVE_MAIN_SENSORS += (
+    NativeHardwareSensorDescription(
+        key="heating_active", translation_key="native_hardware_heating", measurement_key="heating_active",
+        device_class=SensorDeviceClass.ENUM, options=["on", "off"],
+    ),
+    NativeHardwareSensorDescription(
+        key="hardware_soc_min", translation_key="native_hardware_soc_min", measurement_key="hardware_soc_min",
+        native_unit_of_measurement=PERCENTAGE, suggested_display_precision=0,
+    ),
+    NativeHardwareSensorDescription(
+        key="hardware_soc_max", translation_key="native_hardware_soc_max", measurement_key="hardware_soc_max",
+        native_unit_of_measurement=PERCENTAGE, suggested_display_precision=0,
+    ),
+    NativeHardwareSensorDescription(
+        key="pack_count", translation_key="native_hardware_pack_count", measurement_key="pack_count",
+        state_class=SensorStateClass.MEASUREMENT, suggested_display_precision=0,
+    ),
+    NativeHardwareSensorDescription(
+        key="capacity_kwh", translation_key="native_hardware_capacity_kwh", measurement_key="capacity_kwh",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY, state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+    ),
+    NativeHardwareSensorDescription(
+        key="power_w", translation_key="native_hardware_power_w", measurement_key="power_w",
+        native_unit_of_measurement=UnitOfPower.WATT, device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    NativeHardwareSensorDescription(
+        key="offgrid_power_w", translation_key="native_hardware_offgrid_power_w", measurement_key="offgrid_power_w",
+        native_unit_of_measurement=UnitOfPower.WATT, device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+)
+
+# Raw properties stay disabled diagnostics until the user needs them; no guessed enums.
+from .zendure_normalizer import RAW_MAIN_DIAGNOSTICS
+
+NATIVE_MAIN_SENSORS += tuple(
+    NativeHardwareSensorDescription(
+        key=key, name=key, measurement_key=key,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
+    ) for key in RAW_MAIN_DIAGNOSTICS
+)
+
 NATIVE_PACK_SENSORS = (
+    NativeHardwareSensorDescription(
+        key="status", translation_key="native_hardware_pack_status", measurement_key="status",
+        device_class=SensorDeviceClass.ENUM, options=["idle", "charge", "discharge"],
+    ),
+    NativeHardwareSensorDescription(
+        key="cell_delta_v", translation_key="native_hardware_cell_delta_v", measurement_key="cell_delta_v",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE, state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+    ),
+    *tuple(description for description in NATIVE_MAIN_SENSORS if description.key in {"capacity_kwh", "power_w", "heating_active"}),
     NativeHardwareSensorDescription(
         key="soc_pct", translation_key="native_hardware_soc_pct",
         measurement_key="soc_pct", native_unit_of_measurement=PERCENTAGE,

--- a/custom_components/battery_smartflow_ai/strings.json
+++ b/custom_components/battery_smartflow_ai/strings.json
@@ -13,6 +13,7 @@
     },
     "error": {
       "grid_split_missing": "When using two sensors, both grid import and grid export must be selected.",
+      "unsupported_device": "Unsupported device model.",
       "invalid_token": "The App Token format is invalid.",
       "invalid_or_expired_token": "The App Token is invalid or expired.",
       "cannot_connect": "Could not connect to Zendure Cloud.",
@@ -115,6 +116,76 @@
         }
       },
       "user": {
+        "title": "Set up Battery SmartFlow AI",
+        "menu_options": {
+          "native_login": "Connect Zendure directly",
+          "legacy": "Use existing HA entities"
+        }
+      },
+      "native_login": {
+        "title": "Sign in to Zendure",
+        "description": "The App Token is stored privately. The local transport is selected automatically for the device model.",
+        "data": {
+          "native_zendure_app_token": "App Token"
+        }
+      },
+      "native_device": {
+        "title": "Select the Zendure system",
+        "description": "Zendure reported these devices:\n\n{device_summary}\n\nSelect exactly one system. Battery SmartFlow AI automatically uses the supported local transport for its model. Native control is activated only by the separate switch below. When enabled, BSFAI stops writing through the configured Z-HA entities.",
+        "data": {
+          "native_zendure_selected_device": "Zendure system",
+          "native_zendure_control_enabled": "Enable native Zendure control",
+          "native_zendure_local_mqtt_server": "Local MQTT server",
+          "native_zendure_local_mqtt_port": "Local MQTT port",
+          "native_zendure_local_mqtt_username": "Local MQTT username",
+          "native_zendure_local_mqtt_password": "Local MQTT password"
+        },
+        "data_description": {
+          "native_zendure_selected_device": "Exactly one main system is selected; packs cannot be controlled independently. BSFAI selects ZenSDK or Local MQTT from the verified model family.",
+          "native_zendure_control_enabled": "Explicitly transfers BSFAI command output from the Z-HA entities to the model's local transport. Disable this switch to retain the established Z-HA control path.",
+          "native_zendure_local_mqtt_server": "Shown only when the account contains a verified legacy family. The device must already be provisioned to publish to this broker.",
+          "native_zendure_local_mqtt_port": "Usually 1883 for a local unencrypted broker.",
+          "native_zendure_local_mqtt_username": "Broker account used by BSFAI; it is kept private.",
+          "native_zendure_local_mqtt_password": "Keep the dot mask unchanged to reuse the stored password. It is never exposed by sensors or diagnostics."
+        }
+      },
+      "native_external": {
+        "title": "Set up Battery SmartFlow AI",
+        "description": "Select external measurements and price sources. Hardware data and pack capacities are detected automatically.",
+        "data": {
+          "additional_battery_charge_entity": "Additional battery charge power (optional)",
+          "additional_battery_discharge_entity": "Additional battery discharge power (optional)",
+          "installed_pv_wp": "Installed PV power (Wp)",
+          "pv_entity": "PV power sensor",
+          "pv_forecast_today_entity": "PV forecast today (optional)",
+          "pv_forecast_tomorrow_entity": "PV forecast tomorrow (optional)",
+          "price_now_entity": "Current electricity price",
+          "price_export_entity": "Price forecast (e.g. Tibber / EPEX)",
+          "grid_mode": "Grid metering",
+          "grid_power_entity": "Grid power (single)",
+          "grid_import_entity": "Grid import (split)",
+          "grid_export_entity": "Grid export (split)",
+          "feed_in_tariff": "Feed-in tariff",
+          "dynamic_feed_in_price_entity": "Current dynamic feed-in price (optional)"
+        },
+        "data_description": {
+          "additional_battery_charge_entity": "Optional sensor of a second battery system. If this sensor reports positive charge power, Battery SmartFlow AI blocks discharging.",
+          "additional_battery_discharge_entity": "Optional sensor of a second battery system. If this sensor reports positive discharge power, Battery SmartFlow AI blocks charging to avoid battery-to-battery charging.",
+          "installed_pv_wp": "Installed theoretical PV module power of the system in Wp. This value is used for relative PV-context thresholds and other PV-related logic.",
+          "pv_entity": "Sensor with the current PV power in watts.",
+          "pv_forecast_today_entity": "Optional sensor with today's PV daily forecast, for example from Solcast PV Forecast. The forecast is only an additional planning input and is not required for the integration.",
+          "pv_forecast_tomorrow_entity": "Optional sensor with tomorrow's PV daily forecast, for example from Solcast PV Forecast. The forecast is only an additional planning input and is not required for the integration.",
+          "price_now_entity": "Current electricity price. Enables price-dependent discharging.",
+          "price_export_entity": "Price forecast data for the next hours. Enables intelligent charge planning.",
+          "grid_mode": "Defines how grid import and export are recorded.",
+          "grid_power_entity": "A single sensor with positive power for import and negative power for export.",
+          "grid_import_entity": "Sensor with current grid import power in watts.",
+          "grid_export_entity": "Sensor with current grid export power in watts.",
+          "feed_in_tariff": "Compensation per exported kWh in the same currency unit as the electricity prices. Used as a fallback when no valid dynamic feed-in price is available.",
+          "dynamic_feed_in_price_entity": "Optional numeric Home Assistant sensor for the current dynamic feed-in price. A valid sensor value, including zero or a negative price, takes priority over the fixed feed-in tariff."
+        }
+      },
+      "legacy": {
         "title": "Set up Battery SmartFlow AI",
         "description": "Select the required sensors",
         "data": {
@@ -239,13 +310,15 @@
           "expert_mode_enabled": "Enable expert mode",
           "full_charge_maintenance_enabled": "Use full-charge maintenance",
           "full_charge_maintenance_interval_days": "Recommended full-charge interval",
-          "learned_planning_enabled": "Use learned charge-window planning"
+          "learned_planning_enabled": "Use learned charge-window planning",
+          "native_capacity_override_kwh": "Total capacity for an unknown pack profile (kWh)"
         },
         "data_description": {
           "expert_mode_enabled": "Enables the advanced expert area for additional protection and diagnostic functions.",
           "full_charge_maintenance_enabled": "Allows BSFAI to plan a protective full charge at favorable times. This is not a BMS calibration command.",
           "full_charge_maintenance_interval_days": "Days between recommended confirmed full charges (7–90).",
-          "learned_planning_enabled": "When enabled, Battery SmartFlow AI automatically uses learned charge-window planning once enough learning data is available. Until then, classic planning remains active. When disabled, classic planning is always used."
+          "learned_planning_enabled": "When enabled, Battery SmartFlow AI automatically uses learned charge-window planning once enough learning data is available. Until then, classic planning remains active. When disabled, classic planning is always used.",
+          "native_capacity_override_kwh": "Unknown packs only: verified total capacity of all packs in this system. 0 disables the override. Missing measurements still block control."
         }
       },
       "expert_cell_voltage": {
@@ -384,6 +457,15 @@
       "native_zendure_last_message": {"name": "Last native Zendure message"},
       "native_zendure_last_capture": {"name": "Native Zendure initial-sync package"},
       "native_zendure_error": {"name": "Native Zendure error"},
+      "native_hardware_pack_count": {"name":"Battery count"},
+      "native_hardware_capacity_kwh": {"name":"Nominal capacity"},
+      "native_hardware_power_w": {"name":"Battery power"},
+      "native_hardware_offgrid_power_w": {"name":"Off-grid power"},
+      "native_hardware_cell_delta_v": {"name":"Cell voltage difference"},
+      "native_hardware_pack_status": {"name":"Status","state":{"idle":"Idle","charge":"Charging","discharge":"Discharging"}},
+      "native_hardware_soc_min": {"name":"Hardware minimum SoC"},
+      "native_hardware_soc_max": {"name":"Hardware maximum SoC"},
+      "native_hardware_heating": {"name":"Battery heating","state":{"on":"On","off":"Off"}},
       "native_hardware_online": {"name": "Online status", "state": {"online": "Online", "offline": "Offline"}},
       "native_hardware_soc_pct": {"name": "State of charge"},
       "native_hardware_charge_power_w": {"name": "Charge power"},

--- a/custom_components/battery_smartflow_ai/translations/de.json
+++ b/custom_components/battery_smartflow_ai/translations/de.json
@@ -12,6 +12,7 @@
     },
     "error": {
       "grid_split_missing": "Bei \"Zwei Sensoren\" müssen Netzbezug und Netzeinspeisung beide ausgewählt werden.",
+      "unsupported_device": "Nicht unterstütztes Gerätemodell.",
       "invalid_token": "Das Format des App-Tokens ist ungültig.", "invalid_or_expired_token": "Der App-Token ist ungültig oder abgelaufen.", "cannot_connect": "Die Zendure-Cloud konnte nicht erreicht werden.", "timeout": "Die Zendure-Cloud hat nicht rechtzeitig geantwortet.", "invalid_response": "Die Zendure-Cloud hat eine unerwartete Antwort geliefert.", "no_devices": "Für dieses Konto wurden keine Zendure-Geräte gefunden.", "no_mqtt_credentials": "Zendure hat keine Cloud-MQTT-Zugangsdaten geliefert.", "duplicate_device_id": "Zendure hat doppelte Gerätekennungen geliefert.", "incomplete_device": "Zendure hat einen unvollständigen Geräteeintrag geliefert.", "device_not_found": "Das ausgewählte Gerät ist nicht mehr verfügbar.", "local_mqtt_required": "Für dieses Legacy-Gerät werden die Zugangsdaten des lokalen MQTT-Brokers benötigt."
     },
     "step": {
@@ -104,6 +105,76 @@
         }
       },
       "user": {
+        "title": "Battery SmartFlow AI einrichten",
+        "menu_options": {
+          "native_login": "Zendure direkt verbinden",
+          "legacy": "Vorhandene HA-Entitäten verwenden"
+        }
+      },
+      "native_login": {
+        "title": "Bei Zendure anmelden",
+        "description": "Der App-Token wird geschützt gespeichert. Die lokale Verbindung wird automatisch anhand des Gerätemodells gewählt.",
+        "data": {
+          "native_zendure_app_token": "App Token"
+        }
+      },
+      "native_device": {
+        "title": "Zendure-System auswählen",
+        "description": "Zendure hat folgende Geräte gemeldet:\n\n{device_summary}\n\nWähle genau ein System. Battery SmartFlow AI verwendet automatisch den vom Modell unterstützten lokalen Transport. Die native Steuerung wird nur mit dem separaten Schalter darunter aktiviert. Ist sie aktiv, schreibt BSFAI nicht mehr über die konfigurierten Z-HA-Entitäten.",
+        "data": {
+          "native_zendure_selected_device": "Zendure-System",
+          "native_zendure_control_enabled": "Native Zendure-Steuerung aktivieren",
+          "native_zendure_local_mqtt_server": "Lokaler MQTT-Server",
+          "native_zendure_local_mqtt_port": "Lokaler MQTT-Port",
+          "native_zendure_local_mqtt_username": "Lokaler MQTT-Benutzername",
+          "native_zendure_local_mqtt_password": "Lokales MQTT-Passwort"
+        },
+        "data_description": {
+          "native_zendure_selected_device": "Es wird genau ein Hauptsystem ausgewählt; Packs können nicht eigenständig gesteuert werden. BSFAI bestimmt ZenSDK oder Local MQTT anhand der verifizierten Modellfamilie.",
+          "native_zendure_control_enabled": "Überträgt die BSFAI-Befehlsausgabe ausdrücklich von den Z-HA-Entitäten auf den lokalen Modelltransport. Deaktiviere den Schalter, um den bewährten Z-HA-Steuerpfad beizubehalten.",
+          "native_zendure_local_mqtt_server": "Wird nur bei einer verifizierten Legacy-Familie angezeigt. Das Gerät muss bereits für Veröffentlichungen an diesen Broker eingerichtet sein.",
+          "native_zendure_local_mqtt_port": "Für einen lokalen unverschlüsselten Broker normalerweise 1883.",
+          "native_zendure_local_mqtt_username": "Privates Brokerkonto für BSFAI.",
+          "native_zendure_local_mqtt_password": "Die Punktmaske unverändert lassen, um das gespeicherte private Passwort weiterzuverwenden."
+        }
+      },
+      "native_external": {
+        "title": "Battery SmartFlow AI einrichten",
+        "description": "Wähle externe Messwerte und Preisquellen. Hardware-Daten und Pack-Kapazitäten werden automatisch ermittelt.",
+        "data": {
+          "additional_battery_charge_entity": "Zusatzakku Ladeleistung (optional)",
+          "additional_battery_discharge_entity": "Zusatzakku Entladeleistung (optional)",
+          "installed_pv_wp": "Installierte PV-Leistung (Wp)",
+          "pv_entity": "PV-Leistung Sensor",
+          "feed_in_tariff": "Einspeisevergütung",
+          "dynamic_feed_in_price_entity": "Aktueller dynamischer Einspeisepreis (optional)",
+          "pv_forecast_today_entity": "PV-Prognose heute (optional)",
+          "pv_forecast_tomorrow_entity": "PV-Prognose morgen (optional)",
+          "price_now_entity": "Aktueller Strompreis",
+          "price_export_entity": "Preisverlauf (z. B. Tibber / EPEX)",
+          "grid_mode": "Netzmessung",
+          "grid_power_entity": "Netzleistung (Single)",
+          "grid_import_entity": "Netzbezug (Split)",
+          "grid_export_entity": "Netzeinspeisung (Split)"
+        },
+        "data_description": {
+          "additional_battery_charge_entity": "Optionaler Sensor eines zweiten Akkusystems. Wenn dieser Sensor eine positive Ladeleistung meldet, wird die Entladung von Battery SmartFlow AI blockiert.",
+          "additional_battery_discharge_entity": "Optionaler Sensor eines zweiten Akkusystems. Wenn dieser Sensor eine positive Entladeleistung meldet, wird das Laden von Battery SmartFlow AI blockiert, damit kein Akku-zu-Akku-Laden entsteht.",
+          "installed_pv_wp": "Installierte theoretische PV-Modulleistung der Anlage in Wp. Dieser Wert wird für relative PV-Kontextschwellen und weitere PV-bezogene Logik verwendet.",
+          "pv_entity": "Sensor mit der aktuellen PV-Leistung in Watt.",
+          "feed_in_tariff": "Vergütung pro eingespeister kWh in ganzer Währung. Sie dient als Rückfallwert, wenn kein gültiger dynamischer Einspeisepreis verfügbar ist.",
+          "dynamic_feed_in_price_entity": "Optionaler numerischer Home-Assistant-Sensor für den aktuellen dynamischen Einspeisepreis. Ein gültiger Sensorwert einschließlich null oder eines negativen Preises hat Vorrang vor der festen Einspeisevergütung.",
+          "pv_forecast_today_entity": "Optionaler Sensor mit der PV-Tagesprognose für heute, z. B. aus Solcast PV Forecast. Die Prognose ist nur ein zusätzlicher Planungs-Input und keine Voraussetzung für die Integration.",
+          "pv_forecast_tomorrow_entity": "Optionaler Sensor mit der PV-Tagesprognose für morgen, z. B. aus Solcast PV Forecast. Die Prognose ist nur ein zusätzlicher Planungs-Input und keine Voraussetzung für die Integration.",
+          "price_now_entity": "Aktueller Strompreis. Ermöglicht preisabhängige Entladung.",
+          "price_export_entity": "Preisprognosedaten für die nächsten Stunden. Ermöglicht intelligente Ladeplanung.",
+          "grid_mode": "Bestimmt, wie Netzbezug und Einspeisung erfasst werden.",
+          "grid_power_entity": "Ein kombinierter Netzsensor (positiv = Bezug, negativ = Einspeisung).",
+          "grid_import_entity": "Sensor für Netzbezug (Split-Modus).",
+          "grid_export_entity": "Sensor für Netzeinspeisung (Split-Modus)."
+        }
+      },
+      "legacy": {
         "title": "Battery SmartFlow AI einrichten",
         "description": "Wähle die benötigten Sensoren aus",
         "data": {
@@ -214,13 +285,15 @@
           "expert_mode_enabled": "Expertenmodus aktivieren",
           "full_charge_maintenance_enabled": "Volladungswartung verwenden",
           "full_charge_maintenance_interval_days": "Empfohlenes Volladeintervall",
-          "learned_planning_enabled": "Lernbasierte Ladefenster-Planung verwenden"
+          "learned_planning_enabled": "Lernbasierte Ladefenster-Planung verwenden",
+          "native_capacity_override_kwh": "Gesamtkapazität bei unbekanntem Pack-Profil (kWh)"
         },
         "data_description": {
           "expert_mode_enabled": "Aktiviert den erweiterten Expertenbereich für zusätzliche Schutz- und Diagnosefunktionen.",
           "full_charge_maintenance_enabled": "Erlaubt BSFAI, zu günstigen Zeitpunkten eine schonende Volladung zu planen. Dies ist kein BMS-Kalibrierungsbefehl.",
           "full_charge_maintenance_interval_days": "Tage zwischen empfohlenen bestätigten Volladungen (7–90).",
-          "learned_planning_enabled": "Wenn aktiviert, nutzt Battery SmartFlow AI die lernbasierte Ladefenster-Planung automatisch, sobald genügend Lerndaten vorhanden sind. Bis dahin bleibt die klassische Planung aktiv. Wenn deaktiviert, wird dauerhaft die klassische Planung verwendet."
+          "learned_planning_enabled": "Wenn aktiviert, nutzt Battery SmartFlow AI die lernbasierte Ladefenster-Planung automatisch, sobald genügend Lerndaten vorhanden sind. Bis dahin bleibt die klassische Planung aktiv. Wenn deaktiviert, wird dauerhaft die klassische Planung verwendet.",
+          "native_capacity_override_kwh": "Nur bei unbekannten Packs: geprüfte Gesamtkapazität aller Packs dieses Systems. 0 deaktiviert die Ausnahme. Fehlende Messdaten werden damit nicht übergangen."
         }
       },
       "expert_cell_voltage": {
@@ -353,6 +426,15 @@
     },
     "sensor": {
       "native_zendure_status": {"name": "Status nativer Zendure-Test", "state": {"disabled": "Nicht eingerichtet", "discovering": "Geräte werden gesucht", "connecting": "Verbindung wird hergestellt", "capturing": "Erstdaten werden erfasst", "observing": "Beobachtung aktiv", "error": "Fehler"}}, "native_zendure_control": {"name": "Native Zendure-Steuerung", "state": {"disabled_zha_active": "Deaktiviert – Z-HA bleibt aktiv", "native_zensdk_active": "Aktiviert – lokales ZenSDK aktiv", "native_local_mqtt_active": "Aktiviert – Local MQTT aktiv", "native_local_unsupported": "Blockiert – kein verifizierter lokaler Transport"}}, "native_zendure_device_count": {"name": "Gefundene native Zendure-Geräte"}, "native_zendure_message_count": {"name": "Empfangene native Zendure-Nachrichten"}, "native_zendure_last_message": {"name": "Letzte native Zendure-Nachricht"}, "native_zendure_last_capture": {"name": "Paket des nativen Zendure-Erstabgleichs"}, "native_zendure_error": {"name": "Fehler nativer Zendure-Test"},
+      "native_hardware_pack_count": {"name":"Batterieanzahl"},
+      "native_hardware_capacity_kwh": {"name":"Nennkapazität"},
+      "native_hardware_power_w": {"name":"Batterieleistung"},
+      "native_hardware_offgrid_power_w": {"name":"Off-Grid-Leistung"},
+      "native_hardware_cell_delta_v": {"name":"Zellspannungsdifferenz"},
+      "native_hardware_pack_status": {"name":"Status","state":{"idle":"Ruhezustand","charge":"Laden","discharge":"Entladen"}},
+      "native_hardware_soc_min": {"name":"Hardware-SoC-Minimum"},
+      "native_hardware_soc_max": {"name":"Hardware-SoC-Maximum"},
+      "native_hardware_heating": {"name":"Batterieheizung","state":{"on":"Ein","off":"Aus"}},
       "native_hardware_online": {"name": "Online-Status", "state": {"online": "Online", "offline": "Offline"}}, "native_hardware_soc_pct": {"name": "Ladezustand"}, "native_hardware_charge_power_w": {"name": "Ladeleistung"}, "native_hardware_discharge_power_w": {"name": "Entladeleistung"}, "native_hardware_ac_input_power_w": {"name": "AC-Eingangsleistung"}, "native_hardware_ac_output_power_w": {"name": "AC-Ausgangsleistung"}, "native_hardware_pv_power_w": {"name": "PV-Leistung"}, "native_hardware_mode": {"name": "Betriebsmodus", "state": {"idle": "Bereitschaft", "charge": "Laden", "discharge": "Entladen", "unknown": "Unbekannt"}}, "native_hardware_temperature_c": {"name": "Temperatur"}, "native_hardware_battery_voltage_v": {"name": "Batteriespannung"}, "native_hardware_voltage_v": {"name": "Spannung"}, "native_hardware_current_a": {"name": "Strom"}, "native_hardware_cell_min_v": {"name": "Niedrigste Zellspannung"}, "native_hardware_cell_max_v": {"name": "Höchste Zellspannung"}, "native_hardware_state_code": {"name": "Statuscode"}, "native_hardware_pack_type": {"name": "Pack-Typ"}, "native_hardware_fault_code": {"name": "Fehlercode"}, "native_hardware_protection_active": {"name": "Schutz aktiv"}, "native_hardware_firmware": {"name": "Firmware"}, "native_hardware_product_id": {"name": "Produkt-ID"}, "native_hardware_profile": {"name": "Geräteprofil"}, "native_hardware_transport": {"name": "Kommunikationsweg", "state": {"home_assistant": "Home Assistant / Z-HA", "cloud_mqtt": "Cloud", "local_mqtt": "Lokal", "zensdk": "ZenSDK"}}, "native_hardware_control_state": {"name": "Steuerungsstatus", "state": {"observation": "Beobachtung", "eligible": "Steuerbar", "enabled": "Freigegeben", "active": "Aktiv gesteuert", "hems_blocked": "Durch HEMS blockiert", "unsupported": "Nicht unterstützt", "offline": "Offline"}}, "native_hardware_hems": {"name": "Zendure HEMS", "state": {"active": "Aktiv", "inactive": "Inaktiv", "unknown": "Unbekannt", "stale": "Veraltet", "invalid": "Ungültig", "unsupported": "Nicht unterstützt"}}, "native_hardware_last_message": {"name": "Letzter Datenempfang"},
       "device_profile": {
         "name": "Aktives Geräteprofil"

--- a/custom_components/battery_smartflow_ai/translations/en.json
+++ b/custom_components/battery_smartflow_ai/translations/en.json
@@ -12,6 +12,7 @@
     },
     "error": {
       "grid_split_missing": "When using two sensors, both grid import and grid export must be selected.",
+      "unsupported_device": "Unsupported device model.",
       "invalid_token": "The App Token format is invalid.", "invalid_or_expired_token": "The App Token is invalid or expired.", "cannot_connect": "Could not connect to Zendure Cloud.", "timeout": "Zendure Cloud did not respond in time.", "invalid_response": "Zendure Cloud returned an unexpected response.", "no_devices": "No Zendure devices were found for this account.", "no_mqtt_credentials": "Zendure did not return Cloud MQTT access data.", "duplicate_device_id": "Zendure returned duplicate device identities.", "incomplete_device": "Zendure returned an incomplete device record.", "device_not_found": "The selected device is no longer available.", "local_mqtt_required": "This legacy device requires the Local MQTT broker settings."
     },
     "step": {
@@ -104,6 +105,76 @@
         }
       },
       "user": {
+        "title": "Set up Battery SmartFlow AI",
+        "menu_options": {
+          "native_login": "Connect Zendure directly",
+          "legacy": "Use existing HA entities"
+        }
+      },
+      "native_login": {
+        "title": "Sign in to Zendure",
+        "description": "The App Token is stored privately. The local transport is selected automatically for the device model.",
+        "data": {
+          "native_zendure_app_token": "App Token"
+        }
+      },
+      "native_device": {
+        "title": "Select the Zendure system",
+        "description": "Zendure reported these devices:\n\n{device_summary}\n\nSelect exactly one system. Battery SmartFlow AI automatically uses the supported local transport for its model. Native control is activated only by the separate switch below. When enabled, BSFAI stops writing through the configured Z-HA entities.",
+        "data": {
+          "native_zendure_selected_device": "Zendure system",
+          "native_zendure_control_enabled": "Enable native Zendure control",
+          "native_zendure_local_mqtt_server": "Local MQTT server",
+          "native_zendure_local_mqtt_port": "Local MQTT port",
+          "native_zendure_local_mqtt_username": "Local MQTT username",
+          "native_zendure_local_mqtt_password": "Local MQTT password"
+        },
+        "data_description": {
+          "native_zendure_selected_device": "Exactly one main system is selected; packs cannot be controlled independently. BSFAI selects ZenSDK or Local MQTT from the verified model family.",
+          "native_zendure_control_enabled": "Explicitly transfers BSFAI command output from the Z-HA entities to the model's local transport. Disable this switch to retain the established Z-HA control path.",
+          "native_zendure_local_mqtt_server": "Shown only when the account contains a verified legacy family. The device must already be provisioned to publish to this broker.",
+          "native_zendure_local_mqtt_port": "Usually 1883 for a local unencrypted broker.",
+          "native_zendure_local_mqtt_username": "Broker account used by BSFAI; it is kept private.",
+          "native_zendure_local_mqtt_password": "Keep the dot mask unchanged to reuse the stored password. It is never exposed by sensors or diagnostics."
+        }
+      },
+      "native_external": {
+        "title": "Set up Battery SmartFlow AI",
+        "description": "Select external measurements and price sources. Hardware data and pack capacities are detected automatically.",
+        "data": {
+          "additional_battery_charge_entity": "Additional battery charge power (optional)",
+          "additional_battery_discharge_entity": "Additional battery discharge power (optional)",
+          "installed_pv_wp": "Installed PV power (Wp)",
+          "pv_entity": "PV power sensor",
+          "pv_forecast_today_entity": "PV forecast today (optional)",
+          "pv_forecast_tomorrow_entity": "PV forecast tomorrow (optional)",
+          "price_now_entity": "Current electricity price",
+          "price_export_entity": "Price forecast (e.g. Tibber / EPEX)",
+          "grid_mode": "Grid metering",
+          "grid_power_entity": "Grid power (single)",
+          "grid_import_entity": "Grid import (split)",
+          "grid_export_entity": "Grid export (split)",
+          "feed_in_tariff": "Feed-in tariff",
+          "dynamic_feed_in_price_entity": "Current dynamic feed-in price (optional)"
+        },
+        "data_description": {
+          "additional_battery_charge_entity": "Optional sensor of a second battery system. If this sensor reports positive charge power, Battery SmartFlow AI blocks discharging.",
+          "additional_battery_discharge_entity": "Optional sensor of a second battery system. If this sensor reports positive discharge power, Battery SmartFlow AI blocks charging to avoid battery-to-battery charging.",
+          "installed_pv_wp": "Installed theoretical PV module power of the system in Wp. This value is used for relative PV-context thresholds and other PV-related logic.",
+          "pv_entity": "Sensor with the current PV power in watts.",
+          "pv_forecast_today_entity": "Optional sensor with today's PV daily forecast, for example from Solcast PV Forecast. The forecast is only an additional planning input and is not required for the integration.",
+          "pv_forecast_tomorrow_entity": "Optional sensor with tomorrow's PV daily forecast, for example from Solcast PV Forecast. The forecast is only an additional planning input and is not required for the integration.",
+          "price_now_entity": "Current electricity price. Enables price-dependent discharging.",
+          "price_export_entity": "Price forecast data for the next hours. Enables intelligent charge planning.",
+          "grid_mode": "Defines how grid import and export are recorded.",
+          "grid_power_entity": "A single sensor with positive power for import and negative power for export.",
+          "grid_import_entity": "Sensor with current grid import power in watts.",
+          "grid_export_entity": "Sensor with current grid export power in watts.",
+          "feed_in_tariff": "Compensation per exported kWh in the same currency unit as the electricity prices. Used as a fallback when no valid dynamic feed-in price is available.",
+          "dynamic_feed_in_price_entity": "Optional numeric Home Assistant sensor for the current dynamic feed-in price. A valid sensor value, including zero or a negative price, takes priority over the fixed feed-in tariff."
+        }
+      },
+      "legacy": {
         "title": "Set up Battery SmartFlow AI",
         "description": "Select the required sensors",
         "data": {
@@ -214,13 +285,15 @@
           "expert_mode_enabled": "Enable expert mode",
           "full_charge_maintenance_enabled": "Use full-charge maintenance",
           "full_charge_maintenance_interval_days": "Recommended full-charge interval",
-          "learned_planning_enabled": "Use learned charge-window planning"
+          "learned_planning_enabled": "Use learned charge-window planning",
+          "native_capacity_override_kwh": "Total capacity for an unknown pack profile (kWh)"
         },
         "data_description": {
           "expert_mode_enabled": "Enables the advanced expert area for additional protection and diagnostic functions.",
           "full_charge_maintenance_enabled": "Allows BSFAI to plan a protective full charge at favorable times. This is not a BMS calibration command.",
           "full_charge_maintenance_interval_days": "Days between recommended confirmed full charges (7–90).",
-          "learned_planning_enabled": "When enabled, Battery SmartFlow AI automatically uses learned charge-window planning once enough learning data is available. Until then, classic planning remains active. When disabled, classic planning is always used."
+          "learned_planning_enabled": "When enabled, Battery SmartFlow AI automatically uses learned charge-window planning once enough learning data is available. Until then, classic planning remains active. When disabled, classic planning is always used.",
+          "native_capacity_override_kwh": "Unknown packs only: verified total capacity of all packs in this system. 0 disables the override. Missing measurements still block control."
         }
       },
       "expert_cell_voltage": {
@@ -353,6 +426,15 @@
     },
     "sensor": {
       "native_zendure_status": {"name": "Native Zendure test status", "state": {"disabled": "Not configured", "discovering": "Discovering devices", "connecting": "Connecting", "capturing": "Capturing initial data", "observing": "Observation active", "error": "Error"}}, "native_zendure_control": {"name": "Native Zendure control", "state": {"disabled_zha_active": "Disabled – Z-HA remains active", "native_zensdk_active": "Enabled – local ZenSDK active", "native_local_mqtt_active": "Enabled – Local MQTT active", "native_local_unsupported": "Blocked – no verified local transport"}}, "native_zendure_device_count": {"name": "Native Zendure devices found"}, "native_zendure_message_count": {"name": "Native Zendure messages received"}, "native_zendure_last_message": {"name": "Last native Zendure message"}, "native_zendure_last_capture": {"name": "Native Zendure initial-sync package"}, "native_zendure_error": {"name": "Native Zendure error"},
+      "native_hardware_pack_count": {"name":"Battery count"},
+      "native_hardware_capacity_kwh": {"name":"Nominal capacity"},
+      "native_hardware_power_w": {"name":"Battery power"},
+      "native_hardware_offgrid_power_w": {"name":"Off-grid power"},
+      "native_hardware_cell_delta_v": {"name":"Cell voltage difference"},
+      "native_hardware_pack_status": {"name":"Status","state":{"idle":"Idle","charge":"Charging","discharge":"Discharging"}},
+      "native_hardware_soc_min": {"name":"Hardware minimum SoC"},
+      "native_hardware_soc_max": {"name":"Hardware maximum SoC"},
+      "native_hardware_heating": {"name":"Battery heating","state":{"on":"On","off":"Off"}},
       "native_hardware_online": {"name": "Online status", "state": {"online": "Online", "offline": "Offline"}}, "native_hardware_soc_pct": {"name": "State of charge"}, "native_hardware_charge_power_w": {"name": "Charge power"}, "native_hardware_discharge_power_w": {"name": "Discharge power"}, "native_hardware_ac_input_power_w": {"name": "AC input power"}, "native_hardware_ac_output_power_w": {"name": "AC output power"}, "native_hardware_pv_power_w": {"name": "PV power"}, "native_hardware_mode": {"name": "Operating mode", "state": {"idle": "Idle", "charge": "Charging", "discharge": "Discharging", "unknown": "Unknown"}}, "native_hardware_temperature_c": {"name": "Temperature"}, "native_hardware_battery_voltage_v": {"name": "Battery voltage"}, "native_hardware_voltage_v": {"name": "Voltage"}, "native_hardware_current_a": {"name": "Current"}, "native_hardware_cell_min_v": {"name": "Lowest cell voltage"}, "native_hardware_cell_max_v": {"name": "Highest cell voltage"}, "native_hardware_state_code": {"name": "State code"}, "native_hardware_pack_type": {"name": "Pack type"}, "native_hardware_fault_code": {"name": "Fault code"}, "native_hardware_protection_active": {"name": "Protection active"}, "native_hardware_firmware": {"name": "Firmware"}, "native_hardware_product_id": {"name": "Product ID"}, "native_hardware_profile": {"name": "Device profile"}, "native_hardware_transport": {"name": "Communication path", "state": {"home_assistant": "Home Assistant / Z-HA", "cloud_mqtt": "Cloud", "local_mqtt": "Local", "zensdk": "ZenSDK"}}, "native_hardware_control_state": {"name": "Control status", "state": {"observation": "Observation", "eligible": "Eligible", "enabled": "Enabled", "active": "Active", "hems_blocked": "Blocked by HEMS", "unsupported": "Unsupported", "offline": "Offline"}}, "native_hardware_hems": {"name": "Zendure HEMS", "state": {"active": "Active", "inactive": "Inactive", "unknown": "Unknown", "stale": "Outdated", "invalid": "Invalid", "unsupported": "Unsupported"}}, "native_hardware_last_message": {"name": "Last data received"},
       "device_profile": {
         "name": "Active device profile"

--- a/custom_components/battery_smartflow_ai/translations/fr.json
+++ b/custom_components/battery_smartflow_ai/translations/fr.json
@@ -12,6 +12,7 @@
     },
     "error": {
       "grid_split_missing": "Avec deux capteurs, l’importation et l’exportation réseau doivent être sélectionnées.",
+      "unsupported_device": "Unsupported device model.",
       "invalid_token": "Le format du jeton d’application est invalide.", "invalid_or_expired_token": "Le jeton d’application est invalide ou expiré.", "cannot_connect": "Impossible de se connecter à Zendure Cloud.", "timeout": "Zendure Cloud n’a pas répondu à temps.", "invalid_response": "Zendure Cloud a renvoyé une réponse inattendue.", "no_devices": "Aucun appareil Zendure n’a été trouvé.", "no_mqtt_credentials": "Zendure n’a fourni aucun accès Cloud MQTT.", "duplicate_device_id": "Zendure a renvoyé des identités en double.", "incomplete_device": "Zendure a renvoyé un appareil incomplet.", "device_not_found": "L’appareil sélectionné n’est plus disponible.", "local_mqtt_required": "Cet appareil Legacy nécessite les paramètres du broker MQTT local."
     },
     "step": {
@@ -104,6 +105,76 @@
         }
       },
       "user": {
+        "title": "Configurer Battery SmartFlow AI",
+        "menu_options": {
+          "native_login": "Connect Zendure directly",
+          "legacy": "Use existing HA entities"
+        }
+      },
+      "native_login": {
+        "title": "Sign in to Zendure",
+        "description": "The App Token is stored privately. The local transport is selected automatically for the device model.",
+        "data": {
+          "native_zendure_app_token": "App Token"
+        }
+      },
+      "native_device": {
+        "title": "Sélectionner le système Zendure",
+        "description": "Zendure a signalé ces appareils :\n\n{device_summary}\n\nSélectionnez exactement un système. Battery SmartFlow AI utilise automatiquement le transport local pris en charge par son modèle. Le contrôle natif n’est activé que par l’interrupteur séparé ci-dessous.",
+        "data": {
+          "native_zendure_selected_device": "Système Zendure",
+          "native_zendure_control_enabled": "Activer le contrôle Zendure natif",
+          "native_zendure_local_mqtt_server": "Serveur MQTT local",
+          "native_zendure_local_mqtt_port": "Port MQTT local",
+          "native_zendure_local_mqtt_username": "Nom d’utilisateur MQTT local",
+          "native_zendure_local_mqtt_password": "Mot de passe MQTT local"
+        },
+        "data_description": {
+          "native_zendure_selected_device": "Un seul système principal est sélectionné ; les packs ne peuvent pas être contrôlés séparément. BSFAI détermine ZenSDK ou Local MQTT à partir de la famille de modèles vérifiée.",
+          "native_zendure_control_enabled": "Transfère explicitement les commandes BSFAI des entités Z-HA vers le transport local du modèle.",
+          "native_zendure_local_mqtt_server": "Affiché uniquement pour une famille Legacy vérifiée. L’appareil doit déjà publier vers ce broker.",
+          "native_zendure_local_mqtt_port": "Généralement 1883 pour un broker local non chiffré.",
+          "native_zendure_local_mqtt_username": "Compte privé du broker utilisé par BSFAI.",
+          "native_zendure_local_mqtt_password": "Conservez le masque à points pour réutiliser le mot de passe enregistré."
+        }
+      },
+      "native_external": {
+        "title": "Configurer Battery SmartFlow AI",
+        "description": "Select external measurements and price sources. Hardware data and pack capacities are detected automatically.",
+        "data": {
+          "additional_battery_charge_entity": "Puissance de charge batterie supplémentaire (optionnel)",
+          "additional_battery_discharge_entity": "Puissance de décharge batterie supplémentaire (optionnel)",
+          "installed_pv_wp": "Puissance PV installée (Wp)",
+          "pv_entity": "Capteur de puissance PV",
+          "pv_forecast_today_entity": "Prévision PV aujourd’hui (optionnel)",
+          "pv_forecast_tomorrow_entity": "Prévision PV demain (optionnel)",
+          "price_now_entity": "Prix actuel de l’électricité",
+          "price_export_entity": "Prévision de prix (p. ex. Tibber / EPEX)",
+          "grid_mode": "Mesure réseau",
+          "grid_power_entity": "Puissance réseau (simple)",
+          "grid_import_entity": "Import réseau (séparé)",
+          "grid_export_entity": "Export réseau (séparé)",
+          "feed_in_tariff": "Rémunération de l’injection",
+          "dynamic_feed_in_price_entity": "Prix d’injection dynamique actuel (facultatif)"
+        },
+        "data_description": {
+          "additional_battery_charge_entity": "Capteur optionnel d’un second système de batterie. Si ce capteur indique une puissance de charge positive, Battery SmartFlow AI bloque la décharge.",
+          "additional_battery_discharge_entity": "Capteur optionnel d’un second système de batterie. Si ce capteur indique une puissance de décharge positive, Battery SmartFlow AI bloque la charge afin d’éviter une charge batterie-à-batterie.",
+          "installed_pv_wp": "Puissance théorique des modules PV installés en Wp. Cette valeur est utilisée pour les seuils relatifs du contexte PV et d’autres logiques liées au PV.",
+          "pv_entity": "Capteur de puissance PV actuelle en watts.",
+          "pv_forecast_today_entity": "Capteur optionnel avec la prévision journalière PV pour aujourd’hui, par exemple Solcast PV Forecast. La prévision n’est qu’une entrée de planification supplémentaire et n’est pas obligatoire.",
+          "pv_forecast_tomorrow_entity": "Capteur optionnel avec la prévision journalière PV pour demain, par exemple Solcast PV Forecast. La prévision n’est qu’une entrée de planification supplémentaire et n’est pas obligatoire.",
+          "price_now_entity": "Prix actuel de l’électricité. Permet la décharge dépendante du prix.",
+          "price_export_entity": "Données de prévision de prix pour les prochaines heures. Permet une planification de charge intelligente.",
+          "grid_mode": "Détermine comment l’import et l’export réseau sont enregistrés.",
+          "grid_power_entity": "Un capteur unique avec puissance positive en import et négative en export.",
+          "grid_import_entity": "Capteur de puissance d’import réseau actuelle en watts.",
+          "grid_export_entity": "Capteur de puissance d’export réseau actuelle en watts.",
+          "feed_in_tariff": "Rémunération par kWh injecté dans la même unité monétaire que les prix de l’électricité. Elle sert de valeur de repli lorsqu’aucun prix d’injection dynamique valide n’est disponible.",
+          "dynamic_feed_in_price_entity": "Capteur numérique Home Assistant facultatif pour le prix d’injection dynamique actuel. Une valeur valide, y compris zéro ou un prix négatif, est prioritaire sur la rémunération fixe."
+        }
+      },
+      "legacy": {
         "title": "Configurer Battery SmartFlow AI",
         "description": "Sélectionnez les capteurs nécessaires",
         "data": {
@@ -214,13 +285,15 @@
           "expert_mode_enabled": "Activer le mode expert",
           "full_charge_maintenance_enabled": "Utiliser l’entretien par charge complète",
           "full_charge_maintenance_interval_days": "Intervalle recommandé de charge complète",
-          "learned_planning_enabled": "Utiliser la planification apprise des fenêtres de charge"
+          "learned_planning_enabled": "Utiliser la planification apprise des fenêtres de charge",
+          "native_capacity_override_kwh": "Total capacity for an unknown pack profile (kWh)"
         },
         "data_description": {
           "expert_mode_enabled": "Active la zone expert avancée pour des fonctions supplémentaires de protection et de diagnostic.",
           "full_charge_maintenance_enabled": "Autorise BSFAI à planifier une charge complète protectrice à un moment favorable. Il ne s’agit pas d’une commande d’étalonnage du BMS.",
           "full_charge_maintenance_interval_days": "Jours entre les charges complètes confirmées recommandées (7–90).",
-          "learned_planning_enabled": "Si activé, Battery SmartFlow AI utilise automatiquement la planification apprise des fenêtres de charge dès que suffisamment de données sont disponibles. Jusque-là, la planification classique reste active. Si désactivé, la planification classique est toujours utilisée."
+          "learned_planning_enabled": "Si activé, Battery SmartFlow AI utilise automatiquement la planification apprise des fenêtres de charge dès que suffisamment de données sont disponibles. Jusque-là, la planification classique reste active. Si désactivé, la planification classique est toujours utilisée.",
+          "native_capacity_override_kwh": "Unknown packs only: verified total capacity of all packs in this system. 0 disables the override. Missing measurements still block control."
         }
       },
       "expert_cell_voltage": {
@@ -353,6 +426,15 @@
     },
     "sensor": {
       "native_zendure_status": {"name": "État du test Zendure natif", "state": {"disabled": "Non configuré", "discovering": "Recherche des appareils", "connecting": "Connexion", "capturing": "Collecte initiale", "observing": "Observation active", "error": "Erreur"}}, "native_zendure_control": {"name": "Contrôle Zendure natif", "state": {"disabled_zha_active": "Désactivé – Z-HA reste actif", "native_zensdk_active": "Activé – ZenSDK local actif", "native_local_mqtt_active": "Activé – MQTT local actif", "native_local_unsupported": "Bloqué – aucun transport local vérifié"}}, "native_zendure_device_count": {"name": "Appareils Zendure natifs trouvés"}, "native_zendure_message_count": {"name": "Messages Zendure natifs reçus"}, "native_zendure_last_message": {"name": "Dernier message Zendure natif"}, "native_zendure_last_capture": {"name": "Paquet de synchronisation Zendure"}, "native_zendure_error": {"name": "Erreur Zendure native"},
+      "native_hardware_pack_count": {"name":"Battery count"},
+      "native_hardware_capacity_kwh": {"name":"Nominal capacity"},
+      "native_hardware_power_w": {"name":"Battery power"},
+      "native_hardware_offgrid_power_w": {"name":"Off-grid power"},
+      "native_hardware_cell_delta_v": {"name":"Cell voltage difference"},
+      "native_hardware_pack_status": {"name":"Status","state":{"idle":"Idle","charge":"Charging","discharge":"Discharging"}},
+      "native_hardware_soc_min": {"name":"Hardware minimum SoC"},
+      "native_hardware_soc_max": {"name":"Hardware maximum SoC"},
+      "native_hardware_heating": {"name":"Battery heating","state":{"on":"On","off":"Off"}},
       "native_hardware_online": {"name": "État en ligne", "state": {"online": "En ligne", "offline": "Hors ligne"}}, "native_hardware_soc_pct": {"name": "État de charge"}, "native_hardware_charge_power_w": {"name": "Puissance de charge"}, "native_hardware_discharge_power_w": {"name": "Puissance de décharge"}, "native_hardware_ac_input_power_w": {"name": "Puissance d’entrée CA"}, "native_hardware_ac_output_power_w": {"name": "Puissance de sortie CA"}, "native_hardware_pv_power_w": {"name": "Puissance PV"}, "native_hardware_mode": {"name": "Mode de fonctionnement", "state": {"idle": "Veille", "charge": "Charge", "discharge": "Décharge", "unknown": "Inconnu"}}, "native_hardware_temperature_c": {"name": "Température"}, "native_hardware_battery_voltage_v": {"name": "Tension de la batterie"}, "native_hardware_voltage_v": {"name": "Tension"}, "native_hardware_current_a": {"name": "Courant"}, "native_hardware_cell_min_v": {"name": "Tension de cellule minimale"}, "native_hardware_cell_max_v": {"name": "Tension de cellule maximale"}, "native_hardware_state_code": {"name": "Code d’état"}, "native_hardware_pack_type": {"name": "Type de batterie"}, "native_hardware_fault_code": {"name": "Code d’erreur"}, "native_hardware_protection_active": {"name": "Protection active"}, "native_hardware_firmware": {"name": "Micrologiciel"}, "native_hardware_product_id": {"name": "ID du produit"}, "native_hardware_profile": {"name": "Profil de l’appareil"}, "native_hardware_transport": {"name": "Voie de communication", "state": {"home_assistant": "Home Assistant / Z-HA", "cloud_mqtt": "Cloud", "local_mqtt": "Local", "zensdk": "ZenSDK"}}, "native_hardware_control_state": {"name": "État du contrôle", "state": {"observation": "Observation", "eligible": "Éligible", "enabled": "Activé", "active": "Contrôle actif", "hems_blocked": "Bloqué par HEMS", "unsupported": "Non pris en charge", "offline": "Hors ligne"}}, "native_hardware_hems": {"name": "Zendure HEMS", "state": {"active": "Actif", "inactive": "Inactif", "unknown": "Inconnu", "stale": "Obsolète", "invalid": "Invalide", "unsupported": "Non pris en charge"}}, "native_hardware_last_message": {"name": "Dernières données reçues"},
       "device_profile": {
         "name": "Profil d’appareil actif"

--- a/custom_components/battery_smartflow_ai/translations/nl.json
+++ b/custom_components/battery_smartflow_ai/translations/nl.json
@@ -12,6 +12,7 @@
     },
     "error": {
       "grid_split_missing": "Bij gebruik van twee sensoren moeten zowel netafname als netteruglevering zijn geselecteerd.",
+      "unsupported_device": "Unsupported device model.",
       "invalid_token": "De indeling van het app-token is ongeldig.", "invalid_or_expired_token": "Het app-token is ongeldig of verlopen.", "cannot_connect": "Kan geen verbinding maken met Zendure Cloud.", "timeout": "Zendure Cloud antwoordde niet op tijd.", "invalid_response": "Zendure Cloud gaf een onverwacht antwoord.", "no_devices": "Er zijn geen Zendure-apparaten gevonden.", "no_mqtt_credentials": "Zendure gaf geen Cloud MQTT-toegang.", "duplicate_device_id": "Zendure gaf dubbele apparaatidentiteiten.", "incomplete_device": "Zendure gaf een onvolledig apparaat terug.", "device_not_found": "Het geselecteerde apparaat is niet meer beschikbaar.", "local_mqtt_required": "Voor dit Legacy-apparaat zijn de lokale MQTT-brokerinstellingen vereist."
     },
     "step": {
@@ -104,6 +105,76 @@
         }
       },
       "user": {
+        "title": "Battery SmartFlow AI instellen",
+        "menu_options": {
+          "native_login": "Connect Zendure directly",
+          "legacy": "Use existing HA entities"
+        }
+      },
+      "native_login": {
+        "title": "Sign in to Zendure",
+        "description": "The App Token is stored privately. The local transport is selected automatically for the device model.",
+        "data": {
+          "native_zendure_app_token": "App Token"
+        }
+      },
+      "native_device": {
+        "title": "Zendure-systeem selecteren",
+        "description": "Zendure meldde deze apparaten:\n\n{device_summary}\n\nSelecteer precies één systeem. Battery SmartFlow AI gebruikt automatisch het lokale transport dat door het model wordt ondersteund. Native besturing wordt alleen met de aparte schakelaar hieronder geactiveerd.",
+        "data": {
+          "native_zendure_selected_device": "Zendure-systeem",
+          "native_zendure_control_enabled": "Native Zendure-besturing inschakelen",
+          "native_zendure_local_mqtt_server": "Lokale MQTT-server",
+          "native_zendure_local_mqtt_port": "Lokale MQTT-poort",
+          "native_zendure_local_mqtt_username": "Lokale MQTT-gebruikersnaam",
+          "native_zendure_local_mqtt_password": "Lokaal MQTT-wachtwoord"
+        },
+        "data_description": {
+          "native_zendure_selected_device": "Er wordt precies één hoofdsysteem geselecteerd; packs kunnen niet afzonderlijk worden bestuurd. BSFAI bepaalt ZenSDK of Local MQTT aan de hand van de geverifieerde modelfamilie.",
+          "native_zendure_control_enabled": "Zet BSFAI-opdrachten expliciet over van Z-HA-entiteiten naar het lokale transport van het model.",
+          "native_zendure_local_mqtt_server": "Alleen getoond voor een geverifieerde Legacy-familie. Het apparaat moet al naar deze broker publiceren.",
+          "native_zendure_local_mqtt_port": "Meestal 1883 voor een lokale onversleutelde broker.",
+          "native_zendure_local_mqtt_username": "Privébrokeraccount voor BSFAI.",
+          "native_zendure_local_mqtt_password": "Laat het puntenmasker staan om het opgeslagen wachtwoord opnieuw te gebruiken."
+        }
+      },
+      "native_external": {
+        "title": "Battery SmartFlow AI instellen",
+        "description": "Select external measurements and price sources. Hardware data and pack capacities are detected automatically.",
+        "data": {
+          "additional_battery_charge_entity": "Extra batterij laadvermogen (optioneel)",
+          "additional_battery_discharge_entity": "Extra batterij ontlaadvermogen (optioneel)",
+          "installed_pv_wp": "Geïnstalleerd PV-vermogen (Wp)",
+          "pv_entity": "PV-vermogenssensor",
+          "pv_forecast_today_entity": "PV-voorspelling vandaag (optioneel)",
+          "pv_forecast_tomorrow_entity": "PV-voorspelling morgen (optioneel)",
+          "price_now_entity": "Actuele stroomprijs",
+          "price_export_entity": "Prijsprognose (bijv. Tibber / EPEX)",
+          "grid_mode": "Netmeting",
+          "grid_power_entity": "Netvermogen (single)",
+          "grid_import_entity": "Netafname (split)",
+          "grid_export_entity": "Netteruglevering (split)",
+          "feed_in_tariff": "Terugleververgoeding",
+          "dynamic_feed_in_price_entity": "Actuele dynamische terugleverprijs (optioneel)"
+        },
+        "data_description": {
+          "additional_battery_charge_entity": "Optionele sensor van een tweede batterijsysteem. Als deze sensor positief laadvermogen meldt, blokkeert Battery SmartFlow AI het ontladen.",
+          "additional_battery_discharge_entity": "Optionele sensor van een tweede batterijsysteem. Als deze sensor positief ontlaadvermogen meldt, blokkeert Battery SmartFlow AI het laden, zodat er geen batterij-naar-batterij-laden ontstaat.",
+          "installed_pv_wp": "Theoretisch geïnstalleerd PV-modulevermogen van de installatie in Wp. Deze waarde wordt gebruikt voor relatieve PV-contextdrempels en andere PV-logica.",
+          "pv_entity": "Sensor met het actuele PV-vermogen in watt.",
+          "pv_forecast_today_entity": "Optionele sensor met de PV-dagvoorspelling voor vandaag, bijvoorbeeld uit Solcast PV Forecast. De voorspelling is alleen een extra planningsinput en geen vereiste.",
+          "pv_forecast_tomorrow_entity": "Optionele sensor met de PV-dagvoorspelling voor morgen, bijvoorbeeld uit Solcast PV Forecast. De voorspelling is alleen een extra planningsinput en geen vereiste.",
+          "price_now_entity": "Actuele stroomprijs. Maakt prijsafhankelijk ontladen mogelijk.",
+          "price_export_entity": "Prijsprognosegegevens voor de komende uren. Maakt intelligente laadplanning mogelijk.",
+          "grid_mode": "Bepaalt hoe netafname en teruglevering worden geregistreerd.",
+          "grid_power_entity": "Eén sensor met positief vermogen bij afname en negatief bij teruglevering.",
+          "grid_import_entity": "Sensor met actuele netafname in watt.",
+          "grid_export_entity": "Sensor met actuele netteruglevering in watt.",
+          "feed_in_tariff": "Vergoeding per teruggeleverde kWh in dezelfde valuta-eenheid als de stroomprijzen. Deze dient als terugvalwaarde wanneer geen geldige dynamische terugleverprijs beschikbaar is.",
+          "dynamic_feed_in_price_entity": "Optionele numerieke Home Assistant-sensor voor de actuele dynamische terugleverprijs. Een geldige sensorwaarde, inclusief nul of een negatieve prijs, krijgt voorrang op de vaste vergoeding."
+        }
+      },
+      "legacy": {
         "title": "Battery SmartFlow AI instellen",
         "description": "Selecteer de benodigde sensoren",
         "data": {
@@ -214,13 +285,15 @@
           "expert_mode_enabled": "Expertmodus inschakelen",
           "full_charge_maintenance_enabled": "Onderhoud met volledige lading gebruiken",
           "full_charge_maintenance_interval_days": "Aanbevolen interval voor volledige lading",
-          "learned_planning_enabled": "Lerende laadvensterplanning gebruiken"
+          "learned_planning_enabled": "Lerende laadvensterplanning gebruiken",
+          "native_capacity_override_kwh": "Total capacity for an unknown pack profile (kWh)"
         },
         "data_description": {
           "expert_mode_enabled": "Activeert het uitgebreide expertgedeelte voor aanvullende beschermings- en diagnosefuncties.",
           "full_charge_maintenance_enabled": "Laat BSFAI op gunstige momenten een beschermende volledige lading plannen. Dit is geen BMS-kalibratieopdracht.",
           "full_charge_maintenance_interval_days": "Dagen tussen aanbevolen bevestigde volledige ladingen (7–90).",
-          "learned_planning_enabled": "Indien ingeschakeld gebruikt Battery SmartFlow AI automatisch de lerende laadvensterplanning zodra voldoende leerdata beschikbaar is. Tot die tijd blijft de klassieke planning actief. Indien uitgeschakeld wordt altijd de klassieke planning gebruikt."
+          "learned_planning_enabled": "Indien ingeschakeld gebruikt Battery SmartFlow AI automatisch de lerende laadvensterplanning zodra voldoende leerdata beschikbaar is. Tot die tijd blijft de klassieke planning actief. Indien uitgeschakeld wordt altijd de klassieke planning gebruikt.",
+          "native_capacity_override_kwh": "Unknown packs only: verified total capacity of all packs in this system. 0 disables the override. Missing measurements still block control."
         }
       },
       "expert_cell_voltage": {
@@ -353,6 +426,15 @@
     },
     "sensor": {
       "native_zendure_status": {"name": "Status native Zendure-test", "state": {"disabled": "Niet ingesteld", "discovering": "Apparaten zoeken", "connecting": "Verbinden", "capturing": "Eerste gegevens verzamelen", "observing": "Observatie actief", "error": "Fout"}}, "native_zendure_control": {"name": "Native Zendure-besturing", "state": {"disabled_zha_active": "Uitgeschakeld – Z-HA blijft actief", "native_zensdk_active": "Ingeschakeld – lokale ZenSDK actief", "native_local_mqtt_active": "Ingeschakeld – Local MQTT actief", "native_local_unsupported": "Geblokkeerd – geen geverifieerd lokaal transport"}}, "native_zendure_device_count": {"name": "Gevonden native Zendure-apparaten"}, "native_zendure_message_count": {"name": "Ontvangen native Zendure-berichten"}, "native_zendure_last_message": {"name": "Laatste native Zendure-bericht"}, "native_zendure_last_capture": {"name": "Native Zendure-synchronisatiepakket"}, "native_zendure_error": {"name": "Native Zendure-fout"},
+      "native_hardware_pack_count": {"name":"Battery count"},
+      "native_hardware_capacity_kwh": {"name":"Nominal capacity"},
+      "native_hardware_power_w": {"name":"Battery power"},
+      "native_hardware_offgrid_power_w": {"name":"Off-grid power"},
+      "native_hardware_cell_delta_v": {"name":"Cell voltage difference"},
+      "native_hardware_pack_status": {"name":"Status","state":{"idle":"Idle","charge":"Charging","discharge":"Discharging"}},
+      "native_hardware_soc_min": {"name":"Hardware minimum SoC"},
+      "native_hardware_soc_max": {"name":"Hardware maximum SoC"},
+      "native_hardware_heating": {"name":"Battery heating","state":{"on":"On","off":"Off"}},
       "native_hardware_online": {"name": "Onlinestatus", "state": {"online": "Online", "offline": "Offline"}}, "native_hardware_soc_pct": {"name": "Laadstatus"}, "native_hardware_charge_power_w": {"name": "Laadvermogen"}, "native_hardware_discharge_power_w": {"name": "Ontlaadvermogen"}, "native_hardware_ac_input_power_w": {"name": "AC-ingangsvermogen"}, "native_hardware_ac_output_power_w": {"name": "AC-uitgangsvermogen"}, "native_hardware_pv_power_w": {"name": "PV-vermogen"}, "native_hardware_mode": {"name": "Bedrijfsmodus", "state": {"idle": "Stand-by", "charge": "Laden", "discharge": "Ontladen", "unknown": "Onbekend"}}, "native_hardware_temperature_c": {"name": "Temperatuur"}, "native_hardware_battery_voltage_v": {"name": "Accuspanning"}, "native_hardware_voltage_v": {"name": "Spanning"}, "native_hardware_current_a": {"name": "Stroom"}, "native_hardware_cell_min_v": {"name": "Laagste celspanning"}, "native_hardware_cell_max_v": {"name": "Hoogste celspanning"}, "native_hardware_state_code": {"name": "Statuscode"}, "native_hardware_pack_type": {"name": "Accutype"}, "native_hardware_fault_code": {"name": "Foutcode"}, "native_hardware_protection_active": {"name": "Beveiliging actief"}, "native_hardware_firmware": {"name": "Firmware"}, "native_hardware_product_id": {"name": "Product-ID"}, "native_hardware_profile": {"name": "Apparaatprofiel"}, "native_hardware_transport": {"name": "Communicatieroute", "state": {"home_assistant": "Home Assistant / Z-HA", "cloud_mqtt": "Cloud", "local_mqtt": "Lokaal", "zensdk": "ZenSDK"}}, "native_hardware_control_state": {"name": "Besturingsstatus", "state": {"observation": "Observatie", "eligible": "Geschikt", "enabled": "Ingeschakeld", "active": "Actief bestuurd", "hems_blocked": "Geblokkeerd door HEMS", "unsupported": "Niet ondersteund", "offline": "Offline"}}, "native_hardware_hems": {"name": "Zendure HEMS", "state": {"active": "Actief", "inactive": "Inactief", "unknown": "Onbekend", "stale": "Verouderd", "invalid": "Ongeldig", "unsupported": "Niet ondersteund"}}, "native_hardware_last_message": {"name": "Laatste gegevens ontvangen"},
       "device_profile": {
         "name": "Actief apparaatprofiel"

--- a/custom_components/battery_smartflow_ai/zendure_device_matrix.py
+++ b/custom_components/battery_smartflow_ai/zendure_device_matrix.py
@@ -173,6 +173,7 @@ _COMMON_DEVICE_TARGETS = frozenset(
         "hems_active",
         "fault_code",
         "protection_active",
+        "heating_active",
         "temperature_c",
         "battery_voltage_v",
         "firmware",
@@ -193,6 +194,7 @@ _COMMON_PACK_TARGETS = frozenset(
         "state_code",
         "fault_code",
         "protection_active",
+        "heating_active",
     }
 )
 

--- a/custom_components/battery_smartflow_ai/zendure_normalizer.py
+++ b/custom_components/battery_smartflow_ai/zendure_normalizer.py
@@ -157,7 +157,7 @@ MAIN_PROPERTY_MAPPINGS = {
         ),
         _mapping("faultLevel", "fault_code", MappingScope.MAIN, (int,)),
         _mapping(
-            "heatState", "protection_active", MappingScope.MAIN,
+            "heatState", "heating_active", MappingScope.MAIN,
             (bool, int), converter=_binary,
         ),
         _mapping(
@@ -217,11 +217,25 @@ PACK_PROPERTY_MAPPINGS = {
         _mapping("state", "state_code", MappingScope.PACK, (int,)),
         _mapping("faultLevel", "fault_code", MappingScope.PACK, (int,)),
         _mapping(
-            "heatState", "protection_active", MappingScope.PACK,
+            "heatState", "heating_active", MappingScope.PACK,
             (bool, int), converter=_binary,
         ),
     )
 }
+
+# Keep unverified vendor status codes as raw diagnostics, not control decisions.
+RAW_MAIN_DIAGNOSTICS = (
+    "acStatus", "aiState", "batCalTime", "bindstate", "dataReady", "dcStatus",
+    "factoryModeState", "gridStandard", "gridState", "IOTState", "is_error",
+    "LCNState", "localAPIEnable", "net", "OldMode", "OTAState", "phaseSwitch",
+    "pvStatus", "rssi", "smartMode", "socStatus", "socCompSwitch", "writeRsp",
+    "packNum", "solarPower1", "solarPower2", "solarPower3", "solarPower4",
+    "solarPower5", "solarPower6",
+)
+for _raw in RAW_MAIN_DIAGNOSTICS:
+    MAIN_PROPERTY_MAPPINGS[_raw] = _mapping(
+        _raw, _raw, MappingScope.MAIN, (bool, int, float),
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -445,12 +459,18 @@ class ZendureCloudNormalizer:
             ),
             hems_active=hems_active,
             fault_code=device_value("fault_code"),
-            protection_active=device_value("protection_active"),
+            protection_active=_fault_block(
+                device_value("fault_code"),
+                self._value(values, "is_error", frozenset({"is_error"}), online, current),
+            ),
+            heating_active=device_value("heating_active"),
             temperature_c=device_value("temperature_c"),
             battery_voltage_v=device_value("battery_voltage_v"),
             last_message_at=self._last_message[system_id],
             packs=packs,
             offgrid_power_w=device_value("offgrid_power_w"),
+            diagnostics={key: self._value(values, key, frozenset(RAW_MAIN_DIAGNOSTICS), online, current)
+                         for key in RAW_MAIN_DIAGNOSTICS if key in values},
         )
         return NormalizationResult(
             state,
@@ -570,7 +590,8 @@ class ZendureCloudNormalizer:
             temperature_c=value("temperature_c"),
             state_code=value("state_code"),
             fault_code=value("fault_code"),
-            protection_active=value("protection_active"),
+            protection_active=_fault_block(value("fault_code")),
+            heating_active=value("heating_active"),
             last_message_at=accumulator.last_message_at,
         )
 
@@ -601,6 +622,17 @@ class ZendureCloudNormalizer:
         ):
             validity = ValueValidity.STALE
         return MeasuredValue(observed.value, validity, observed.observed_at)
+
+
+def _fault_block(*values):
+    """Fail closed on missing evidence; heating is not a fault indicator."""
+    available = [value for value in values if value.valid]
+    if not available:
+        return MeasuredValue.absent(ValueValidity.UNAVAILABLE)
+    return MeasuredValue.available(
+        any(float(value.value) != 0 for value in available),
+        observed_at=min((value.observed_at for value in available if value.observed_at), default=None),
+    )
 
 
 def _normalize(

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "5.0.0.beta1")
+        self.assertEqual(manifest_version, "5.0.0-beta2")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_full_charge_maintenance.py
+++ b/tests/test_full_charge_maintenance.py
@@ -180,8 +180,11 @@ class FullChargeMaintenanceTests(unittest.TestCase):
         resumed = self.planner.evaluate(
             restored, observation(now=NOW + timedelta(minutes=1))
         )
-        self.assertEqual(resumed.state, MaintenanceState.CHARGING_TO_FULL)
-        self.assertTrue(resumed.request_full_charge)
+        self.assertEqual(resumed.state, MaintenanceState.WAITING_FOR_FAVORABLE_WINDOW)
+        self.assertFalse(resumed.request_full_charge)
+        self.assertTrue(resumed.record.active)
+        favorable = self.planner.evaluate(resumed.record, observation(price_window_favorable=True))
+        self.assertTrue(favorable.request_full_charge)
 
     def test_multiple_devices_are_independent(self):
         first = self.planner.evaluate(

--- a/tests/test_full_charge_maintenance_runtime.py
+++ b/tests/test_full_charge_maintenance_runtime.py
@@ -50,7 +50,9 @@ class FullChargeMaintenanceRuntimeTests(unittest.TestCase):
                 price_window_favorable=False,
             ),
         )
-        self.assertEqual(resumed.state, MaintenanceState.CHARGING_TO_FULL)
+        self.assertEqual(resumed.state, MaintenanceState.WAITING_FOR_FAVORABLE_WINDOW)
+        self.assertTrue(resumed.record.active)
+        self.assertFalse(resumed.request_full_charge)
         self.assertNotIn("command", str(persisted).lower())
         self.assertNotIn("transport", str(persisted).lower())
 

--- a/tests/test_native_beta2.py
+++ b/tests/test_native_beta2.py
@@ -1,0 +1,155 @@
+"""Behavioral coverage for native setup, inventory and additional measurements."""
+from __future__ import annotations
+
+import ast
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+import unittest
+import voluptuous as vol
+
+from support import bootstrap
+bootstrap()
+
+from custom_components.battery_smartflow_ai import const
+from custom_components.battery_smartflow_ai.core.models import MeasuredValue, ValueValidity
+from custom_components.battery_smartflow_ai.native_capacity import native_capacity, pack_capacity_kwh
+from custom_components.battery_smartflow_ai.native_device_overview import _difference, _pack_status
+from custom_components.battery_smartflow_ai.native_source_fusion import NativeSourceFusion
+from custom_components.battery_smartflow_ai.zendure_device_matrix import preferred_local_transport, resolve_zendure_device
+from custom_components.battery_smartflow_ai.native_config_ui import native_device_label, native_device_summary_line
+from custom_components.battery_smartflow_ai.price_currency import price_input_profile, resolve_price_currency
+from custom_components.battery_smartflow_ai.device_profiles import DEVICE_PROFILE_MODELS
+from test_native_source_fusion import make_bootstrap, report
+from test_native_device_overview import observed_pack
+
+
+class NativeCapacityTests(unittest.TestCase):
+    def test_mixed_packs_and_no_arbitrary_count_limit(self):
+        packs = [observed_pack(f"F02N-test-{n}", "main") for n in range(9)]
+        packs.append(observed_pack("C04E-test", "main"))
+        result = native_capacity(SimpleNamespace(packs=packs))
+        self.assertEqual(result.pack_count, 10)
+        self.assertEqual(result.capacity_kwh, 27.84)
+
+    def test_missing_unknown_and_incomplete_are_not_zero_capacity(self):
+        self.assertIsNone(native_capacity(None).pack_count)
+        pack = observed_pack("Unknown-serial", "main")
+        self.assertEqual(native_capacity(SimpleNamespace(packs=[pack])).reason, "unknown_pack_profile")
+        self.assertIsNone(native_capacity(SimpleNamespace(packs=[pack]), 2).capacity_kwh)
+
+    def test_stale_pack_does_not_reuse_manual_capacity(self):
+        pack = observed_pack("F02N-test", "main")
+        pack.soc_pct = MeasuredValue.absent(ValueValidity.STALE)
+        self.assertEqual(native_capacity(SimpleNamespace(packs=[pack])).reason, "pack_data_unavailable")
+
+    def test_internal_large_pack_is_not_mistaken_for_ab1000(self):
+        self.assertEqual(pack_capacity_kwh("B000-test", "70"), 8.0)
+        self.assertIsNone(pack_capacity_kwh(None, "5"))
+
+    def test_derived_values_keep_valid_zero_and_unknown_codes(self):
+        self.assertEqual(_difference(MeasuredValue.available(3.22), MeasuredValue.available(3.21)).value, 0.01)
+        self.assertEqual(_pack_status(MeasuredValue.available(0)).value, "idle")
+        self.assertFalse(_pack_status(MeasuredValue.available(99)).valid)
+
+
+class AdditionalDiagnosticTests(unittest.IsolatedAsyncioTestCase):
+    async def test_heating_does_not_mean_protection_but_faults_block(self):
+        now = datetime(2026, 9, 8, tzinfo=timezone.utc)
+        fusion = NativeSourceFusion(await make_bootstrap())
+        heating_only = fusion.apply(report(now, {"heatState": 1}))
+        self.assertTrue(heating_only.state.heating_active.value)
+        self.assertFalse(heating_only.state.protection_active.valid)
+        normal = fusion.apply(report(now, {"is_error": 0}))
+        self.assertFalse(normal.state.protection_active.value)
+        error = fusion.apply(report(now, {"is_error": 1}))
+        self.assertTrue(error.state.protection_active.value)
+
+    async def test_raw_status_survives_source_fusion_and_expires(self):
+        now = datetime(2026, 9, 8, tzinfo=timezone.utc)
+        fusion = NativeSourceFusion(await make_bootstrap())
+        result = fusion.apply(report(now, {"OTAState": 1, "solarPower2": 0}))
+        self.assertEqual(result.state.diagnostics["OTAState"].value, 1)
+        self.assertEqual(result.state.diagnostics["solarPower2"].value, 0)
+        expired = fusion.snapshot("cloud_mqtt:device-1", now=now + timedelta(days=1))
+        self.assertFalse(expired.state.diagnostics["OTAState"].valid)
+
+
+class FlowBase:
+    def __init_subclass__(cls, **kwargs):
+        pass
+    def async_show_form(self, **kwargs):
+        return {"type": "form", **kwargs}
+    def async_show_menu(self, **kwargs):
+        return {"type": "menu", **kwargs}
+    def async_create_entry(self, **kwargs):
+        return {"type": "create_entry", **kwargs}
+
+
+class SelectorStub:
+    """Only replace HA selectors; execute the real complete flow methods."""
+    def __getattr__(self, name):
+        if name in {"TextSelectorType", "SelectSelectorMode", "NumberSelectorMode"}:
+            return SimpleNamespace(PASSWORD="password", DROPDOWN="dropdown", BOX="box")
+        return lambda *args, **kwargs: (lambda value: value) if not name.endswith("Config") else kwargs
+
+
+def load_flow_classes():
+    source = Path(__file__).parents[1] / "custom_components/battery_smartflow_ai/config_flow.py"
+    tree = ast.parse(source.read_text(encoding="utf-8"))
+    nodes = [node for node in tree.body if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.Assign))]
+    namespace = dict(vars(const))
+    namespace.update(
+        vol=vol, selector=SelectorStub(),
+        config_entries=SimpleNamespace(ConfigFlow=FlowBase, OptionsFlow=FlowBase),
+        resolve_zendure_device=resolve_zendure_device,
+        preferred_local_transport=preferred_local_transport,
+        DEVICE_PROFILE_MODELS=DEVICE_PROFILE_MODELS,
+        resolve_price_currency=resolve_price_currency,
+        price_input_profile=price_input_profile,
+        native_device_label=native_device_label,
+        native_device_summary_line=native_device_summary_line,
+    )
+    from custom_components.battery_smartflow_ai.core.models import ZendureTransport
+    namespace["ZendureTransport"] = ZendureTransport
+    exec(compile(ast.Module(body=nodes, type_ignores=[]), str(source), "exec"), namespace)
+    return namespace["ZendureSmartFlowConfigFlow"]
+
+
+class NativeSetupTests(unittest.IsolatedAsyncioTestCase):
+    async def test_native_selection_to_entry_needs_no_zha_hardware_entities(self):
+        flow = load_flow_classes()()
+        flow.hass = SimpleNamespace(config=SimpleNamespace(currency="EUR"))
+        flow._native_bootstrap = await make_bootstrap()
+        flow._native_options = {const.CONF_NATIVE_ZENDURE_APP_TOKEN: "private-test-token"}
+        menu = await flow.async_step_user()
+        self.assertEqual(menu["menu_options"][0], "native_login")
+        result = await flow.async_step_native_device({
+            const.CONF_NATIVE_ZENDURE_SELECTED_DEVICE: "cloud_mqtt:device-1",
+            const.CONF_NATIVE_ZENDURE_CONTROL_ENABLED: True,
+        })
+        keys = {key.schema for key in result["data_schema"].schema}
+        self.assertNotIn(const.CONF_SOC_ENTITY, keys)
+        self.assertNotIn(const.CONF_PACK_CAPACITY_KWH, keys)
+        self.assertNotIn(const.CONF_OUTPUT_LIMIT_ENTITY, keys)
+        self.assertIn(const.CONF_PV_ENTITY, keys)
+        await flow.async_step_native_external({const.CONF_PV_ENTITY: "sensor.pv", const.CONF_GRID_MODE: const.GRID_MODE_SINGLE})
+        entry = await flow.async_step_grid({const.CONF_GRID_POWER_ENTITY: "sensor.grid"})
+        self.assertEqual(entry["type"], "create_entry")
+        self.assertEqual(entry["data"][const.CONF_DEVICE_PROFILE], "SF2400AC")
+        self.assertNotIn(const.CONF_NATIVE_ZENDURE_APP_TOKEN, entry["data"])
+        self.assertEqual(entry["options"][const.CONF_NATIVE_ZENDURE_APP_TOKEN], "private-test-token")
+
+    async def test_invalid_device_cannot_create_entry(self):
+        flow = load_flow_classes()()
+        flow._native_bootstrap = await make_bootstrap()
+        result = await flow.async_step_native_device({const.CONF_NATIVE_ZENDURE_SELECTED_DEVICE: "missing"})
+        self.assertEqual(result["errors"]["base"], "device_not_found")
+
+    def test_reconfiguration_hides_native_inputs_without_deleting_legacy_data(self):
+        flow = load_flow_classes()()
+        flow.hass = SimpleNamespace(config=SimpleNamespace(currency="EUR"))
+        entry = SimpleNamespace(data={const.CONF_SOC_ENTITY: "sensor.old"}, options={const.CONF_NATIVE_ZENDURE_CONTROL_ENABLED: True})
+        keys = {key.schema for key in flow._base_schema(entry).schema}
+        self.assertNotIn(const.CONF_SOC_ENTITY, keys)
+        self.assertEqual(entry.data[const.CONF_SOC_ENTITY], "sensor.old")

--- a/tests/test_native_zendure_ha_integration.py
+++ b/tests/test_native_zendure_ha_integration.py
@@ -17,7 +17,7 @@ class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
         manifest = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )
-        self.assertEqual(manifest["version"], "5.0.0.beta1")
+        self.assertEqual(manifest["version"], "5.0.0-beta2")
         self.assertIn("paho-mqtt==2.1.0", manifest["requirements"])
 
     def test_options_flow_uses_a_password_field_and_never_suggests_token(self) -> None:
@@ -128,7 +128,7 @@ class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
             for node in ast.walk(tree)
             if isinstance(node, ast.Call)
             and getattr(node.func, "id", None) == "NativeHardwareSensorDescription"
-            and any(keyword.arg == "key" for keyword in node.keywords)
+            and any(keyword.arg == "key" and isinstance(keyword.value, ast.Constant) for keyword in node.keywords)
         }
         for key in (
             "battery_voltage_v",


### PR DESCRIPTION
## Summary
- move native Zendure setup into first-run configuration
- derive hardware inventory, packs, capacity and hardware SoC limits from native data
- expose additional native measurements and diagnostics while keeping unknown values fail-closed
- preserve existing V4 configuration compatibility and harden maintenance behavior

## Validation
- 758 pytest tests passed
- 471 subtests passed
- git diff --check clean

This is a prerelease implementation and still requires field validation across supported device families before final V5.