### PR TITLE
Expose Zendure PowerCycle counter

### DIFF
--- a/custom_components/battery_smartflow_ai/native_device_overview.py
+++ b/custom_components/battery_smartflow_ai/native_device_overview.py
@@ -160,6 +160,7 @@ def build_native_device_overview(
                      "hardware_soc_min": _measurement(getattr(state, "setpoints", None), "min_soc_pct"),
                      "hardware_soc_max": _measurement(getattr(state, "setpoints", None), "max_soc_pct"),
                      "heating_active": _boolean_status(_measurement(state, "heating_active")),
+                     "switching_count": _measurement(state, "diagnostics.switching_count"),
                     }
                     if state
                     else {}

--- a/custom_components/battery_smartflow_ai/sensor.py
+++ b/custom_components/battery_smartflow_ai/sensor.py
@@ -296,6 +296,11 @@ NATIVE_MAIN_SENSORS = (
 
 NATIVE_MAIN_SENSORS += (
     NativeHardwareSensorDescription(
+        key="switching_count", translation_key="native_hardware_switching_count",
+        measurement_key="switching_count", entity_category=EntityCategory.DIAGNOSTIC,
+        suggested_display_precision=0,
+    ),
+    NativeHardwareSensorDescription(
         key="heating_active", translation_key="native_hardware_heating", measurement_key="heating_active",
         device_class=SensorDeviceClass.ENUM, options=["on", "off"],
     ),

--- a/custom_components/battery_smartflow_ai/strings.json
+++ b/custom_components/battery_smartflow_ai/strings.json
@@ -463,6 +463,7 @@
       "native_hardware_offgrid_power_w": {"name":"Off-grid power"},
       "native_hardware_cell_delta_v": {"name":"Cell voltage difference"},
       "native_hardware_pack_status": {"name":"Status","state":{"idle":"Idle","charge":"Charging","discharge":"Discharging"}},
+      "native_hardware_switching_count": {"name": "Switching operations"},
       "native_hardware_soc_min": {"name":"Hardware minimum SoC"},
       "native_hardware_soc_max": {"name":"Hardware maximum SoC"},
       "native_hardware_heating": {"name":"Battery heating","state":{"on":"On","off":"Off"}},

--- a/custom_components/battery_smartflow_ai/translations/de.json
+++ b/custom_components/battery_smartflow_ai/translations/de.json
@@ -432,6 +432,7 @@
       "native_hardware_offgrid_power_w": {"name":"Off-Grid-Leistung"},
       "native_hardware_cell_delta_v": {"name":"Zellspannungsdifferenz"},
       "native_hardware_pack_status": {"name":"Status","state":{"idle":"Ruhezustand","charge":"Laden","discharge":"Entladen"}},
+      "native_hardware_switching_count": {"name": "Schaltvorgänge"},
       "native_hardware_soc_min": {"name":"Hardware-SoC-Minimum"},
       "native_hardware_soc_max": {"name":"Hardware-SoC-Maximum"},
       "native_hardware_heating": {"name":"Batterieheizung","state":{"on":"Ein","off":"Aus"}},

--- a/custom_components/battery_smartflow_ai/translations/en.json
+++ b/custom_components/battery_smartflow_ai/translations/en.json
@@ -432,6 +432,7 @@
       "native_hardware_offgrid_power_w": {"name":"Off-grid power"},
       "native_hardware_cell_delta_v": {"name":"Cell voltage difference"},
       "native_hardware_pack_status": {"name":"Status","state":{"idle":"Idle","charge":"Charging","discharge":"Discharging"}},
+      "native_hardware_switching_count": {"name": "Switching operations"},
       "native_hardware_soc_min": {"name":"Hardware minimum SoC"},
       "native_hardware_soc_max": {"name":"Hardware maximum SoC"},
       "native_hardware_heating": {"name":"Battery heating","state":{"on":"On","off":"Off"}},

--- a/custom_components/battery_smartflow_ai/translations/fr.json
+++ b/custom_components/battery_smartflow_ai/translations/fr.json
@@ -432,6 +432,7 @@
       "native_hardware_offgrid_power_w": {"name":"Off-grid power"},
       "native_hardware_cell_delta_v": {"name":"Cell voltage difference"},
       "native_hardware_pack_status": {"name":"Status","state":{"idle":"Idle","charge":"Charging","discharge":"Discharging"}},
+      "native_hardware_switching_count": {"name": "Cycles de commutation"},
       "native_hardware_soc_min": {"name":"Hardware minimum SoC"},
       "native_hardware_soc_max": {"name":"Hardware maximum SoC"},
       "native_hardware_heating": {"name":"Battery heating","state":{"on":"On","off":"Off"}},

--- a/custom_components/battery_smartflow_ai/translations/nl.json
+++ b/custom_components/battery_smartflow_ai/translations/nl.json
@@ -432,6 +432,7 @@
       "native_hardware_offgrid_power_w": {"name":"Off-grid power"},
       "native_hardware_cell_delta_v": {"name":"Cell voltage difference"},
       "native_hardware_pack_status": {"name":"Status","state":{"idle":"Idle","charge":"Charging","discharge":"Discharging"}},
+      "native_hardware_switching_count": {"name": "Schakelbewerkingen"},
       "native_hardware_soc_min": {"name":"Hardware minimum SoC"},
       "native_hardware_soc_max": {"name":"Hardware maximum SoC"},
       "native_hardware_heating": {"name":"Battery heating","state":{"on":"On","off":"Off"}},

--- a/custom_components/battery_smartflow_ai/zendure_normalizer.py
+++ b/custom_components/battery_smartflow_ai/zendure_normalizer.py
@@ -230,12 +230,15 @@ RAW_MAIN_DIAGNOSTICS = (
     "LCNState", "localAPIEnable", "net", "OldMode", "OTAState", "phaseSwitch",
     "pvStatus", "rssi", "smartMode", "socStatus", "socCompSwitch", "writeRsp",
     "packNum", "solarPower1", "solarPower2", "solarPower3", "solarPower4",
-    "solarPower5", "solarPower6",
+    "solarPower5", "solarPower6", "PowerCycle",
 )
 for _raw in RAW_MAIN_DIAGNOSTICS:
     MAIN_PROPERTY_MAPPINGS[_raw] = _mapping(
         _raw, _raw, MappingScope.MAIN, (bool, int, float),
     )
+MAIN_PROPERTY_MAPPINGS["PowerCycle"] = _mapping(
+    "PowerCycle", "switching_count", MappingScope.MAIN, (int, float), minimum=0,
+)
 
 
 @dataclass(frozen=True, slots=True)


### PR DESCRIPTION
Add the Zendure PowerCycle data point as the native hardware diagnostic sensor 'Switching operations'. The value is read directly from the native data stream; no write-response or locally inferred counter is used. Integer display precision is enforced.\n\nValidation: 758 tests passed and 471 subtests passed.