### PR TITLE
Release 5.0.0-beta10

### DIFF
--- a/custom_components/battery_smartflow_ai/config_flow.py
+++ b/custom_components/battery_smartflow_ai/config_flow.py
@@ -851,11 +851,7 @@ class ZendureSmartFlowOptionsFlow(config_entries.OptionsFlow):
         )
         return self.async_show_menu(
             step_id="init",
-            menu_options=(
-                ["general", "expert", "debug"]
-                if native_configured
-                else ["general", "expert", "native_zendure", "debug"]
-            ),
+            menu_options=["general", "expert", "native_zendure", "debug"],
         )
 
     async def async_step_native_zendure(

--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -38,7 +38,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "5.0.0-beta2"
+INTEGRATION_VERSION = "5.0.0-beta10"
 
 # V5 native Zendure discovery is observation-only in the first development
 # build. The App Token is account discovery material and must never be copied

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": ["paho-mqtt==2.1.0"],
-  "version": "5.0.0-beta9"
+  "version": "5.0.0-beta10"
 }


### PR DESCRIPTION
Keep native Zendure reconfiguration available after initial setup, including masked token replacement and rediscovery. Align manifest and const.py to 5.0.0-beta10.