### PR TITLE
Fix false native protection block for 5.0.0-beta.12

### DIFF
--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -38,7 +38,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "5.0.0-beta.11"
+INTEGRATION_VERSION = "5.0.0-beta.12"
 
 # V5 native Zendure discovery is observation-only in the first development
 # build. The App Token is account discovery material and must never be copied

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": ["paho-mqtt==2.1.0"],
-  "version": "5.0.0-beta.11"
+  "version": "5.0.0-beta.12"
 }

--- a/custom_components/battery_smartflow_ai/zendure_normalizer.py
+++ b/custom_components/battery_smartflow_ai/zendure_normalizer.py
@@ -467,9 +467,11 @@ class ZendureCloudNormalizer:
             ),
             hems_active=hems_active,
             fault_code=device_value("fault_code"),
-            protection_active=_fault_block(
-                device_value("fault_code"),
-                self._value(values, "is_error", frozenset({"is_error"}), online, current),
+            protection_active=_device_protection_state(
+                fault_code=device_value("fault_code"),
+                is_error=self._value(
+                    values, "is_error", frozenset({"is_error"}), online, current
+                ),
             ),
             heating_active=device_value("heating_active"),
             temperature_c=device_value("temperature_c"),
@@ -641,6 +643,23 @@ def _fault_block(*values):
         any(float(value.value) != 0 for value in available),
         observed_at=min((value.observed_at for value in available if value.observed_at), default=None),
     )
+
+
+def _device_protection_state(*, fault_code, is_error):
+    """Use the explicit error flag before interpreting model-specific fault levels.
+
+    ZenSDK devices can report a non-zero ``faultLevel`` during normal operation
+    (the SF2400AC has been observed with ``faultLevel=2`` and ``is_error=0``).
+    When the explicit flag is available it is therefore authoritative. The raw
+    fault level remains a conservative fallback for devices that do not expose
+    ``is_error`` at all.
+    """
+    if is_error.valid:
+        return MeasuredValue.available(
+            float(is_error.value) != 0,
+            observed_at=is_error.observed_at,
+        )
+    return _fault_block(fault_code)
 
 
 def _normalize(

--- a/tests/test_zendure_normalizer.py
+++ b/tests/test_zendure_normalizer.py
@@ -220,6 +220,18 @@ class ZendureNormalizerTests(unittest.IsolatedAsyncioTestCase):
             self.at,
         )
 
+    async def test_explicit_no_error_overrides_nonzero_zensdk_fault_level(self):
+        """SF2400AC faultLevel=2 is no protection block when is_error=0."""
+        result = ZendureCloudNormalizer(self.bootstrap).apply(
+            report(
+                self.at,
+                {"properties": {"faultLevel": 2, "is_error": 0}},
+            )
+        )
+
+        self.assertTrue(result.state.protection_active.valid)
+        self.assertFalse(result.state.protection_active.value)
+
     async def test_missing_invalid_unsupported_stale_and_offline_are_distinct(self):
         system_id = "cloud_mqtt:device-1"
         normalizer = ZendureCloudNormalizer(


### PR DESCRIPTION
## Summary

- treat the explicit Zendure `is_error` flag as authoritative when it is available
- keep the model-specific `faultLevel` only as a conservative fallback
- prevent the normal SF2400AC combination `faultLevel=2` / `is_error=0` from blocking native charge and discharge commands
- add a regression test based on the live ZenSDK payload
- bump both integration version declarations to `5.0.0-beta.12`

## Verification

- 11 Zendure normalizer tests passed
- 16 native command-gate tests passed
- 28 native power-controller tests passed
- Python compile check passed
- manifest JSON validation passed
- `git diff --check` passed

## Release notes

Fixed an incorrect native protection block on ZenSDK devices. An SF2400AC can report `faultLevel=2` during normal operation while the explicit `is_error` flag remains clear. BSFAI now honors that explicit error state, allowing expected price-based charging and discharging while retaining fail-closed behavior when no explicit error flag is available.
