### PR TITLE
Release 5.0.0-beta6

### DIFF
--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": ["paho-mqtt==2.1.0"],
-  "version": "5.0.0-beta5"
+  "version": "5.0.0-beta6"
 }


### PR DESCRIPTION
Rebuild the beta release from the current merged main branch after the corrupted beta5 packaging. No functional changes beyond the version bump.