### PR TITLE
Fix debug recording freeze for 5.0.0-rc04

### DIFF
--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -38,7 +38,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "5.0.0-rc03"
+INTEGRATION_VERSION = "5.0.0-rc04"
 
 # V5 native Zendure discovery is observation-only in the first development
 # build. The App Token is account discovery material and must never be copied

--- a/custom_components/battery_smartflow_ai/coordinator.py
+++ b/custom_components/battery_smartflow_ai/coordinator.py
@@ -194,7 +194,10 @@ from .command_effectiveness import (
 )
 from .debug_recorder import DebugRecorder
 from .debug_exporter import DebugExportError, export_debug_package
-from .debug_sample_builder import build_debug_sample
+from .debug_sample_builder import (
+    build_debug_sample,
+    configured_entity_availability,
+)
 from .price_currency import (
     PriceCurrency,
     migrate_legacy_price_fields,
@@ -1818,14 +1821,10 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     def _debug_entity_availability(self) -> dict[str, bool | None]:
         """Return availability for configured diagnostic entities."""
 
-        return {
-            role: (
-                self.hass.states.get(entity_id) is not None
-                if entity_id
-                else None
-            )
-            for role, entity_id in self._debug_configured_entities().items()
-        }
+        return configured_entity_availability(
+            self._debug_configured_entities(),
+            self.hass.states.get,
+        )
 
     async def _async_export_debug_package(self, package) -> None:
         """Write a completed package outside the event loop and retain its path."""

--- a/custom_components/battery_smartflow_ai/debug_sample_builder.py
+++ b/custom_components/battery_smartflow_ai/debug_sample_builder.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Mapping
+from typing import Any, Callable, Mapping
 
 from .debug_package import DebugSample, redact_secrets
 
@@ -93,7 +93,7 @@ def _prefixed(
 
 
 def build_entity_diagnostics(
-    configured_entities: Mapping[str, str | None] | None,
+    configured_entities: Mapping[str, Any] | None,
     entity_availability: Mapping[str, bool | None] | None,
     *,
     compact: bool = False,
@@ -129,11 +129,32 @@ def build_entity_diagnostics(
     return redact_secrets(result)
 
 
+def configured_entity_availability(
+    configured_entities: Mapping[str, Any] | None,
+    state_getter: Callable[[str], Any],
+) -> dict[str, bool | None]:
+    """Read availability only for actual Home Assistant entity IDs.
+
+    Debug configuration also contains structured source selections such as the
+    list of Energy dashboard forecast config entries. Those values describe a
+    provider, not an entity, and must never be passed to ``hass.states.get``.
+    """
+
+    return {
+        str(role): (
+            state_getter(entity_id) is not None
+            if isinstance(entity_id, str) and bool(entity_id)
+            else None
+        )
+        for role, entity_id in (configured_entities or {}).items()
+    }
+
+
 def build_debug_sample(
     *,
     timestamp: datetime,
     details: Mapping[str, Any],
-    configured_entities: Mapping[str, str | None] | None = None,
+    configured_entities: Mapping[str, Any] | None = None,
     entity_availability: Mapping[str, bool | None] | None = None,
 ) -> DebugSample:
     """Group existing coordinator diagnostics into one schema-v1 sample.

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": ["paho-mqtt==2.1.0"],
-  "version": "5.0.0-rc03"
+  "version": "5.0.0-rc04"
 }

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "5.0.0-rc03")
+        self.assertEqual(manifest_version, "5.0.0-rc04")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_debug_sample_builder.py
+++ b/tests/test_debug_sample_builder.py
@@ -13,6 +13,7 @@ bootstrap()
 from custom_components.battery_smartflow_ai.debug_sample_builder import (  # noqa: E402
     build_debug_sample,
     build_entity_diagnostics,
+    configured_entity_availability,
 )
 
 
@@ -178,6 +179,27 @@ class DebugSampleBuilderTests(unittest.TestCase):
             result["raw_values"]["entities"]["token_sensor"],
             "[REDACTED]",
         )
+
+    def test_availability_skips_structured_forecast_source_selection(self) -> None:
+        requested: list[str] = []
+
+        def get_state(entity_id: str):
+            requested.append(entity_id)
+            return object() if entity_id == "sensor.battery_soc" else None
+
+        result = configured_entity_availability(
+            {
+                "soc": "sensor.battery_soc",
+                "pv_forecast_config_entries": ["forecast-east", "forecast-west"],
+                "optional": None,
+            },
+            get_state,
+        )
+
+        self.assertEqual(requested, ["sensor.battery_soc"])
+        self.assertTrue(result["soc"])
+        self.assertIsNone(result["pv_forecast_config_entries"])
+        self.assertIsNone(result["optional"])
 
     def test_source_mapping_changes_do_not_change_built_sample(self) -> None:
         details = {"soc": 40.0, "automatic_strategy_active": True}

--- a/tests/test_energy_forecast_config.py
+++ b/tests/test_energy_forecast_config.py
@@ -51,8 +51,8 @@ class EnergyForecastConfigTests(unittest.TestCase):
     def test_rc_version_is_consistent(self):
         const = (COMPONENT / "const.py").read_text(encoding="utf-8")
         manifest = (COMPONENT / "manifest.json").read_text(encoding="utf-8")
-        self.assertIn('INTEGRATION_VERSION = "5.0.0-rc03"', const)
-        self.assertIn('"version": "5.0.0-rc03"', manifest)
+        self.assertIn('INTEGRATION_VERSION = "5.0.0-rc04"', const)
+        self.assertIn('"version": "5.0.0-rc04"', manifest)
         self.assertIn('"after_dependencies": ["energy"]', manifest)
         self.assertLess(
             manifest.index('"after_dependencies"'), manifest.index('"codeowners"')

--- a/tests/test_native_zendure_ha_integration.py
+++ b/tests/test_native_zendure_ha_integration.py
@@ -17,7 +17,7 @@ class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
         manifest = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )
-        self.assertEqual(manifest["version"], "5.0.0-rc03")
+        self.assertEqual(manifest["version"], "5.0.0-rc04")
         self.assertIn("paho-mqtt==2.1.0", manifest["requirements"])
 
     def test_options_flow_uses_a_password_field_and_never_suggests_token(self) -> None:


### PR DESCRIPTION
## Summary

- prevent structured Energy forecast source selections from being passed to the Home Assistant entity-state lookup
- keep forecast provider selections in debug packages while marking their entity availability as not applicable
- preserve normal availability checks for actual entity IDs
- bump integration and manifest versions to 5.0.0-rc04

## Impact

Starting debug recording no longer aborts coordinator updates or makes all integration entities unavailable after the Energy dashboard forecast selector is configured.

## Validation

- 783 tests passed
- 479 subtests passed
- focused debug recording regression tests passed
- Python compilation passed
- git diff check passed