### PR TITLE
Keep ZenSDK control available without MQTT

### DIFF
--- a/custom_components/battery_smartflow_ai/native_zendure_runtime.py
+++ b/custom_components/battery_smartflow_ai/native_zendure_runtime.py
@@ -1211,6 +1211,11 @@ class NativeZendureRuntime:
                     self._local_transport is not None
                     and self._local_transport.state is ConnectionState.CONNECTED
                     and system_id in self._local_transport.device_states
+                )
+                or (
+                    system_id in self._zensdk_last_result
+                    and self._zensdk_health(system_id, now)["availability"]
+                    in {"available", "degraded"}
                 ),
                 observed_at=now,
             )

--- a/custom_components/battery_smartflow_ai/zendure_hems_activity.py
+++ b/custom_components/battery_smartflow_ai/zendure_hems_activity.py
@@ -34,7 +34,7 @@ class HemsActivityTracker:
         self._last_activity_at: datetime | None = None
 
     def set_monitoring(self, available: bool, *, observed_at: datetime) -> None:
-        """Start a fresh quiet window only for a healthy subscribed transport."""
+        """Start a fresh quiet window while a native observation path is healthy."""
 
         if available and not self._monitoring:
             self._monitoring_started_at = observed_at

--- a/custom_components/battery_smartflow_ai/zendure_normalizer.py
+++ b/custom_components/battery_smartflow_ai/zendure_normalizer.py
@@ -378,7 +378,7 @@ class ZendureCloudNormalizer:
         *,
         observed_at: datetime,
     ) -> None:
-        """Tell the tracker whether Cloud MQTT is currently subscribed."""
+        """Tell the tracker whether a native observation path is healthy."""
 
         if system_id not in self._models:
             raise KeyError(system_id)

--- a/tests/test_zendure_zensdk.py
+++ b/tests/test_zendure_zensdk.py
@@ -401,6 +401,37 @@ class ZenSdkReadTests(unittest.IsolatedAsyncioTestCase):
             ZendureTransport.ZENSDK,
         )
 
+        # HEMS activity is a safety gate, but its quiet-window tracking must
+        # follow the healthy native control path.  Losing an optional MQTT
+        # side channel must not leave a ZenSDK device blocked forever.
+        runtime._refresh_snapshots()
+        hems = runtime._normalizer.hems_diagnostics(
+            candidate_id,
+            now=datetime.now(timezone.utc),
+        )
+        self.assertTrue(hems.monitoring)
+        self.assertIsNotNone(hems.monitoring_started_at)
+
+        # Once that uninterrupted observation window has been quiet for more
+        # than 60 seconds, the HEMS gate can safely return to inactive even
+        # though neither MQTT transport is connected.
+        now = datetime.now(timezone.utc)
+        runtime._normalizer.set_hems_monitoring(
+            candidate_id,
+            False,
+            observed_at=now,
+        )
+        runtime._normalizer.set_hems_monitoring(
+            candidate_id,
+            True,
+            observed_at=now - timedelta(seconds=61),
+        )
+        runtime._refresh_snapshots()
+        self.assertEqual(
+            runtime._inventory.devices[candidate_id].hems_status.value,
+            "inactive",
+        )
+
     async def test_local_health_ages_without_failures_and_cloud_cannot_refresh_it(self):
         data = await make_bootstrap()
         device = data.devices[0].candidate.candidate_id


### PR DESCRIPTION
## Summary

- keep HEMS quiet-window monitoring active while the device has a healthy ZenSDK observation path
- prevent an optional Cloud/local MQTT disconnect from leaving ZenSDK systems permanently blocked as `zendure_hems_unknown`
- retain fail-closed behavior during startup, after stale/offline telemetry, and for explicit or observed HEMS activity
- add a regression test for the multi-device failure reported by MacdiverOne in Discussion #456

## Validation

- 17 ZenSDK tests passed
- 14 HEMS tests passed
- 31 native power-controller tests passed
- 702 tests passed in the broad local run; five unrelated modules could not load because the local Python environment lacks optional test dependencies (`tzdata`, `pytest`, and `voluptuous`)
- Python compilation and JSON parsing passed

## Release

This completes `5.0.0-rc05` together with the already merged smartMode display clarification from PR #479. The release tag will be created only after this PR is merged.