### PR TITLE
Fix current price false staleness for beta.11

### DIFF
--- a/custom_components/battery_smartflow_ai/market_price/sources.py
+++ b/custom_components/battery_smartflow_ai/market_price/sources.py
@@ -95,7 +95,14 @@ class GenericStatePriceSource:
                 if raw_currency is not None
                 else None
             ),
-            timestamp=getattr(state, "last_updated", None),
+            # ``last_updated`` changes only when state or attributes change.
+            # Price providers may legitimately report the same price again;
+            # HA's ``last_reported`` records that fresh report without causing
+            # a false six-hour stale gap (Issue #396).
+            timestamp=(
+                getattr(state, "last_reported", None)
+                or getattr(state, "last_updated", None)
+            ),
             source=self.entity_id,
             status=status,
             is_dynamic=True,

--- a/tests/test_market_price_sources.py
+++ b/tests/test_market_price_sources.py
@@ -30,6 +30,7 @@ class FakeState:
     state: object
     attributes: dict[str, object]
     last_updated: datetime = NOW
+    last_reported: datetime | None = None
 
 
 class MarketPriceSourceTests(unittest.TestCase):
@@ -61,6 +62,37 @@ class MarketPriceSourceTests(unittest.TestCase):
         self.assertEqual(price.source, "sensor.import_price")
         self.assertTrue(price.is_dynamic)
         self.assertFalse(price.is_fallback)
+
+    def test_unchanged_price_uses_fresh_last_reported_timestamp(self) -> None:
+        old_update = datetime(2026, 8, 21, 5, 0, tzinfo=timezone.utc)
+        fresh_report = datetime(2026, 8, 21, 12, 55, tzinfo=timezone.utc)
+        source = GenericStatePriceSource(
+            "sensor.import_price",
+            lambda _: FakeState(
+                state="0.20",
+                attributes={"unit_of_measurement": "EUR/kWh"},
+                last_updated=old_update,
+                last_reported=fresh_report,
+            ),
+        )
+
+        price = MarketPriceSourceAdapter(
+            source=source,
+            normalizer=NumericPriceNormalizer(now=NOW),
+            direction=MarketPriceDirection.IMPORT,
+            active_currency="EUR",
+        ).read()
+
+        self.assertTrue(price.valid)
+        self.assertEqual(price.timestamp, fresh_report)
+
+    def test_older_state_without_last_reported_falls_back_to_last_updated(self) -> None:
+        source = GenericStatePriceSource(
+            "sensor.import_price",
+            lambda _: FakeState(state="0.20", attributes={}, last_updated=NOW),
+        )
+
+        self.assertEqual(source.read().timestamp, NOW)
 
     def test_generic_state_preserves_explicit_currency_metadata(self) -> None:
         states = {


### PR DESCRIPTION
## Summary

Fix Issue #396 by using Home Assistant's `last_reported` timestamp for dynamic current-price freshness. Unlike `last_updated`, `last_reported` advances when a provider reports the same unchanged price again. Older Home Assistant state objects remain supported through a fallback to `last_updated`.

The six-hour stale safeguard remains active for providers that genuinely stop reporting.

## Validation

- Market price source tests: 11 passed on Python 3.12.
- Market price normalization tests: 15 passed on Python 3.12.
- Includes regressions for unchanged-but-fresh prices and the legacy timestamp fallback.