### PR TITLE
V5 beta2 follow-up: native diagnostics and reconfiguration

### DIFF
--- a/custom_components/battery_smartflow_ai/config_flow.py
+++ b/custom_components/battery_smartflow_ai/config_flow.py
@@ -845,9 +845,17 @@ class ZendureSmartFlowOptionsFlow(config_entries.OptionsFlow):
 
     async def async_step_init(self, user_input: dict[str, Any] | None = None):
         self._working_options = {}
+        native_configured = bool(
+            self.config_entry.options.get(CONF_NATIVE_ZENDURE_APP_TOKEN)
+            or self.config_entry.data.get("connection_type") == "native"
+        )
         return self.async_show_menu(
             step_id="init",
-            menu_options=["general", "expert", "native_zendure", "debug"],
+            menu_options=(
+                ["general", "expert", "debug"]
+                if native_configured
+                else ["general", "expert", "native_zendure", "debug"]
+            ),
         )
 
     async def async_step_native_zendure(

--- a/custom_components/battery_smartflow_ai/sensor.py
+++ b/custom_components/battery_smartflow_ai/sensor.py
@@ -335,6 +335,7 @@ from .zendure_normalizer import RAW_MAIN_DIAGNOSTICS
 NATIVE_MAIN_SENSORS += tuple(
     NativeHardwareSensorDescription(
         key=key, name=key, measurement_key=key,
+        suggested_display_precision=0,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
     ) for key in RAW_MAIN_DIAGNOSTICS


### PR DESCRIPTION
Follow-up fixes for the merged beta2 implementation:\n\n- hide the native token flow from the options gear menu once native setup is configured\n- render integer-like raw diagnostic values without decimal places\n- keep the native diagnostic presentation consistent\n\nValidation: 758 tests passed and 471 subtests passed.