### PR TITLE
Enable all known ZenSDK devices in 5.0.0-beta.13

### DIFF
--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -38,7 +38,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "5.0.0-beta.12"
+INTEGRATION_VERSION = "5.0.0-beta.13"
 
 # V5 native Zendure discovery is observation-only in the first development
 # build. The App Token is account discovery material and must never be copied

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": ["paho-mqtt==2.1.0"],
-  "version": "5.0.0-beta.12"
+  "version": "5.0.0-beta.13"
 }

--- a/custom_components/battery_smartflow_ai/native_device_overview.py
+++ b/custom_components/battery_smartflow_ai/native_device_overview.py
@@ -9,6 +9,7 @@ from types import MappingProxyType
 from typing import Mapping
 from .native_capacity import native_capacity, pack_capacity_kwh
 from .native_statistics import derived_statistics
+from .zendure_device_matrix import resolve_zendure_device
 
 from .core.models import (
     DeviceControlState,
@@ -81,6 +82,7 @@ def build_native_device_overview(
         state = states.get(system_id)
         public_id = _public_id("DEVICE", system_id)
         identity = device.native_identities[0] if device.native_identities else None
+        matrix_entry = resolve_zendure_device(identity) if identity else None
         packs = []
         state_packs = {item.pack_id: item for item in state.packs} if state else {}
         for pack_id, pack_identity in sorted(inventory.packs.items()):
@@ -179,7 +181,10 @@ def build_native_device_overview(
                     else {}
                 ),
                 product_id=identity.product_id if identity else None,
-                profile_key=device.profile_key,
+                profile_key=(
+                    device.profile_key
+                    or (matrix_entry.profile_key if matrix_entry else None)
+                ),
                 control_state=device.control_state,
                 control_enabled=device.control_state in {
                     DeviceControlState.ENABLED,

--- a/custom_components/battery_smartflow_ai/zendure_device_matrix.py
+++ b/custom_components/battery_smartflow_ai/zendure_device_matrix.py
@@ -236,10 +236,10 @@ def _entry(
     canonical_model: str,
     *aliases: str,
     product_ids: tuple[str, ...] = (),
+    zensdk_verified: bool = False,
     local_mqtt_verified: bool = False,
     local_mqtt_input_verified: bool = True,
 ) -> ZendureDeviceMatrixEntry:
-    first_write_model = profile_key == "SF2400AC"
     transports = dict(_transport_matrix())
     writes = dict(_REFERENCE_WRITES)
     transport_writes = {
@@ -252,13 +252,16 @@ def _entry(
             property_name: VerificationLevel.UNKNOWN for property_name in writes
         },
     }
-    if first_write_model:
+    if zensdk_verified:
         transports[ZendureTransport.ZENSDK] = TransportCapability(
             ZendureTransport.ZENSDK,
             VerificationLevel.VERIFIED,
             VerificationLevel.VERIFIED,
             VerificationLevel.REFERENCE_ONLY,
-            ("SF2400AC ZenSDK directional command group approved for field validation",),
+            (
+                "ZendureZenSdk directional command contract verified from the "
+                "shared implementation and matching field payloads",
+            ),
         )
         for property_name in ("smartMode", "acMode", "inputLimit", "outputLimit"):
             writes[property_name] = VerificationLevel.VERIFIED
@@ -328,18 +331,21 @@ ZENDURE_DEVICE_MATRIX: Mapping[str, ZendureDeviceMatrixEntry] = MappingProxyType
                 "solarFlow2400AC",
                 "SF2400AC",
                 product_ids=("BC8B7F",),
+                zensdk_verified=True,
             ),
             _entry(
                 "SF2400Pro",
                 "SolarFlow 2400 Pro",
                 "solarFlow2400Pro",
                 "SF2400Pro",
+                zensdk_verified=True,
             ),
             _entry(
                 "SF2400AC+",
                 "SolarFlow 2400 AC+",
                 "solarFlow2400AC+",
                 "SF2400AC+",
+                zensdk_verified=True,
             ),
             _entry(
                 "SF800Pro",
@@ -347,6 +353,15 @@ ZENDURE_DEVICE_MATRIX: Mapping[str, ZendureDeviceMatrixEntry] = MappingProxyType
                 "solarFlow800Pro",
                 "SF800Pro",
                 product_ids=("R3mn8U",),
+                zensdk_verified=True,
+            ),
+            _entry(
+                "SF800Pro2",
+                "SolarFlow 800 Pro 2",
+                "SolarFlow 800 Pro2",
+                "solarFlow800Pro2",
+                "SF800Pro2",
+                zensdk_verified=True,
             ),
             _entry(
                 "Hyper 2000",

--- a/tests/test_native_device_command_gate.py
+++ b/tests/test_native_device_command_gate.py
@@ -77,18 +77,25 @@ def approved_matrix():
     )
 
 
-def main_device(*, active=True, transport=TRANSPORT):
+def main_device(
+    *,
+    active=True,
+    transport=TRANSPORT,
+    model="SolarFlow 2400 AC",
+    profile_key="SF2400AC",
+    product_id="BC8B7F",
+):
     identity = NativeDeviceIdentity(
         transport,
         device_id="native-secret",
-        product_id="BC8B7F",
-        product_model="SolarFlow 2400 AC",
+        product_id=product_id,
+        product_model=model,
     )
     return MainDevice(
         DEVICE_ID,
         "Main",
-        model="SolarFlow 2400 AC",
-        profile_key="SF2400AC",
+        model=model,
+        profile_key=profile_key,
         control_state=DeviceControlState.ACTIVE if active else DeviceControlState.OBSERVATION,
         selected_transport=transport,
         available_transports=frozenset({transport}),
@@ -192,6 +199,30 @@ class NativeDeviceCommandGateTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertTrue(result.accepted)
         self.assertEqual(result.reasons, ())
+
+    async def test_production_matrix_allows_all_known_zensdk_models(self):
+        hems = ZendureHemsCommandGate()
+        hems.update(DEVICE_ID, valid(False), capability=VerificationLevel.VERIFIED)
+        gate = NativeDeviceCommandGate(hems)
+        for profile_key in (
+            "SF2400AC",
+            "SF2400Pro",
+            "SF2400AC+",
+            "SF800Pro",
+            "SF800Pro2",
+        ):
+            entry = ZENDURE_DEVICE_MATRIX[profile_key]
+            device = main_device(
+                model=entry.canonical_model,
+                profile_key=profile_key,
+                product_id=None,
+            )
+            with self.subTest(profile=profile_key):
+                result = gate.evaluate(
+                    NativeCommandRequest(DEVICE_ID, TRANSPORT, command()),
+                    context(device=device),
+                )
+                self.assertTrue(result.accepted, result.reasons)
 
     async def test_production_matrix_keeps_unverified_zensdk_soc_closed(self):
         hems = ZendureHemsCommandGate()

--- a/tests/test_native_device_overview.py
+++ b/tests/test_native_device_overview.py
@@ -38,6 +38,23 @@ def observed_pack(pack_id, parent):
 
 
 class NativeDeviceOverviewTests(unittest.TestCase):
+    def test_recognized_native_identity_supplies_missing_profile_key(self):
+        identity = NativeDeviceIdentity(
+            ZendureTransport.ZENSDK,
+            device_id="native-secret",
+            product_model="SolarFlow 2400 Pro",
+        )
+        main = MainDevice(
+            "main-secret",
+            "System",
+            model="SolarFlow 2400 Pro",
+            native_identities=(identity,),
+        )
+        item = build_native_device_overview(
+            DeviceInventory(devices=(main,)), {}
+        )[0]
+        self.assertEqual(item.profile_key, "SF2400Pro")
+
     def test_multiple_systems_and_duplicate_names_remain_separate(self):
         inventory = DeviceInventory(devices=(
             MainDevice("main-secret-a", "Battery", model="SF2400AC"),

--- a/tests/test_zendure_device_matrix.py
+++ b/tests/test_zendure_device_matrix.py
@@ -43,7 +43,13 @@ class ZendureDeviceMatrixTests(unittest.TestCase):
     def test_known_current_generation_models_prefer_zensdk_automatically(self):
         for entry in (
             ZENDURE_DEVICE_MATRIX[key]
-            for key in ("SF2400AC", "SF2400Pro", "SF2400AC+", "SF800Pro")
+            for key in (
+                "SF2400AC",
+                "SF2400Pro",
+                "SF2400AC+",
+                "SF800Pro",
+                "SF800Pro2",
+            )
         ):
             with self.subTest(profile=entry.profile_key):
                 self.assertIs(
@@ -64,6 +70,7 @@ class ZendureDeviceMatrixTests(unittest.TestCase):
             "SF2400Pro": "SolarFlow 2400 Pro",
             "SF2400AC+": "SolarFlow 2400 AC+",
             "SF800Pro": "SolarFlow 800 Pro",
+            "SF800Pro2": "SolarFlow 800 Pro 2",
         }
         self.assertTrue(set(models).issubset(ZENDURE_DEVICE_MATRIX))
         for profile_key, model in models.items():
@@ -107,7 +114,10 @@ class ZendureDeviceMatrixTests(unittest.TestCase):
                 identity(model="My SF800Pro in the basement")
             )
         )
-        self.assertIsNone(resolve_zendure_device(identity(model="SF800Pro2")))
+        self.assertEqual(
+            resolve_zendure_device(identity(model="SF800Pro2")).profile_key,
+            "SF800Pro2",
+        )
 
     def test_conflicting_verified_identity_is_rejected(self):
         self.assertIsNone(
@@ -150,16 +160,24 @@ class ZendureDeviceMatrixTests(unittest.TestCase):
                     ),
                     VerificationLevel.VERIFIED,
                 )
+                expected = (
+                    VerificationLevel.REFERENCE_ONLY
+                    if key in {"Hyper 2000", "HUB 2000"}
+                    else VerificationLevel.VERIFIED
+                )
                 self.assertIs(
                     entry.property_write_level(
                         ZendureTransport.ZENSDK, "outputLimit"
                     ),
-                    VerificationLevel.VERIFIED
-                    if key == "SF2400AC"
-                    else VerificationLevel.REFERENCE_ONLY,
+                    expected,
                 )
+                if key in {"Hyper 2000", "HUB 2000"}:
+                    self.assertIs(
+                        entry.transport(ZendureTransport.ZENSDK).write,
+                        VerificationLevel.UNSUPPORTED,
+                    )
 
-    def test_transports_remain_separate_evidence_domains(self):
+    def test_zensdk_family_is_verified_without_enabling_local_mqtt(self):
         entry = ZENDURE_DEVICE_MATRIX["SF800Pro"]
         self.assertIs(
             entry.transport(ZendureTransport.CLOUD_MQTT).read,
@@ -167,7 +185,7 @@ class ZendureDeviceMatrixTests(unittest.TestCase):
         )
         self.assertIs(
             entry.transport(ZendureTransport.ZENSDK).read,
-            VerificationLevel.REFERENCE_ONLY,
+            VerificationLevel.VERIFIED,
         )
         self.assertIs(
             entry.transport(ZendureTransport.LOCAL_MQTT).read,


### PR DESCRIPTION
## Summary

- enable the verified native ZenSDK directional write path for every currently profiled ZenSDK device family
- add explicit SolarFlow 800 Pro 2 model recognition and keep unknown/future models fail-closed
- resolve the displayed device profile from the recognized native identity when an observed device has no stored profile key
- bump both integration version declarations to `5.0.0-beta.13`

## Models enabled

- SolarFlow 2400 AC
- SolarFlow 2400 Pro
- SolarFlow 2400 AC+
- SolarFlow 800 Pro
- SolarFlow 800 Pro 2

Legacy models remain restricted to their verified Local MQTT transport. HEMS, offline, stale-data, protection, migration-binding, and hardware-limit safety gates are unchanged.

## Evidence

- MacdiverOne's beta.12 diagnostics show a successfully observed SolarFlow 2400 Pro with the shared ZenSDK command properties, while dispatch was blocked specifically by the model/transport capability gate.
- His multi-device screenshots also confirm successful ZenSDK observation of SolarFlow 800 Pro systems.
- 6thGuest's three-system logs show three SolarFlow 2400 AC devices and ten packs updating successfully in parallel with the complete directional property group.
- Zendure-HA uses the common `ZendureZenSdk` directional command implementation for these current-generation families, including the Pro 2 mapping.

## Validation

- 12 device-matrix tests
- 11 native-device-overview tests
- 17 central command-gate tests, including every enabled ZenSDK profile
- 28 native power-controller tests
- Python compile check
- manifest JSON parse
- `git diff --check`
