### PR TITLE
Release 5.0.0-beta8

### DIFF
--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": ["paho-mqtt==2.1.0"],
-  "version": "5.0.0-beta7"
+  "version": "5.0.0-beta8"
 }

--- a/custom_components/battery_smartflow_ai/sensor.py
+++ b/custom_components/battery_smartflow_ai/sensor.py
@@ -1799,7 +1799,7 @@ class NativeZendureHardwareSensor(CoordinatorEntity, SensorEntity):
     @property
     def available(self) -> bool:
         item = self._item()
-        if item is None or not self.coordinator.last_update_success:
+        if item is None:
             return False
         description = self.entity_description
         if description.source == "measurement":


### PR DESCRIPTION
Fix native sensor availability: valid device measurements are no longer hidden by the global coordinator last_update_success flag. Optional missing fields remain isolated to their own sensors.