### PR TITLE
Release 5.0.0-beta5

### DIFF
--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": ["paho-mqtt==2.1.0"],
-  "version": "5.0.0-beta4"
+  "version": "5.0.0-beta5"
 }

--- a/custom_components/battery_smartflow_ai/native_device_overview.py
+++ b/custom_components/battery_smartflow_ai/native_device_overview.py
@@ -179,7 +179,11 @@ def build_native_device_overview(
                     else {}
                 ),
                 product_id=identity.product_id if identity else None,
-                profile_key=device.profile_key,
+                profile_key=(device.profile_key or (
+                    getattr(resolve_zendure_device(identity), "profile_key", None)
+                    or getattr(resolve_zendure_device(identity), "key", None)
+                    or (identity.product_model if identity is not None else None)
+                )),
                 control_state=device.control_state,
                 control_enabled=device.control_state in {
                     DeviceControlState.ENABLED,


### PR DESCRIPTION
Beta5 shows the resolved BSFAI hardware profile even when Zendure does not provide a separate profile field. Unknown native properties remain isolated as disabled diagnostics and are never used for control decisions. Version 5.0.0-beta5.