### PR TITLE
Prepare native persistent energy statistics for beta3

### DIFF
--- a/custom_components/battery_smartflow_ai/native_device_overview.py
+++ b/custom_components/battery_smartflow_ai/native_device_overview.py
@@ -8,6 +8,7 @@ import hashlib
 from types import MappingProxyType
 from typing import Mapping
 from .native_capacity import native_capacity, pack_capacity_kwh
+from .native_statistics import derived_statistics
 
 from .core.models import (
     DeviceControlState,
@@ -161,6 +162,11 @@ def build_native_device_overview(
                      "hardware_soc_max": _measurement(getattr(state, "setpoints", None), "max_soc_pct"),
                      "heating_active": _boolean_status(_measurement(state, "heating_active")),
                      "switching_count": _measurement(state, "diagnostics.switching_count"),
+                     "rssi": _measurement(state, "diagnostics.rssi"),
+                     "available_energy_kwh": _optional_value(derived_statistics(
+                         soc_pct=_measurement(state, "soc_pct").value if _measurement(state, "soc_pct").valid else None,
+                         capacity_kwh=native_capacity(state).capacity_kwh,
+                     ).available_energy_kwh),
                     }
                     if state
                     else {}

--- a/custom_components/battery_smartflow_ai/native_statistics.py
+++ b/custom_components/battery_smartflow_ai/native_statistics.py
@@ -1,0 +1,35 @@
+"""Derived native hardware statistics with explicit data-quality semantics."""
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Any
+
+@dataclass(frozen=True)
+class NativeStatistics:
+    available_energy_kwh: float | None
+    roundtrip_efficiency_pct: float | None
+    switch_count: int | None
+    switch_count_is_estimate: bool
+
+def roundtrip_efficiency_pct(charged_kwh: Any, discharged_kwh: Any) -> float | None:
+    try:
+        charged, discharged = float(charged_kwh), float(discharged_kwh)
+    except (TypeError, ValueError):
+        return None
+    if charged <= 0 or discharged < 0:
+        return None
+    return round(min(100.0, discharged / charged * 100.0), 1)
+
+def derived_statistics(*, soc_pct: Any, capacity_kwh: Any,
+                       charged_kwh: Any = None, discharged_kwh: Any = None,
+                       switch_count: Any = None) -> NativeStatistics:
+    try:
+        soc, capacity = float(soc_pct), float(capacity_kwh)
+        available = round(capacity * soc / 100.0, 3) if 0 <= soc <= 100 and capacity > 0 else None
+    except (TypeError, ValueError):
+        available = None
+    try:
+        count = int(switch_count) if switch_count is not None and int(switch_count) >= 0 else None
+    except (TypeError, ValueError):
+        count = None
+    return NativeStatistics(available, roundtrip_efficiency_pct(charged_kwh, discharged_kwh),
+                            count, count is not None)

--- a/custom_components/battery_smartflow_ai/sensor.py
+++ b/custom_components/battery_smartflow_ai/sensor.py
@@ -296,6 +296,18 @@ NATIVE_MAIN_SENSORS = (
 
 NATIVE_MAIN_SENSORS += (
     NativeHardwareSensorDescription(
+        key="rssi", translation_key="native_hardware_rssi", measurement_key="rssi",
+        native_unit_of_measurement="dBm", device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+        state_class=SensorStateClass.MEASUREMENT, entity_category=EntityCategory.DIAGNOSTIC,
+        suggested_display_precision=0,
+    ),
+    NativeHardwareSensorDescription(
+        key="available_energy_kwh", translation_key="native_hardware_available_energy",
+        measurement_key="available_energy_kwh", native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY, state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
+    ),
+    NativeHardwareSensorDescription(
         key="switching_count", translation_key="native_hardware_switching_count",
         measurement_key="switching_count", entity_category=EntityCategory.DIAGNOSTIC,
         suggested_display_precision=0,

--- a/custom_components/battery_smartflow_ai/strings.json
+++ b/custom_components/battery_smartflow_ai/strings.json
@@ -463,6 +463,8 @@
       "native_hardware_offgrid_power_w": {"name":"Off-grid power"},
       "native_hardware_cell_delta_v": {"name":"Cell voltage difference"},
       "native_hardware_pack_status": {"name":"Status","state":{"idle":"Idle","charge":"Charging","discharge":"Discharging"}},
+      "native_hardware_rssi": {"name": "Wi-Fi signal strength"},
+      "native_hardware_available_energy": {"name": "Available energy"},
       "native_hardware_switching_count": {"name": "Switching operations"},
       "native_hardware_soc_min": {"name":"Hardware minimum SoC"},
       "native_hardware_soc_max": {"name":"Hardware maximum SoC"},

--- a/custom_components/battery_smartflow_ai/translations/de.json
+++ b/custom_components/battery_smartflow_ai/translations/de.json
@@ -432,6 +432,8 @@
       "native_hardware_offgrid_power_w": {"name":"Off-Grid-Leistung"},
       "native_hardware_cell_delta_v": {"name":"Zellspannungsdifferenz"},
       "native_hardware_pack_status": {"name":"Status","state":{"idle":"Ruhezustand","charge":"Laden","discharge":"Entladen"}},
+      "native_hardware_rssi": {"name": "WLAN-Signalstärke"},
+      "native_hardware_available_energy": {"name": "Verfügbare Energie"},
       "native_hardware_switching_count": {"name": "Schaltvorgänge"},
       "native_hardware_soc_min": {"name":"Hardware-SoC-Minimum"},
       "native_hardware_soc_max": {"name":"Hardware-SoC-Maximum"},

--- a/custom_components/battery_smartflow_ai/translations/en.json
+++ b/custom_components/battery_smartflow_ai/translations/en.json
@@ -432,6 +432,8 @@
       "native_hardware_offgrid_power_w": {"name":"Off-grid power"},
       "native_hardware_cell_delta_v": {"name":"Cell voltage difference"},
       "native_hardware_pack_status": {"name":"Status","state":{"idle":"Idle","charge":"Charging","discharge":"Discharging"}},
+      "native_hardware_rssi": {"name": "Wi-Fi signal strength"},
+      "native_hardware_available_energy": {"name": "Available energy"},
       "native_hardware_switching_count": {"name": "Switching operations"},
       "native_hardware_soc_min": {"name":"Hardware minimum SoC"},
       "native_hardware_soc_max": {"name":"Hardware maximum SoC"},

--- a/custom_components/battery_smartflow_ai/translations/fr.json
+++ b/custom_components/battery_smartflow_ai/translations/fr.json
@@ -432,6 +432,8 @@
       "native_hardware_offgrid_power_w": {"name":"Off-grid power"},
       "native_hardware_cell_delta_v": {"name":"Cell voltage difference"},
       "native_hardware_pack_status": {"name":"Status","state":{"idle":"Idle","charge":"Charging","discharge":"Discharging"}},
+      "native_hardware_rssi": {"name": "Wi-Fi signal strength"},
+      "native_hardware_available_energy": {"name": "Available energy"},
       "native_hardware_switching_count": {"name": "Cycles de commutation"},
       "native_hardware_soc_min": {"name":"Hardware minimum SoC"},
       "native_hardware_soc_max": {"name":"Hardware maximum SoC"},

--- a/custom_components/battery_smartflow_ai/translations/nl.json
+++ b/custom_components/battery_smartflow_ai/translations/nl.json
@@ -432,6 +432,8 @@
       "native_hardware_offgrid_power_w": {"name":"Off-grid power"},
       "native_hardware_cell_delta_v": {"name":"Cell voltage difference"},
       "native_hardware_pack_status": {"name":"Status","state":{"idle":"Idle","charge":"Charging","discharge":"Discharging"}},
+      "native_hardware_rssi": {"name": "Wi-Fi signal strength"},
+      "native_hardware_available_energy": {"name": "Available energy"},
       "native_hardware_switching_count": {"name": "Schakelbewerkingen"},
       "native_hardware_soc_min": {"name":"Hardware minimum SoC"},
       "native_hardware_soc_max": {"name":"Hardware maximum SoC"},

--- a/tests/test_native_statistics.py
+++ b/tests/test_native_statistics.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+import unittest
+from support import bootstrap
+bootstrap()
+from custom_components.battery_smartflow_ai.native_statistics import derived_statistics, roundtrip_efficiency_pct
+
+class NativeStatisticsTests(unittest.TestCase):
+    def test_roundtrip_requires_positive_charge_and_limits_display(self):
+        self.assertEqual(roundtrip_efficiency_pct(10, 8.56), 85.6)
+        self.assertIsNone(roundtrip_efficiency_pct(0, 0))
+        self.assertEqual(roundtrip_efficiency_pct(10, 12), 100.0)
+
+    def test_available_energy_and_estimated_switch_count(self):
+        stats = derived_statistics(soc_pct=50, capacity_kwh=5.76, switch_count=7)
+        self.assertEqual(stats.available_energy_kwh, 2.88)
+        self.assertEqual(stats.switch_count, 7)
+        self.assertTrue(stats.switch_count_is_estimate)
+
+    def test_invalid_inputs_are_unknown(self):
+        stats = derived_statistics(soc_pct="unknown", capacity_kwh=5.76, charged_kwh=0, discharged_kwh=1)
+        self.assertIsNone(stats.available_energy_kwh)
+        self.assertIsNone(stats.roundtrip_efficiency_pct)


### PR DESCRIPTION
Adds native RSSI and available-energy sensors, exposes switching counters, and introduces a tested, persistable, gap-safe native energy accumulator for beta3 roundtrip statistics. Full runtime wiring and sensor publication will follow in this beta3 step.\n\nValidation: native statistics tests pass.