### PR TITLE
Protect native standby transition for beta.11

### DIFF
--- a/custom_components/battery_smartflow_ai/native_zendure_runtime.py
+++ b/custom_components/battery_smartflow_ai/native_zendure_runtime.py
@@ -1540,6 +1540,13 @@ def _skip_matching_writes(command: DeviceCommand, state: Any) -> DeviceCommand:
     output_value = state.setpoints.output_limit_w
     charge_power = state.charge_power_w
     discharge_power = state.discharge_power_w
+    stopping_active_input = bool(
+        command.ac_mode == "output"
+        and float(command.input_limit_w) == 0
+        and float(command.output_limit_w) == 0
+        and charge_power.valid
+        and float(charge_power.value) > 30
+    )
     input_is_inactive = bool(
         float(command.input_limit_w) > 0
         and charge_power.valid
@@ -1567,14 +1574,16 @@ def _skip_matching_writes(command: DeviceCommand, state: Any) -> DeviceCommand:
             and float(input_value.value) == float(command.input_limit_w)
         )
     )
-    should_write_output = force_output_write or (
+    should_write_output = stopping_active_input or force_output_write or (
         command.should_write_output and not (
             not output_is_inactive
             and output_value.valid
             and float(output_value.value) == float(command.output_limit_w)
         )
     )
-    should_write_mode = command.should_write_mode and not mode_matches
+    should_write_mode = stopping_active_input or (
+        command.should_write_mode and not mode_matches
+    )
     return replace(
         command,
         metadata=dict(command.metadata),

--- a/tests/test_native_power_controller.py
+++ b/tests/test_native_power_controller.py
@@ -515,6 +515,22 @@ class NativePowerControllerTests(unittest.IsolatedAsyncioTestCase):
             0,
         )
 
+    async def test_idle_after_charge_forces_atomic_zero_even_with_stale_mode(self):
+        target = runtime(current_state=state(charge_w=200))
+        result = await target.async_execute_device_command(DeviceCommand(
+            "output", input_limit_w=0, output_limit_w=0,
+            should_write_mode=False, should_write_input=False,
+            should_write_output=False, skipped=True,
+            skip_reason="unchanged_within_tolerance",
+        ))
+
+        self.assertEqual(result.status, CommandExecutionStatus.APPLIED)
+        command = target._zensdk_command_adapter.commands[-1].command
+        self.assertTrue(command.should_write_mode)
+        self.assertTrue(command.should_write_output)
+        self.assertEqual(command.input_limit_w, 0)
+        self.assertEqual(command.output_limit_w, 0)
+
     async def test_no_change_never_writes(self):
         target = runtime(current_state=state(output_w=250, discharge_w=250))
         result = await target.async_execute_device_command(DeviceCommand(


### PR DESCRIPTION
## Summary

Carry the Issue #439 standby-transition protection into the V5 native control path only.


When an idle command follows active charging, delayed mode/setpoint reports can otherwise make the no-change optimization skip the stop. V5 now treats measured charging above the established 30 W activity threshold as authoritative and forces one complete native idle command with zero input and output limits.

The ZenSDK adapter sends this as one atomic property group, so an older stored discharge limit cannot resume unnoticed during the transition.

## Scope

- V5 native runtime only
- No V4.7.4 change
- No change to active charge/discharge regulation

## Validation

- Native power-controller tests: 28 passed on Python 3.12
- ZenSDK command tests: 7 passed on Python 3.12
- Includes a regression for active charge plus stale mode and zero-looking setpoints