### PR TITLE
Prepare 5.0.0-rc02 energy and forecast observability

### DIFF
--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -38,7 +38,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "5.0.0-rc01"
+INTEGRATION_VERSION = "5.0.0-rc02"
 
 # V5 native Zendure discovery is observation-only in the first development
 # build. The App Token is account discovery material and must never be copied

--- a/custom_components/battery_smartflow_ai/coordinator.py
+++ b/custom_components/battery_smartflow_ai/coordinator.py
@@ -622,6 +622,10 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             )
             migrate_legacy_price_fields(loaded_data)
             self._persist.update(loaded_data)
+            if hasattr(self.native_zendure, "restore_statistics"):
+                self.native_zendure.restore_statistics(
+                    self._persist.get("native_energy_statistics")
+                )
             invalid_maintenance = self._full_charge_maintenance.restore(
                 self._persist.get("full_charge_maintenance")
             )
@@ -675,6 +679,10 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def _save(self) -> None:
         self._persist["runtime_mode"] = dict(self.runtime_mode)
+        if hasattr(self.native_zendure, "statistics_state"):
+            self._persist["native_energy_statistics"] = (
+                self.native_zendure.statistics_state()
+            )
         self._persist["full_charge_maintenance"] = (
             self._full_charge_maintenance.persisted_state()
         )
@@ -7260,8 +7268,20 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 "pv_outlook": forecast_summary.pv_outlook,
                 "forecast_remaining_today_kwh": float(forecast_summary.remaining_today_kwh),
                 "forecast_tomorrow_kwh": float(forecast_summary.tomorrow_kwh),
+                "forecast_gross_remaining_today_kwh": float(
+                    forecast_summary.gross_remaining_today_kwh
+                ),
+                "forecast_gross_tomorrow_kwh": float(
+                    forecast_summary.gross_tomorrow_kwh
+                ),
                 "forecast_next_3h_kwh": float(forecast_summary.next_3h_kwh),
                 "forecast_next_6h_kwh": float(forecast_summary.next_6h_kwh),
+                "forecast_gross_next_3h_kwh": float(
+                    forecast_summary.gross_next_3h_kwh
+                ),
+                "forecast_gross_next_6h_kwh": float(
+                    forecast_summary.gross_next_6h_kwh
+                ),
                 "forecast_peak_today_w": float(forecast_summary.peak_today_w),
                 "forecast_peak_tomorrow_w": float(forecast_summary.peak_tomorrow_w),
                 "forecast_source_name": forecast_summary.source_name,

--- a/custom_components/battery_smartflow_ai/forecast.py
+++ b/custom_components/battery_smartflow_ai/forecast.py
@@ -30,9 +30,13 @@ class ForecastSummary:
 
     remaining_today_kwh: float = 0.0
     tomorrow_kwh: float = 0.0
+    gross_remaining_today_kwh: float = 0.0
+    gross_tomorrow_kwh: float = 0.0
 
     next_3h_kwh: float = 0.0
     next_6h_kwh: float = 0.0
+    gross_next_3h_kwh: float = 0.0
+    gross_next_6h_kwh: float = 0.0
 
     peak_today_w: float = 0.0
     peak_tomorrow_w: float = 0.0
@@ -460,6 +464,15 @@ def build_forecast_summary(
         forecast_base_load_w=forecast_base_load_w,
         now_local=now_local,
     )
+    gross_remaining_today_kwh = _compute_daily_net_energy_for_sensor(
+        hass, today_entity_id, today_kwh_raw, today, 0.0
+    )
+    gross_tomorrow_kwh = _compute_daily_net_energy_for_sensor(
+        hass, tomorrow_entity_id, tomorrow_kwh_raw, tomorrow, 0.0
+    )
+    gross_next_3h_kwh, gross_next_6h_kwh, _, _ = _compute_subday_metrics(
+        hass, today_entity_id, tomorrow_entity_id, 0.0, now_local
+    )
 
     pv_outlook = _classify_pv_outlook(
         remaining_today_kwh=remaining_today_kwh,
@@ -473,8 +486,12 @@ def build_forecast_summary(
         source_name="Solcast",
         remaining_today_kwh=round(float(remaining_today_kwh), 3),
         tomorrow_kwh=round(float(tomorrow_kwh_val), 3),
+        gross_remaining_today_kwh=round(float(gross_remaining_today_kwh), 3),
+        gross_tomorrow_kwh=round(float(gross_tomorrow_kwh), 3),
         next_3h_kwh=round(float(next_3h_kwh), 3),
         next_6h_kwh=round(float(next_6h_kwh), 3),
+        gross_next_3h_kwh=round(float(gross_next_3h_kwh), 3),
+        gross_next_6h_kwh=round(float(gross_next_6h_kwh), 3),
         peak_today_w=round(float(peak_today_w), 1),
         peak_tomorrow_w=round(float(peak_tomorrow_w), 1),
         pv_outlook=pv_outlook,
@@ -558,6 +575,18 @@ def build_energy_forecast_summary(
     next_6h = _energy_window_kwh(
         intervals, now_local, now_local + timedelta(hours=6), forecast_base_load_w
     )
+    gross_remaining_today = _energy_window_kwh(
+        intervals, now_local, tomorrow_start, 0.0
+    )
+    gross_tomorrow = _energy_window_kwh(
+        intervals, tomorrow_start, day_after_tomorrow, 0.0
+    )
+    gross_next_3h = _energy_window_kwh(
+        intervals, now_local, now_local + timedelta(hours=3), 0.0
+    )
+    gross_next_6h = _energy_window_kwh(
+        intervals, now_local, now_local + timedelta(hours=6), 0.0
+    )
 
     peak_today_w = 0.0
     peak_tomorrow_w = 0.0
@@ -578,8 +607,12 @@ def build_energy_forecast_summary(
         source_name=source_name,
         remaining_today_kwh=round(remaining_today, 3),
         tomorrow_kwh=round(tomorrow, 3),
+        gross_remaining_today_kwh=round(gross_remaining_today, 3),
+        gross_tomorrow_kwh=round(gross_tomorrow, 3),
         next_3h_kwh=round(next_3h, 3),
         next_6h_kwh=round(next_6h, 3),
+        gross_next_3h_kwh=round(gross_next_3h, 3),
+        gross_next_6h_kwh=round(gross_next_6h, 3),
         peak_today_w=round(peak_today_w, 1),
         peak_tomorrow_w=round(peak_tomorrow_w, 1),
         pv_outlook=outlook,

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": ["paho-mqtt==2.1.0"],
-  "version": "5.0.0-rc01"
+  "version": "5.0.0-rc02"
 }

--- a/custom_components/battery_smartflow_ai/native_device_overview.py
+++ b/custom_components/battery_smartflow_ai/native_device_overview.py
@@ -73,13 +73,16 @@ def build_native_device_overview(
     inventory: DeviceInventory,
     states: Mapping[str, NeutralDeviceState],
     *,
+    statistics: Mapping[str, Mapping[str, object]] | None = None,
     migration_bound_device: str | None = None,
 ) -> tuple[MainSystemOverview, ...]:
     """Build an unbounded hierarchy without exposing stable source identities."""
 
     result = []
+    statistics = statistics or {}
     for system_id, device in sorted(inventory.devices.items()):
         state = states.get(system_id)
+        system_statistics = statistics.get(system_id, {})
         public_id = _public_id("DEVICE", system_id)
         identity = device.native_identities[0] if device.native_identities else None
         matrix_entry = resolve_zendure_device(identity) if identity else None
@@ -163,22 +166,32 @@ def build_native_device_overview(
                      "hardware_soc_min": _measurement(getattr(state, "setpoints", None), "min_soc_pct"),
                      "hardware_soc_max": _measurement(getattr(state, "setpoints", None), "max_soc_pct"),
                      "heating_active": _boolean_status(_measurement(state, "heating_active")),
-                     "switching_count": _diagnostic_measurement(state, "switching_count"),
+                     "switching_count": _first_valid(
+                         _diagnostic_measurement(state, "switching_count"),
+                         _optional_value(system_statistics.get("switching_count")),
+                     ),
+                     "switching_count_is_estimate": _optional_value(
+                         not _diagnostic_measurement(state, "switching_count").valid
+                     ),
                      "rssi": _diagnostic_measurement(state, "rssi"),
+                     "charged_energy_kwh": _optional_value(
+                         system_statistics.get("charged_kwh")
+                     ),
+                     "discharged_energy_kwh": _optional_value(
+                         system_statistics.get("discharged_kwh")
+                     ),
                      "available_energy_kwh": _optional_value(derived_statistics(
                          soc_pct=_measurement(state, "soc_pct").value if _measurement(state, "soc_pct").valid else None,
                          capacity_kwh=native_capacity(state).capacity_kwh,
-                         charged_kwh=_measurement(state, "diagnostics.charged_kwh").value,
-                         discharged_kwh=_measurement(state, "diagnostics.discharged_kwh").value,
+                         charged_kwh=system_statistics.get("charged_kwh"),
+                         discharged_kwh=system_statistics.get("discharged_kwh"),
                      ).available_energy_kwh),
                      "roundtrip_efficiency_pct": _optional_value(derived_statistics(
                          soc_pct=None, capacity_kwh=None,
-                         charged_kwh=_measurement(state, "diagnostics.charged_kwh").value,
-                         discharged_kwh=_measurement(state, "diagnostics.discharged_kwh").value,
+                         charged_kwh=system_statistics.get("charged_kwh"),
+                         discharged_kwh=system_statistics.get("discharged_kwh"),
                      ).roundtrip_efficiency_pct),
                     }
-                    if state
-                    else {}
                 ),
                 product_id=identity.product_id if identity else None,
                 profile_key=(
@@ -229,6 +242,10 @@ def _diagnostic_measurement(state: object | None, key: str) -> MeasuredValue:
 
 def _optional_value(value):
     return MeasuredValue.available(value) if value is not None else MeasuredValue.absent(ValueValidity.UNKNOWN)
+
+
+def _first_valid(primary, fallback):
+    return primary if primary.valid else fallback
 
 
 def _difference(left, right):

--- a/custom_components/battery_smartflow_ai/native_statistics.py
+++ b/custom_components/battery_smartflow_ai/native_statistics.py
@@ -1,7 +1,10 @@
 """Derived native hardware statistics with explicit data-quality semantics."""
+
 from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Any
+
 
 @dataclass(frozen=True)
 class NativeStatistics:
@@ -9,6 +12,7 @@ class NativeStatistics:
     roundtrip_efficiency_pct: float | None
     switch_count: int | None
     switch_count_is_estimate: bool
+
 
 @dataclass
 class NativeEnergyAccumulator:
@@ -31,14 +35,24 @@ class NativeEnergyAccumulator:
         return cls(charge, discharge, stamp)
 
     def as_dict(self) -> dict[str, float | None]:
-        return {"charged_kwh": self.charged_kwh, "discharged_kwh": self.discharged_kwh,
-                "last_timestamp": self.last_timestamp}
+        return {
+            "charged_kwh": self.charged_kwh,
+            "discharged_kwh": self.discharged_kwh,
+            "last_timestamp": self.last_timestamp,
+        }
 
-    def add(self, *, timestamp: Any, charge_power_w: Any, discharge_power_w: Any,
-            max_interval_seconds: float = 300.0) -> bool:
+    def add(
+        self,
+        *,
+        timestamp: Any,
+        charge_power_w: Any,
+        discharge_power_w: Any,
+        max_interval_seconds: float = 300.0,
+    ) -> bool:
         """Integrate one sample; reject invalid samples and large/offline gaps."""
         try:
-            now = float(timestamp); charge = max(0.0, float(charge_power_w))
+            now = float(timestamp)
+            charge = max(0.0, float(charge_power_w))
             discharge = max(0.0, float(discharge_power_w))
         except (TypeError, ValueError):
             return False
@@ -50,6 +64,7 @@ class NativeEnergyAccumulator:
         self.last_timestamp = now
         return True
 
+
 def roundtrip_efficiency_pct(charged_kwh: Any, discharged_kwh: Any) -> float | None:
     try:
         charged, discharged = float(charged_kwh), float(discharged_kwh)
@@ -59,17 +74,35 @@ def roundtrip_efficiency_pct(charged_kwh: Any, discharged_kwh: Any) -> float | N
         return None
     return round(min(100.0, discharged / charged * 100.0), 1)
 
-def derived_statistics(*, soc_pct: Any, capacity_kwh: Any,
-                       charged_kwh: Any = None, discharged_kwh: Any = None,
-                       switch_count: Any = None) -> NativeStatistics:
+
+def derived_statistics(
+    *,
+    soc_pct: Any,
+    capacity_kwh: Any,
+    charged_kwh: Any = None,
+    discharged_kwh: Any = None,
+    switch_count: Any = None,
+) -> NativeStatistics:
     try:
         soc, capacity = float(soc_pct), float(capacity_kwh)
-        available = round(capacity * soc / 100.0, 3) if 0 <= soc <= 100 and capacity > 0 else None
+        available = (
+            round(capacity * soc / 100.0, 3)
+            if 0 <= soc <= 100 and capacity > 0
+            else None
+        )
     except (TypeError, ValueError):
         available = None
     try:
-        count = int(switch_count) if switch_count is not None and int(switch_count) >= 0 else None
+        count = (
+            int(switch_count)
+            if switch_count is not None and int(switch_count) >= 0
+            else None
+        )
     except (TypeError, ValueError):
         count = None
-    return NativeStatistics(available, roundtrip_efficiency_pct(charged_kwh, discharged_kwh),
-                            count, count is not None)
+    return NativeStatistics(
+        available,
+        roundtrip_efficiency_pct(charged_kwh, discharged_kwh),
+        count,
+        count is not None,
+    )

--- a/custom_components/battery_smartflow_ai/native_zendure_runtime.py
+++ b/custom_components/battery_smartflow_ai/native_zendure_runtime.py
@@ -67,6 +67,7 @@ from .zendure_local_mqtt import (
 )
 from .zendure_local_mqtt_commands import LocalMqttCommandStatus
 from .native_source_fusion import NativeSourceFusion
+from .native_statistics import NativeEnergyAccumulator
 from .zendure_privacy import ZendureDiagnosticSanitizer
 from .zendure_zensdk import (
     ZenSdkReadResult,
@@ -164,6 +165,9 @@ class NativeZendureRuntime:
         self._last_command_result: dict[str, Any] | None = None
         self._control_baseline_consumed = False
         self._transport_router = NativeTransportRouter()
+        self._energy_accumulators: dict[str, NativeEnergyAccumulator] = {}
+        self._switching_counts: dict[str, int] = {}
+        self._last_energy_modes: dict[str, str] = {}
 
     @property
     def configured(self) -> bool:
@@ -466,6 +470,7 @@ class NativeZendureRuntime:
         overview = build_native_device_overview(
             self._inventory,
             self._states,
+            statistics=self.statistics_state(),
             migration_bound_device=self._migration_bound_device,
         )
         selected_transport = self._selected_local_transport()
@@ -492,6 +497,71 @@ class NativeZendureRuntime:
             else item
             for index, item in enumerate(overview)
         )
+
+    def restore_statistics(self, data: Any) -> None:
+        """Restore locally accumulated, per-device lifetime statistics."""
+
+        if not isinstance(data, dict):
+            return
+        for system_id, values in data.items():
+            if not isinstance(values, dict):
+                continue
+            self._energy_accumulators[str(system_id)] = (
+                NativeEnergyAccumulator.from_dict(values)
+            )
+            try:
+                self._switching_counts[str(system_id)] = max(
+                    0, int(values.get("switching_count", 0))
+                )
+            except (TypeError, ValueError):
+                self._switching_counts[str(system_id)] = 0
+            mode = values.get("last_mode")
+            if mode in {"idle", "charge", "discharge"}:
+                self._last_energy_modes[str(system_id)] = str(mode)
+
+    def statistics_state(self) -> dict[str, dict[str, Any]]:
+        """Return the persistable native statistics and their quality metadata."""
+
+        system_ids = set(self._energy_accumulators) | set(self._switching_counts)
+        result: dict[str, dict[str, Any]] = {}
+        for system_id in system_ids:
+            accumulator = self._energy_accumulators.get(
+                system_id, NativeEnergyAccumulator()
+            )
+            result[system_id] = {
+                **accumulator.as_dict(),
+                "switching_count": int(self._switching_counts.get(system_id, 0)),
+                "last_mode": self._last_energy_modes.get(system_id),
+            }
+        return result
+
+    def _update_statistics(self, state: Any) -> None:
+        """Integrate valid native power samples without bridging telemetry gaps."""
+
+        timestamp = getattr(state, "last_message_at", None)
+        charge = _numeric_value(getattr(state, "charge_power_w", None))
+        discharge = _numeric_value(getattr(state, "discharge_power_w", None))
+        if timestamp is None or charge is None or discharge is None:
+            return
+        system_id = str(state.system_id)
+        accumulator = self._energy_accumulators.setdefault(
+            system_id, NativeEnergyAccumulator()
+        )
+        accumulator.add(
+            timestamp=timestamp.timestamp(),
+            charge_power_w=charge,
+            discharge_power_w=discharge,
+        )
+
+        mode = "charge" if charge > 0 else "discharge" if discharge > 0 else "idle"
+        previous = self._last_energy_modes.get(system_id)
+        # Match Z-HA's orientation counter: one completed active phase is
+        # counted when the battery returns to idle. It remains an estimate.
+        if previous in {"charge", "discharge"} and mode == "idle":
+            self._switching_counts[system_id] = (
+                self._switching_counts.get(system_id, 0) + 1
+            )
+        self._last_energy_modes[system_id] = mode
 
     def _hardware_control_state(self) -> DeviceControlState:
         """Describe readiness separately from the current strategy decision."""
@@ -1372,6 +1442,7 @@ class NativeZendureRuntime:
 
     def _apply_state(self, state: Any) -> None:
         self._states[state.system_id] = state
+        self._update_statistics(state)
         device = self._inventory.devices[state.system_id]
         identity = device.native_identities[0] if device.native_identities else None
         profile = resolve_zendure_device(identity) if identity is not None else None
@@ -1431,6 +1502,15 @@ def _control_path_name(transport: ZendureTransport | None) -> str:
 
 def _value(measured: Any) -> str | None:
     return str(measured.value) if measured.validity is ValueValidity.VALID else None
+
+
+def _numeric_value(measured: Any) -> float | None:
+    if measured is None or getattr(measured, "validity", None) is not ValueValidity.VALID:
+        return None
+    try:
+        return max(0.0, float(measured.value))
+    except (TypeError, ValueError):
+        return None
 
 
 def _fresh_native_state(state: Any, *, maximum_age_seconds: float = 30.0) -> bool:

--- a/custom_components/battery_smartflow_ai/sensor.py
+++ b/custom_components/battery_smartflow_ai/sensor.py
@@ -314,6 +314,22 @@ NATIVE_MAIN_SENSORS += (
         suggested_display_precision=1,
     ),
     NativeHardwareSensorDescription(
+        key="charged_energy_kwh", translation_key="native_hardware_charged_energy",
+        measurement_key="charged_energy_kwh",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=2,
+    ),
+    NativeHardwareSensorDescription(
+        key="discharged_energy_kwh", translation_key="native_hardware_discharged_energy",
+        measurement_key="discharged_energy_kwh",
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=2,
+    ),
+    NativeHardwareSensorDescription(
         key="switching_count", translation_key="native_hardware_switching_count",
         measurement_key="switching_count", entity_category=EntityCategory.DIAGNOSTIC,
         suggested_display_precision=0,
@@ -774,6 +790,34 @@ _SENSOR_DESCRIPTIONS: tuple[ZendureSensorEntityDescription, ...] = (
         key="forecast_next_6h_kwh",
         translation_key="forecast_next_6h_kwh",
         runtime_key="forecast_next_6h_kwh",
+        native_unit_of_measurement="kWh",
+        icon="mdi:clock-outline",
+    ),
+    ZendureSensorEntityDescription(
+        key="forecast_gross_remaining_today_kwh",
+        translation_key="forecast_gross_remaining_today_kwh",
+        runtime_key="forecast_gross_remaining_today_kwh",
+        native_unit_of_measurement="kWh",
+        icon="mdi:solar-power",
+    ),
+    ZendureSensorEntityDescription(
+        key="forecast_gross_tomorrow_kwh",
+        translation_key="forecast_gross_tomorrow_kwh",
+        runtime_key="forecast_gross_tomorrow_kwh",
+        native_unit_of_measurement="kWh",
+        icon="mdi:weather-sunny",
+    ),
+    ZendureSensorEntityDescription(
+        key="forecast_gross_next_3h_kwh",
+        translation_key="forecast_gross_next_3h_kwh",
+        runtime_key="forecast_gross_next_3h_kwh",
+        native_unit_of_measurement="kWh",
+        icon="mdi:clock-fast",
+    ),
+    ZendureSensorEntityDescription(
+        key="forecast_gross_next_6h_kwh",
+        translation_key="forecast_gross_next_6h_kwh",
+        runtime_key="forecast_gross_next_6h_kwh",
         native_unit_of_measurement="kWh",
         icon="mdi:clock-outline",
     ),
@@ -1790,11 +1834,17 @@ class NativeZendureHardwareSensor(CoordinatorEntity, SensorEntity):
         item = self._item()
         if self._kind != "main" or item is None:
             return None
-        return {
+        attributes = {
             "v4_migration_binding": (
                 "confirmed" if item.migration_bound else "not_bound"
             )
         }
+        if self.entity_description.key == "switching_count":
+            estimate = item.measurements.get("switching_count_is_estimate")
+            attributes["estimated"] = bool(
+                estimate is not None and estimate.valid and estimate.value
+            )
+        return attributes
 
     @property
     def available(self) -> bool:
@@ -1804,6 +1854,12 @@ class NativeZendureHardwareSensor(CoordinatorEntity, SensorEntity):
         description = self.entity_description
         if description.source == "measurement":
             measured = item.measurements.get(description.measurement_key)
+            if (
+                description.measurement_key == "localAPIEnable"
+                and (measured is None or not measured.valid)
+                and item.selected_transport.value == "zensdk"
+            ):
+                return True
             return bool(measured is not None and measured.valid)
         if description.source == "firmware":
             return bool(item.firmware.valid)
@@ -1823,6 +1879,12 @@ class NativeZendureHardwareSensor(CoordinatorEntity, SensorEntity):
         source = self.entity_description.source
         if source == "measurement":
             measured = item.measurements.get(self.entity_description.measurement_key)
+            if (
+                self.entity_description.measurement_key == "localAPIEnable"
+                and (measured is None or not measured.valid)
+                and item.selected_transport.value == "zensdk"
+            ):
+                return 1
             return _measured_value(measured)
         if source == "firmware":
             return _measured_value(item.firmware)

--- a/custom_components/battery_smartflow_ai/strings.json
+++ b/custom_components/battery_smartflow_ai/strings.json
@@ -472,6 +472,8 @@
       "native_hardware_rssi": {"name": "Wi-Fi signal strength"},
       "native_hardware_available_energy": {"name": "Available energy"},
       "native_hardware_roundtrip_efficiency": {"name": "Round-trip efficiency"},
+      "native_hardware_charged_energy": {"name": "Total energy charged"},
+      "native_hardware_discharged_energy": {"name": "Total energy discharged"},
       "native_hardware_switching_count": {"name": "Switching operations"},
       "native_hardware_soc_min": {"name":"Hardware minimum SoC"},
       "native_hardware_soc_max": {"name":"Hardware maximum SoC"},
@@ -667,16 +669,28 @@
         "name": "Diagnostic: Learned planning current slot avg. power"
       },
       "forecast_remaining_today_kwh": {
-        "name": "PV forecast today"
+        "name": "Usable PV forecast remaining today"
       },
       "forecast_tomorrow_kwh": {
-        "name": "PV forecast tomorrow"
+        "name": "Usable PV forecast tomorrow"
       },
       "forecast_next_3h_kwh": {
-        "name": "PV forecast next 3 hours"
+        "name": "Usable PV forecast next 3 hours"
       },
       "forecast_next_6h_kwh": {
-        "name": "PV forecast next 6 hours"
+        "name": "Usable PV forecast next 6 hours"
+      },
+      "forecast_gross_remaining_today_kwh": {
+        "name": "Gross PV forecast remaining today"
+      },
+      "forecast_gross_tomorrow_kwh": {
+        "name": "Gross PV forecast tomorrow"
+      },
+      "forecast_gross_next_3h_kwh": {
+        "name": "Gross PV forecast next 3 hours"
+      },
+      "forecast_gross_next_6h_kwh": {
+        "name": "Gross PV forecast next 6 hours"
       },
       "price_daily_average": {
         "name": "Prices – Dynamic daily average"

--- a/custom_components/battery_smartflow_ai/translations/de.json
+++ b/custom_components/battery_smartflow_ai/translations/de.json
@@ -441,6 +441,8 @@
       "native_hardware_rssi": {"name": "WLAN-Signalstärke"},
       "native_hardware_available_energy": {"name": "Verfügbare Energie"},
       "native_hardware_roundtrip_efficiency": {"name": "Wirkungsgrad (Roundtrip)"},
+      "native_hardware_charged_energy": {"name": "Gesamtenergie Laden"},
+      "native_hardware_discharged_energy": {"name": "Gesamtenergie Entladen"},
       "native_hardware_switching_count": {"name": "Schaltvorgänge"},
       "native_hardware_soc_min": {"name":"Hardware-SoC-Minimum"},
       "native_hardware_soc_max": {"name":"Hardware-SoC-Maximum"},
@@ -612,16 +614,28 @@
         "name": "Diagnose: Lernplanung aktueller Slot Ø Leistung"
       },
       "forecast_remaining_today_kwh": {
-        "name": "PV-Prognose heute"
+        "name": "Nutzbare PV-Prognose – Rest heute"
       },
       "forecast_tomorrow_kwh": {
-        "name": "PV-Prognose morgen"
+        "name": "Nutzbare PV-Prognose – morgen"
       },
       "forecast_next_3h_kwh": {
-        "name": "PV-Prognose nächste 3 Stunden"
+        "name": "Nutzbare PV-Prognose – nächste 3 Stunden"
       },
       "forecast_next_6h_kwh": {
-        "name": "PV-Prognose nächste 6 Stunden"
+        "name": "Nutzbare PV-Prognose – nächste 6 Stunden"
+      },
+      "forecast_gross_remaining_today_kwh": {
+        "name": "PV-Prognose brutto – Rest heute"
+      },
+      "forecast_gross_tomorrow_kwh": {
+        "name": "PV-Prognose brutto – morgen"
+      },
+      "forecast_gross_next_3h_kwh": {
+        "name": "PV-Prognose brutto – nächste 3 Stunden"
+      },
+      "forecast_gross_next_6h_kwh": {
+        "name": "PV-Prognose brutto – nächste 6 Stunden"
       },
       "price_daily_average": {
         "name": "Preise – Ø dynamischer Tagespreis"

--- a/custom_components/battery_smartflow_ai/translations/en.json
+++ b/custom_components/battery_smartflow_ai/translations/en.json
@@ -441,6 +441,8 @@
       "native_hardware_rssi": {"name": "Wi-Fi signal strength"},
       "native_hardware_available_energy": {"name": "Available energy"},
       "native_hardware_roundtrip_efficiency": {"name": "Round-trip efficiency"},
+      "native_hardware_charged_energy": {"name": "Total energy charged"},
+      "native_hardware_discharged_energy": {"name": "Total energy discharged"},
       "native_hardware_switching_count": {"name": "Switching operations"},
       "native_hardware_soc_min": {"name":"Hardware minimum SoC"},
       "native_hardware_soc_max": {"name":"Hardware maximum SoC"},
@@ -612,16 +614,28 @@
         "name": "Diagnostic: Learned planning current slot avg. power"
       },
       "forecast_remaining_today_kwh": {
-        "name": "PV forecast today"
+        "name": "Usable PV forecast remaining today"
       },
       "forecast_tomorrow_kwh": {
-        "name": "PV forecast tomorrow"
+        "name": "Usable PV forecast tomorrow"
       },
       "forecast_next_3h_kwh": {
-        "name": "PV forecast next 3 hours"
+        "name": "Usable PV forecast next 3 hours"
       },
       "forecast_next_6h_kwh": {
-        "name": "PV forecast next 6 hours"
+        "name": "Usable PV forecast next 6 hours"
+      },
+      "forecast_gross_remaining_today_kwh": {
+        "name": "Gross PV forecast remaining today"
+      },
+      "forecast_gross_tomorrow_kwh": {
+        "name": "Gross PV forecast tomorrow"
+      },
+      "forecast_gross_next_3h_kwh": {
+        "name": "Gross PV forecast next 3 hours"
+      },
+      "forecast_gross_next_6h_kwh": {
+        "name": "Gross PV forecast next 6 hours"
       },
       "price_daily_average": {
         "name": "Prices – Dynamic daily average"

--- a/custom_components/battery_smartflow_ai/translations/fr.json
+++ b/custom_components/battery_smartflow_ai/translations/fr.json
@@ -441,6 +441,8 @@
       "native_hardware_rssi": {"name": "Wi-Fi signal strength"},
       "native_hardware_available_energy": {"name": "Available energy"},
       "native_hardware_roundtrip_efficiency": {"name": "Rendement aller-retour"},
+      "native_hardware_charged_energy": {"name": "Énergie totale chargée"},
+      "native_hardware_discharged_energy": {"name": "Énergie totale déchargée"},
       "native_hardware_switching_count": {"name": "Cycles de commutation"},
       "native_hardware_soc_min": {"name":"Hardware minimum SoC"},
       "native_hardware_soc_max": {"name":"Hardware maximum SoC"},
@@ -612,16 +614,28 @@
         "name": "Diagnostic : puissance moyenne du slot actuel planification apprise"
       },
       "forecast_remaining_today_kwh": {
-        "name": "Prévision PV aujourd’hui"
+        "name": "Prévision PV utilisable restante aujourd’hui"
       },
       "forecast_tomorrow_kwh": {
-        "name": "Prévision PV demain"
+        "name": "Prévision PV utilisable demain"
       },
       "forecast_next_3h_kwh": {
-        "name": "Prévision PV prochaines 3 heures"
+        "name": "Prévision PV utilisable prochaines 3 heures"
       },
       "forecast_next_6h_kwh": {
-        "name": "Prévision PV prochaines 6 heures"
+        "name": "Prévision PV utilisable prochaines 6 heures"
+      },
+      "forecast_gross_remaining_today_kwh": {
+        "name": "Prévision PV brute restante aujourd’hui"
+      },
+      "forecast_gross_tomorrow_kwh": {
+        "name": "Prévision PV brute demain"
+      },
+      "forecast_gross_next_3h_kwh": {
+        "name": "Prévision PV brute prochaines 3 heures"
+      },
+      "forecast_gross_next_6h_kwh": {
+        "name": "Prévision PV brute prochaines 6 heures"
       },
       "price_daily_average": {
         "name": "Prix – Moyenne journalière dynamique"

--- a/custom_components/battery_smartflow_ai/translations/nl.json
+++ b/custom_components/battery_smartflow_ai/translations/nl.json
@@ -441,6 +441,8 @@
       "native_hardware_rssi": {"name": "Wi-Fi signal strength"},
       "native_hardware_available_energy": {"name": "Available energy"},
       "native_hardware_roundtrip_efficiency": {"name": "Retourrendement"},
+      "native_hardware_charged_energy": {"name": "Totale geladen energie"},
+      "native_hardware_discharged_energy": {"name": "Totale ontladen energie"},
       "native_hardware_switching_count": {"name": "Schakelbewerkingen"},
       "native_hardware_soc_min": {"name":"Hardware minimum SoC"},
       "native_hardware_soc_max": {"name":"Hardware maximum SoC"},
@@ -612,16 +614,28 @@
         "name": "Diagnose: gemiddeld vermogen huidig slot lerende planning"
       },
       "forecast_remaining_today_kwh": {
-        "name": "PV-prognose vandaag"
+        "name": "Bruikbare PV-prognose resterend vandaag"
       },
       "forecast_tomorrow_kwh": {
-        "name": "PV-prognose morgen"
+        "name": "Bruikbare PV-prognose morgen"
       },
       "forecast_next_3h_kwh": {
-        "name": "PV-prognose komende 3 uur"
+        "name": "Bruikbare PV-prognose komende 3 uur"
       },
       "forecast_next_6h_kwh": {
-        "name": "PV-prognose komende 6 uur"
+        "name": "Bruikbare PV-prognose komende 6 uur"
+      },
+      "forecast_gross_remaining_today_kwh": {
+        "name": "Bruto PV-prognose resterend vandaag"
+      },
+      "forecast_gross_tomorrow_kwh": {
+        "name": "Bruto PV-prognose morgen"
+      },
+      "forecast_gross_next_3h_kwh": {
+        "name": "Bruto PV-prognose komende 3 uur"
+      },
+      "forecast_gross_next_6h_kwh": {
+        "name": "Bruto PV-prognose komende 6 uur"
       },
       "price_daily_average": {
         "name": "Prijzen – Dynamisch daggemiddelde"

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -13,7 +13,7 @@ COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
 
 
 class DebugIntegrationContractTests(unittest.TestCase):
-    def test_manifest_and_runtime_version_match_v5_beta1_release(self) -> None:
+    def test_manifest_and_runtime_version_match_current_release(self) -> None:
         manifest_version = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )["version"]
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "5.0.0-beta.11")
+        self.assertEqual(manifest_version, "5.0.0-rc02")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_energy_forecast.py
+++ b/tests/test_energy_forecast.py
@@ -57,6 +57,10 @@ class EnergyForecastTests(unittest.TestCase):
         self.assertEqual(result.next_3h_kwh, 2.75)
         self.assertEqual(result.next_6h_kwh, 2.75)
         self.assertEqual(result.tomorrow_kwh, 0.7)
+        self.assertEqual(result.gross_remaining_today_kwh, 3.5)
+        self.assertEqual(result.gross_tomorrow_kwh, 1.0)
+        self.assertEqual(result.gross_next_3h_kwh, 3.5)
+        self.assertEqual(result.gross_next_6h_kwh, 3.5)
         self.assertEqual(result.peak_today_w, 2000.0)
 
     def test_empty_or_invalid_energy_forecast_is_unavailable(self):
@@ -127,6 +131,7 @@ class EnergyForecastApiTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(result.status, FORECAST_STATUS_AVAILABLE)
         self.assertEqual(result.remaining_today_kwh, 1.0)
+        self.assertEqual(result.gross_remaining_today_kwh, 1.0)
         self.assertEqual(result.source_name, "Broken roof, East roof")
 
 

--- a/tests/test_energy_forecast_config.py
+++ b/tests/test_energy_forecast_config.py
@@ -51,8 +51,8 @@ class EnergyForecastConfigTests(unittest.TestCase):
     def test_rc_version_is_consistent(self):
         const = (COMPONENT / "const.py").read_text(encoding="utf-8")
         manifest = (COMPONENT / "manifest.json").read_text(encoding="utf-8")
-        self.assertIn('INTEGRATION_VERSION = "5.0.0-rc01"', const)
-        self.assertIn('"version": "5.0.0-rc01"', manifest)
+        self.assertIn('INTEGRATION_VERSION = "5.0.0-rc02"', const)
+        self.assertIn('"version": "5.0.0-rc02"', manifest)
         self.assertIn('"after_dependencies": ["energy"]', manifest)
         self.assertLess(
             manifest.index('"after_dependencies"'), manifest.index('"codeowners"')

--- a/tests/test_native_device_overview.py
+++ b/tests/test_native_device_overview.py
@@ -38,6 +38,26 @@ def observed_pack(pack_id, parent):
 
 
 class NativeDeviceOverviewTests(unittest.TestCase):
+    def test_persisted_native_statistics_feed_energy_and_efficiency_sensors(self):
+        main = MainDevice("main-secret", "System")
+        item = build_native_device_overview(
+            DeviceInventory(devices=(main,)),
+            {},
+            statistics={
+                main.system_id: {
+                    "charged_kwh": 12.5,
+                    "discharged_kwh": 10.0,
+                    "switching_count": 7,
+                }
+            },
+        )[0]
+
+        self.assertEqual(item.measurements["charged_energy_kwh"].value, 12.5)
+        self.assertEqual(item.measurements["discharged_energy_kwh"].value, 10.0)
+        self.assertEqual(item.measurements["roundtrip_efficiency_pct"].value, 80.0)
+        self.assertEqual(item.measurements["switching_count"].value, 7)
+        self.assertTrue(item.measurements["switching_count_is_estimate"].value)
+
     def test_recognized_native_identity_supplies_missing_profile_key(self):
         identity = NativeDeviceIdentity(
             ZendureTransport.ZENSDK,

--- a/tests/test_native_statistics.py
+++ b/tests/test_native_statistics.py
@@ -1,8 +1,18 @@
 from __future__ import annotations
+
 import unittest
+
 from support import bootstrap
+
+
 bootstrap()
-from custom_components.battery_smartflow_ai.native_statistics import NativeEnergyAccumulator, derived_statistics, roundtrip_efficiency_pct
+
+from custom_components.battery_smartflow_ai.native_statistics import (  # noqa: E402
+    NativeEnergyAccumulator,
+    derived_statistics,
+    roundtrip_efficiency_pct,
+)
+
 
 class NativeStatisticsTests(unittest.TestCase):
     def test_accumulator_integrates_and_restores(self):
@@ -18,6 +28,7 @@ class NativeStatisticsTests(unittest.TestCase):
         accumulator.add(timestamp=100, charge_power_w=3600, discharge_power_w=0)
         accumulator.add(timestamp=1000, charge_power_w=3600, discharge_power_w=0)
         self.assertEqual(accumulator.charged_kwh, 0.0)
+
     def test_roundtrip_requires_positive_charge_and_limits_display(self):
         self.assertEqual(roundtrip_efficiency_pct(10, 8.56), 85.6)
         self.assertIsNone(roundtrip_efficiency_pct(0, 0))
@@ -30,6 +41,11 @@ class NativeStatisticsTests(unittest.TestCase):
         self.assertTrue(stats.switch_count_is_estimate)
 
     def test_invalid_inputs_are_unknown(self):
-        stats = derived_statistics(soc_pct="unknown", capacity_kwh=5.76, charged_kwh=0, discharged_kwh=1)
+        stats = derived_statistics(
+            soc_pct="unknown",
+            capacity_kwh=5.76,
+            charged_kwh=0,
+            discharged_kwh=1,
+        )
         self.assertIsNone(stats.available_energy_kwh)
         self.assertIsNone(stats.roundtrip_efficiency_pct)

--- a/tests/test_native_zendure_ha_integration.py
+++ b/tests/test_native_zendure_ha_integration.py
@@ -13,11 +13,11 @@ COMPONENT = ROOT / "custom_components" / "battery_smartflow_ai"
 
 
 class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
-    def test_beta1_version_and_mqtt_dependency_are_packaged(self) -> None:
+    def test_current_version_and_mqtt_dependency_are_packaged(self) -> None:
         manifest = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )
-        self.assertEqual(manifest["version"], "5.0.0-beta.11")
+        self.assertEqual(manifest["version"], "5.0.0-rc02")
         self.assertIn("paho-mqtt==2.1.0", manifest["requirements"])
 
     def test_options_flow_uses_a_password_field_and_never_suggests_token(self) -> None:

--- a/tests/test_v470_backward_compatibility.py
+++ b/tests/test_v470_backward_compatibility.py
@@ -134,7 +134,7 @@ class EntityRegistryCompatibilityTests(unittest.TestCase):
     V460_DESCRIPTION_HASHES = {
         "sensor.py": (
             "_SENSOR_DESCRIPTIONS",
-            "ad999147f51777d7f1be09e12e0b9b597cea0980e37bb069b07fc4265dc9b564",
+            "d9863a3278870b786ace527fdd222b1f533198990b78429b190c447a652a12d1",
         ),
         "number.py": (
             "NUMBERS",


### PR DESCRIPTION
## Summary

- add persistent total charge and discharge energy sensors for the Home Assistant Energy Dashboard
- derive roundtrip efficiency and an explicitly estimated switching count from persisted native telemetry
- expose ZenSDK local API availability when the active native transport proves it is enabled
- retain the existing usable net PV forecasts and add gross forecast sensors for import visibility
- bump integration and manifest versions to 5.0.0-rc02

## Validation

- 779 tests passed
- 479 subtests passed
- Python compilation passed
- JSON validation passed for manifest, strings, and all translations
- git diff check passed

## Notes

The new total energy counters start accumulating with RC02 because Zendure does not provide a reliable historical lifetime total through this data path. Values are persisted across Home Assistant restarts and do not bridge longer telemetry gaps.