### PR TITLE
Release 5.0.0-beta3

### DIFF
--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": ["paho-mqtt==2.1.0"],
-  "version": "5.0.0-beta2"
+  "version": "5.0.0-beta3"
 }

--- a/custom_components/battery_smartflow_ai/native_device_overview.py
+++ b/custom_components/battery_smartflow_ai/native_device_overview.py
@@ -166,7 +166,14 @@ def build_native_device_overview(
                      "available_energy_kwh": _optional_value(derived_statistics(
                          soc_pct=_measurement(state, "soc_pct").value if _measurement(state, "soc_pct").valid else None,
                          capacity_kwh=native_capacity(state).capacity_kwh,
+                         charged_kwh=_measurement(state, "diagnostics.charged_kwh").value,
+                         discharged_kwh=_measurement(state, "diagnostics.discharged_kwh").value,
                      ).available_energy_kwh),
+                     "roundtrip_efficiency_pct": _optional_value(derived_statistics(
+                         soc_pct=None, capacity_kwh=None,
+                         charged_kwh=_measurement(state, "diagnostics.charged_kwh").value,
+                         discharged_kwh=_measurement(state, "diagnostics.discharged_kwh").value,
+                     ).roundtrip_efficiency_pct),
                     }
                     if state
                     else {}

--- a/custom_components/battery_smartflow_ai/native_statistics.py
+++ b/custom_components/battery_smartflow_ai/native_statistics.py
@@ -10,6 +10,46 @@ class NativeStatistics:
     switch_count: int | None
     switch_count_is_estimate: bool
 
+@dataclass
+class NativeEnergyAccumulator:
+    """Persistable, gap-safe integration of native power measurements."""
+    charged_kwh: float = 0.0
+    discharged_kwh: float = 0.0
+    last_timestamp: float | None = None
+
+    @classmethod
+    def from_dict(cls, data: Any) -> "NativeEnergyAccumulator":
+        if not isinstance(data, dict):
+            return cls()
+        try:
+            charge = max(0.0, float(data.get("charged_kwh", 0.0)))
+            discharge = max(0.0, float(data.get("discharged_kwh", 0.0)))
+            stamp = data.get("last_timestamp")
+            stamp = float(stamp) if stamp is not None else None
+        except (TypeError, ValueError):
+            return cls()
+        return cls(charge, discharge, stamp)
+
+    def as_dict(self) -> dict[str, float | None]:
+        return {"charged_kwh": self.charged_kwh, "discharged_kwh": self.discharged_kwh,
+                "last_timestamp": self.last_timestamp}
+
+    def add(self, *, timestamp: Any, charge_power_w: Any, discharge_power_w: Any,
+            max_interval_seconds: float = 300.0) -> bool:
+        """Integrate one sample; reject invalid samples and large/offline gaps."""
+        try:
+            now = float(timestamp); charge = max(0.0, float(charge_power_w))
+            discharge = max(0.0, float(discharge_power_w))
+        except (TypeError, ValueError):
+            return False
+        if self.last_timestamp is not None:
+            delta = now - self.last_timestamp
+            if 0 < delta <= max_interval_seconds:
+                self.charged_kwh += charge * delta / 3_600_000
+                self.discharged_kwh += discharge * delta / 3_600_000
+        self.last_timestamp = now
+        return True
+
 def roundtrip_efficiency_pct(charged_kwh: Any, discharged_kwh: Any) -> float | None:
     try:
         charged, discharged = float(charged_kwh), float(discharged_kwh)

--- a/custom_components/battery_smartflow_ai/sensor.py
+++ b/custom_components/battery_smartflow_ai/sensor.py
@@ -308,6 +308,12 @@ NATIVE_MAIN_SENSORS += (
         suggested_display_precision=2,
     ),
     NativeHardwareSensorDescription(
+        key="roundtrip_efficiency_pct", translation_key="native_hardware_roundtrip_efficiency",
+        measurement_key="roundtrip_efficiency_pct", native_unit_of_measurement="%",
+        state_class=SensorStateClass.MEASUREMENT, entity_category=EntityCategory.DIAGNOSTIC,
+        suggested_display_precision=1,
+    ),
+    NativeHardwareSensorDescription(
         key="switching_count", translation_key="native_hardware_switching_count",
         measurement_key="switching_count", entity_category=EntityCategory.DIAGNOSTIC,
         suggested_display_precision=0,

--- a/custom_components/battery_smartflow_ai/strings.json
+++ b/custom_components/battery_smartflow_ai/strings.json
@@ -465,6 +465,7 @@
       "native_hardware_pack_status": {"name":"Status","state":{"idle":"Idle","charge":"Charging","discharge":"Discharging"}},
       "native_hardware_rssi": {"name": "Wi-Fi signal strength"},
       "native_hardware_available_energy": {"name": "Available energy"},
+      "native_hardware_roundtrip_efficiency": {"name": "Round-trip efficiency"},
       "native_hardware_switching_count": {"name": "Switching operations"},
       "native_hardware_soc_min": {"name":"Hardware minimum SoC"},
       "native_hardware_soc_max": {"name":"Hardware maximum SoC"},

--- a/custom_components/battery_smartflow_ai/translations/de.json
+++ b/custom_components/battery_smartflow_ai/translations/de.json
@@ -434,6 +434,7 @@
       "native_hardware_pack_status": {"name":"Status","state":{"idle":"Ruhezustand","charge":"Laden","discharge":"Entladen"}},
       "native_hardware_rssi": {"name": "WLAN-Signalstärke"},
       "native_hardware_available_energy": {"name": "Verfügbare Energie"},
+      "native_hardware_roundtrip_efficiency": {"name": "Wirkungsgrad (Roundtrip)"},
       "native_hardware_switching_count": {"name": "Schaltvorgänge"},
       "native_hardware_soc_min": {"name":"Hardware-SoC-Minimum"},
       "native_hardware_soc_max": {"name":"Hardware-SoC-Maximum"},

--- a/custom_components/battery_smartflow_ai/translations/en.json
+++ b/custom_components/battery_smartflow_ai/translations/en.json
@@ -434,6 +434,7 @@
       "native_hardware_pack_status": {"name":"Status","state":{"idle":"Idle","charge":"Charging","discharge":"Discharging"}},
       "native_hardware_rssi": {"name": "Wi-Fi signal strength"},
       "native_hardware_available_energy": {"name": "Available energy"},
+      "native_hardware_roundtrip_efficiency": {"name": "Round-trip efficiency"},
       "native_hardware_switching_count": {"name": "Switching operations"},
       "native_hardware_soc_min": {"name":"Hardware minimum SoC"},
       "native_hardware_soc_max": {"name":"Hardware maximum SoC"},

--- a/tests/test_native_statistics.py
+++ b/tests/test_native_statistics.py
@@ -2,9 +2,22 @@ from __future__ import annotations
 import unittest
 from support import bootstrap
 bootstrap()
-from custom_components.battery_smartflow_ai.native_statistics import derived_statistics, roundtrip_efficiency_pct
+from custom_components.battery_smartflow_ai.native_statistics import NativeEnergyAccumulator, derived_statistics, roundtrip_efficiency_pct
 
 class NativeStatisticsTests(unittest.TestCase):
+    def test_accumulator_integrates_and_restores(self):
+        accumulator = NativeEnergyAccumulator()
+        accumulator.add(timestamp=100, charge_power_w=3600, discharge_power_w=0)
+        accumulator.add(timestamp=110, charge_power_w=3600, discharge_power_w=1800)
+        restored = NativeEnergyAccumulator.from_dict(accumulator.as_dict())
+        self.assertAlmostEqual(restored.charged_kwh, 0.01)
+        self.assertAlmostEqual(restored.discharged_kwh, 0.005)
+
+    def test_accumulator_does_not_bridge_offline_gap(self):
+        accumulator = NativeEnergyAccumulator()
+        accumulator.add(timestamp=100, charge_power_w=3600, discharge_power_w=0)
+        accumulator.add(timestamp=1000, charge_power_w=3600, discharge_power_w=0)
+        self.assertEqual(accumulator.charged_kwh, 0.0)
     def test_roundtrip_requires_positive_charge_and_limits_display(self):
         self.assertEqual(roundtrip_efficiency_pct(10, 8.56), 85.6)
         self.assertIsNone(roundtrip_efficiency_pct(0, 0))


### PR DESCRIPTION
Beta3 release: native persistent energy-statistics groundwork, RSSI and available-energy diagnostics, switching counter exposure, and round-trip efficiency sensor integration.

Validation: native statistics tests pass.