### PR TITLE
Fix native standby transition for 5.0.0-rc03

### DIFF
--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -38,7 +38,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "5.0.0-rc02"
+INTEGRATION_VERSION = "5.0.0-rc03"
 
 # V5 native Zendure discovery is observation-only in the first development
 # build. The App Token is account discovery material and must never be copied

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": ["paho-mqtt==2.1.0"],
-  "version": "5.0.0-rc02"
+  "version": "5.0.0-rc03"
 }

--- a/custom_components/battery_smartflow_ai/native_zendure_runtime.py
+++ b/custom_components/battery_smartflow_ai/native_zendure_runtime.py
@@ -1620,13 +1620,24 @@ def _skip_matching_writes(command: DeviceCommand, state: Any) -> DeviceCommand:
     output_value = state.setpoints.output_limit_w
     charge_power = state.charge_power_w
     discharge_power = state.discharge_power_w
-    stopping_active_input = bool(
+    zero_power_command = bool(
         command.ac_mode == "output"
         and float(command.input_limit_w) == 0
         and float(command.output_limit_w) == 0
+    )
+    stopping_active_input = bool(
+        zero_power_command
         and charge_power.valid
         and float(charge_power.value) > 30
     )
+    stopping_previous_target = bool(
+        zero_power_command
+        and any(
+            float(command.metadata.get(key, 0.0) or 0.0) > 0
+            for key in ("last_input_limit_w", "last_output_limit_w")
+        )
+    )
+    force_atomic_idle = stopping_active_input or stopping_previous_target
     input_is_inactive = bool(
         float(command.input_limit_w) > 0
         and charge_power.valid
@@ -1654,14 +1665,14 @@ def _skip_matching_writes(command: DeviceCommand, state: Any) -> DeviceCommand:
             and float(input_value.value) == float(command.input_limit_w)
         )
     )
-    should_write_output = stopping_active_input or force_output_write or (
+    should_write_output = force_atomic_idle or force_output_write or (
         command.should_write_output and not (
             not output_is_inactive
             and output_value.valid
             and float(output_value.value) == float(command.output_limit_w)
         )
     )
-    should_write_mode = stopping_active_input or (
+    should_write_mode = force_atomic_idle or (
         command.should_write_mode and not mode_matches
     )
     return replace(

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "5.0.0-rc02")
+        self.assertEqual(manifest_version, "5.0.0-rc03")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_energy_forecast_config.py
+++ b/tests/test_energy_forecast_config.py
@@ -51,8 +51,8 @@ class EnergyForecastConfigTests(unittest.TestCase):
     def test_rc_version_is_consistent(self):
         const = (COMPONENT / "const.py").read_text(encoding="utf-8")
         manifest = (COMPONENT / "manifest.json").read_text(encoding="utf-8")
-        self.assertIn('INTEGRATION_VERSION = "5.0.0-rc02"', const)
-        self.assertIn('"version": "5.0.0-rc02"', manifest)
+        self.assertIn('INTEGRATION_VERSION = "5.0.0-rc03"', const)
+        self.assertIn('"version": "5.0.0-rc03"', manifest)
         self.assertIn('"after_dependencies": ["energy"]', manifest)
         self.assertLess(
             manifest.index('"after_dependencies"'), manifest.index('"codeowners"')

--- a/tests/test_native_power_controller.py
+++ b/tests/test_native_power_controller.py
@@ -531,6 +531,52 @@ class NativePowerControllerTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(command.input_limit_w, 0)
         self.assertEqual(command.output_limit_w, 0)
 
+    async def test_idle_after_hardware_stopped_charge_clears_previous_target(self):
+        target = runtime(current_state=state(charge_w=0, input_w=0, output_w=0))
+        result = await target.async_execute_device_command(DeviceCommand(
+            "output", input_limit_w=0, output_limit_w=0,
+            should_write_mode=False, should_write_input=False,
+            should_write_output=True,
+            metadata={"last_input_limit_w": 800, "last_output_limit_w": 0},
+        ))
+
+        self.assertEqual(result.status, CommandExecutionStatus.APPLIED)
+        command = target._zensdk_command_adapter.commands[-1].command
+        self.assertTrue(command.should_write_mode)
+        self.assertTrue(command.should_write_output)
+        self.assertEqual(command.input_limit_w, 0)
+        self.assertEqual(command.output_limit_w, 0)
+
+    async def test_idle_after_hardware_stopped_discharge_clears_previous_target(self):
+        target = runtime(current_state=state(charge_w=0, discharge_w=0, output_w=0))
+        result = await target.async_execute_device_command(DeviceCommand(
+            "output", input_limit_w=0, output_limit_w=0,
+            should_write_mode=False, should_write_input=False,
+            should_write_output=True,
+            metadata={"last_input_limit_w": 0, "last_output_limit_w": 650},
+        ))
+
+        self.assertEqual(result.status, CommandExecutionStatus.APPLIED)
+        command = target._zensdk_command_adapter.commands[-1].command
+        self.assertTrue(command.should_write_mode)
+        self.assertTrue(command.should_write_output)
+        self.assertEqual(command.input_limit_w, 0)
+        self.assertEqual(command.output_limit_w, 0)
+
+    async def test_stable_idle_does_not_repeat_atomic_zero(self):
+        target = runtime(current_state=state(charge_w=0, discharge_w=0))
+        result = await target.async_execute_device_command(DeviceCommand(
+            "output", input_limit_w=0, output_limit_w=0,
+            should_write_mode=False, should_write_input=False,
+            should_write_output=False, skipped=True,
+            skip_reason="unchanged_within_tolerance",
+            metadata={"last_input_limit_w": 0, "last_output_limit_w": 0},
+        ))
+
+        self.assertEqual(result.status, CommandExecutionStatus.SKIPPED)
+        self.assertEqual(result.reason, "native_setpoints_unchanged")
+        self.assertEqual(target._zensdk_command_adapter.commands, [])
+
     async def test_no_change_never_writes(self):
         target = runtime(current_state=state(output_w=250, discharge_w=250))
         result = await target.async_execute_device_command(DeviceCommand(

--- a/tests/test_native_zendure_ha_integration.py
+++ b/tests/test_native_zendure_ha_integration.py
@@ -17,7 +17,7 @@ class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
         manifest = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )
-        self.assertEqual(manifest["version"], "5.0.0-rc02")
+        self.assertEqual(manifest["version"], "5.0.0-rc03")
         self.assertIn("paho-mqtt==2.1.0", manifest["requirements"])
 
     def test_options_flow_uses_a_password_field_and_never_suggests_token(self) -> None:


### PR DESCRIPTION
## Summary

- force one complete atomic ZenSDK zero command when entering idle after a previously active charge or discharge target
- cover the race where hardware power has already fallen to zero before the next BSFAI control cycle
- retain write suppression during stable idle so zero commands are not repeated
- bump integration and manifest versions to 5.0.0-rc03

## Validation

- 782 tests passed
- 479 subtests passed
- Python compilation passed
- git diff check passed

Fixes #439