### PR TITLE
Prepare mandatory native configuration for 5.0.0-beta.11

### DIFF
--- a/custom_components/battery_smartflow_ai/config_flow.py
+++ b/custom_components/battery_smartflow_ai/config_flow.py
@@ -861,17 +861,6 @@ class ZendureSmartFlowOptionsFlow(config_entries.OptionsFlow):
 
         errors: dict[str, str] = {}
         if user_input is not None:
-            if bool(user_input.get("disable_native_zendure_test", False)):
-                options = dict(self.config_entry.options)
-                options.pop(CONF_NATIVE_ZENDURE_APP_TOKEN, None)
-                options.pop(CONF_NATIVE_ZENDURE_SELECTED_DEVICE, None)
-                options.pop(CONF_NATIVE_ZENDURE_CONTROL_ENABLED, None)
-                options.pop(CONF_NATIVE_ZENDURE_CONTROL_TRANSPORT, None)
-                options.pop(CONF_NATIVE_ZENDURE_LOCAL_MQTT_SERVER, None)
-                options.pop(CONF_NATIVE_ZENDURE_LOCAL_MQTT_PORT, None)
-                options.pop(CONF_NATIVE_ZENDURE_LOCAL_MQTT_USERNAME, None)
-                options.pop(CONF_NATIVE_ZENDURE_LOCAL_MQTT_PASSWORD, None)
-                return self.async_create_entry(title="", data=options)
             token = resolve_app_token_input(
                 user_input.get(CONF_NATIVE_ZENDURE_APP_TOKEN),
                 self.config_entry.options.get(CONF_NATIVE_ZENDURE_APP_TOKEN),
@@ -924,10 +913,6 @@ class ZendureSmartFlowOptionsFlow(config_entries.OptionsFlow):
                 selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD)
             )
         }
-        if configured:
-            schema[vol.Optional("disable_native_zendure_test", default=False)] = (
-                selector.BooleanSelector()
-            )
         return vol.Schema(schema)
 
     async def async_step_native_zendure_device(
@@ -960,9 +945,7 @@ class ZendureSmartFlowOptionsFlow(config_entries.OptionsFlow):
             options = dict(self.config_entry.options)
             options[CONF_NATIVE_ZENDURE_APP_TOKEN] = self._native_token
             options[CONF_NATIVE_ZENDURE_SELECTED_DEVICE] = selected
-            options[CONF_NATIVE_ZENDURE_CONTROL_ENABLED] = bool(
-                user_input.get(CONF_NATIVE_ZENDURE_CONTROL_ENABLED, False)
-            )
+            options[CONF_NATIVE_ZENDURE_CONTROL_ENABLED] = True
             options.pop(CONF_NATIVE_ZENDURE_CONTROL_TRANSPORT, None)
             selected_device = next(
                 item for item in devices
@@ -1059,10 +1042,6 @@ class ZendureSmartFlowOptionsFlow(config_entries.OptionsFlow):
                             mode=selector.SelectSelectorMode.DROPDOWN,
                         )
                     ),
-                vol.Optional(
-                    CONF_NATIVE_ZENDURE_CONTROL_ENABLED,
-                    default=native_control_enabled,
-                ): selector.BooleanSelector(),
             }
         if any(
             preferred_local_transport(item.candidate.identity)

--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -38,7 +38,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "5.0.0-beta10"
+INTEGRATION_VERSION = "5.0.0-beta.11"
 
 # V5 native Zendure discovery is observation-only in the first development
 # build. The App Token is account discovery material and must never be copied

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": ["paho-mqtt==2.1.0"],
-  "version": "5.0.0-beta10"
+  "version": "5.0.0-beta.11"
 }

--- a/custom_components/battery_smartflow_ai/translations/fr.json
+++ b/custom_components/battery_smartflow_ai/translations/fr.json
@@ -434,6 +434,7 @@
       "native_hardware_pack_status": {"name":"Status","state":{"idle":"Idle","charge":"Charging","discharge":"Discharging"}},
       "native_hardware_rssi": {"name": "Wi-Fi signal strength"},
       "native_hardware_available_energy": {"name": "Available energy"},
+      "native_hardware_roundtrip_efficiency": {"name": "Rendement aller-retour"},
       "native_hardware_switching_count": {"name": "Cycles de commutation"},
       "native_hardware_soc_min": {"name":"Hardware minimum SoC"},
       "native_hardware_soc_max": {"name":"Hardware maximum SoC"},

--- a/custom_components/battery_smartflow_ai/translations/nl.json
+++ b/custom_components/battery_smartflow_ai/translations/nl.json
@@ -434,6 +434,7 @@
       "native_hardware_pack_status": {"name":"Status","state":{"idle":"Idle","charge":"Charging","discharge":"Discharging"}},
       "native_hardware_rssi": {"name": "Wi-Fi signal strength"},
       "native_hardware_available_energy": {"name": "Available energy"},
+      "native_hardware_roundtrip_efficiency": {"name": "Retourrendement"},
       "native_hardware_switching_count": {"name": "Schakelbewerkingen"},
       "native_hardware_soc_min": {"name":"Hardware minimum SoC"},
       "native_hardware_soc_max": {"name":"Hardware maximum SoC"},

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "5.0.0-beta2")
+        self.assertEqual(manifest_version, "5.0.0-beta.11")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_native_zendure_ha_integration.py
+++ b/tests/test_native_zendure_ha_integration.py
@@ -17,7 +17,7 @@ class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
         manifest = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )
-        self.assertEqual(manifest["version"], "5.0.0-beta2")
+        self.assertEqual(manifest["version"], "5.0.0-beta.11")
         self.assertIn("paho-mqtt==2.1.0", manifest["requirements"])
 
     def test_options_flow_uses_a_password_field_and_never_suggests_token(self) -> None:
@@ -33,7 +33,7 @@ class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
         self.assertIn("TextSelectorType.PASSWORD", text)
         self.assertNotIn("add_suggested_values_to_schema", text)
         self.assertIn("STORED_APP_TOKEN_MASK", text)
-        self.assertIn("disable_native_zendure_test", text)
+        self.assertNotIn("disable_native_zendure_test", text)
 
     def test_options_flow_does_not_ask_for_a_transport(self) -> None:
         source = (COMPONENT / "config_flow.py").read_text(encoding="utf-8")
@@ -42,7 +42,8 @@ class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
             source.index("def _native_device_summary")
         ]
         self.assertNotIn("CONF_NATIVE_ZENDURE_CONTROL_TRANSPORT", schema)
-        self.assertIn("CONF_NATIVE_ZENDURE_CONTROL_ENABLED", schema)
+        self.assertNotIn("CONF_NATIVE_ZENDURE_CONTROL_ENABLED", schema)
+        self.assertIn("options[CONF_NATIVE_ZENDURE_CONTROL_ENABLED] = True", source)
 
     def test_runtime_keeps_native_control_explicit_and_transport_typed(self) -> None:
         setup = (COMPONENT / "__init__.py").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- Keep native Zendure communication mandatory after setup.
- Remove the options that disable native communication or native command ownership.
- Preserve masked App Token replacement and device rediscovery.
- Adopt the sortable prerelease version format `5.0.0-beta.11`.
- Complete the French and Dutch round-trip efficiency translations found during validation.

## Validation

- Native Zendure Home Assistant integration contract: 10 tests passed.
- Translation coverage: 10 tests passed.
- Debug integration contract: 6 tests passed.
- Full local discovery is limited by the workstation's Python 3.9 runtime; the project uses `StrEnum`, which requires the newer Home Assistant Python runtime.