### PR TITLE
Release 5.0.0-beta7

### DIFF
--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": ["paho-mqtt==2.1.0"],
-  "version": "5.0.0-beta6"
+  "version": "5.0.0-beta7"
 }

--- a/custom_components/battery_smartflow_ai/native_device_overview.py
+++ b/custom_components/battery_smartflow_ai/native_device_overview.py
@@ -180,9 +180,11 @@ def build_native_device_overview(
                 ),
                 product_id=identity.product_id if identity else None,
                 profile_key=(device.profile_key or (
-                    getattr(resolve_zendure_device(identity), "profile_key", None)
-                    or getattr(resolve_zendure_device(identity), "key", None)
-                    or (identity.product_model if identity is not None else None)
+                    (
+                        getattr(resolve_zendure_device(identity), "profile_key", None)
+                        or getattr(resolve_zendure_device(identity), "key", None)
+                        or identity.product_model
+                    ) if identity is not None else None
                 )),
                 control_state=device.control_state,
                 control_enabled=device.control_state in {


### PR DESCRIPTION
Fix a native overview regression introduced by the profile fallback: profile resolution is now skipped safely when no native identity is available, preventing all hardware and pack sensors from becoming unavailable.