### PR TITLE
Restore ZenSDK control and identify native battery packs

### DIFF
--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -38,7 +38,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "5.0.0-rc05"
+INTEGRATION_VERSION = "5.0.0-rc06"
 
 # V5 native Zendure discovery is observation-only in the first development
 # build. The App Token is account discovery material and must never be copied

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": ["paho-mqtt==2.1.0"],
-  "version": "5.0.0-rc05"
+  "version": "5.0.0-rc06"
 }

--- a/custom_components/battery_smartflow_ai/native_device_overview.py
+++ b/custom_components/battery_smartflow_ai/native_device_overview.py
@@ -274,6 +274,16 @@ def _pack_model(value: str | None, parent_model: str | None) -> str | None:
     )
     if normalized == "5" and normalized_parent == "solarflow2400ac":
         return "AB3000X"
+    # Confirmed from multi-model field diagnostics in Discussion #456.  Type
+    # 300 is shared by AB2000S and AB2000X, so do not invent a distinction the
+    # native report does not provide.
+    confirmed_pack_types = {
+        "250": "AB1000",
+        "300": "AB2000S / AB2000X",
+        "500": "SF2400Pro internal battery",
+    }
+    if normalized in confirmed_pack_types:
+        return confirmed_pack_types[normalized]
     return normalized if normalized and not normalized.isdecimal() else None
 
 

--- a/custom_components/battery_smartflow_ai/sensor.py
+++ b/custom_components/battery_smartflow_ai/sensor.py
@@ -64,6 +64,7 @@ from .native_registry_identity import (
     native_main_device_identifier,
     native_pack_device_identifier,
 )
+from .native_config_ui import native_device_name
 from .price_currency import price_input_profile
 
 _LOGGER = logging.getLogger(__name__)
@@ -1787,7 +1788,10 @@ class NativeZendureHardwareSensor(CoordinatorEntity, SensorEntity):
             firmware = _measured_value(getattr(item, "firmware", None))
             self._attr_device_info = DeviceInfo(
                 identifiers={native_main_device_identifier(public_id)},
-                name=item.display_name if item else "Zendure system",
+                name=(
+                    native_device_name(item.display_name, item.model)
+                    if item else "Zendure system"
+                ),
                 manufacturer="Zendure",
                 model=(item.model or "Unknown Zendure system") if item else None,
                 serial_number=item.serial_number if item else None,
@@ -1810,7 +1814,8 @@ class NativeZendureHardwareSensor(CoordinatorEntity, SensorEntity):
                 else 1
             )
             parent_name = (
-                parent.display_name if parent is not None else "Zendure"
+                native_device_name(parent.display_name, parent.model)
+                if parent is not None else "Zendure"
             )
             self._attr_device_info = DeviceInfo(
                 identifiers={native_pack_device_identifier(public_id)},

--- a/custom_components/battery_smartflow_ai/zendure_zensdk.py
+++ b/custom_components/battery_smartflow_ai/zendure_zensdk.py
@@ -108,7 +108,21 @@ async def async_write_zensdk_properties(
     if device is None:
         return ZenSdkWriteResult(False, None, "device_not_found")
     identity = device.candidate.identity
-    if identity.product_model != "SolarFlow 2400 AC" or not identity.serial_number:
+    matrix_entry = resolve_zendure_device(identity)
+    if (
+        not identity.serial_number
+        or matrix_entry is None
+        or not matrix_entry.native_control_approved
+        or matrix_entry.transport(ZendureTransport.ZENSDK).write
+        is not VerificationLevel.VERIFIED
+        or any(
+            matrix_entry.property_write_level(
+                ZendureTransport.ZENSDK, property_name
+            )
+            is not VerificationLevel.VERIFIED
+            for property_name in property_names
+        )
+    ):
         return ZenSdkWriteResult(False, None, "model_not_allowed")
     raw = next(
         (item for item in bootstrap.raw_device_list

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "5.0.0-rc05")
+        self.assertEqual(manifest_version, "5.0.0-rc06")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_energy_forecast_config.py
+++ b/tests/test_energy_forecast_config.py
@@ -51,8 +51,8 @@ class EnergyForecastConfigTests(unittest.TestCase):
     def test_rc_version_is_consistent(self):
         const = (COMPONENT / "const.py").read_text(encoding="utf-8")
         manifest = (COMPONENT / "manifest.json").read_text(encoding="utf-8")
-        self.assertIn('INTEGRATION_VERSION = "5.0.0-rc05"', const)
-        self.assertIn('"version": "5.0.0-rc05"', manifest)
+        self.assertIn('INTEGRATION_VERSION = "5.0.0-rc06"', const)
+        self.assertIn('"version": "5.0.0-rc06"', manifest)
         self.assertIn('"after_dependencies": ["energy"]', manifest)
         self.assertLess(
             manifest.index('"after_dependencies"'), manifest.index('"codeowners"')

--- a/tests/test_native_device_overview.py
+++ b/tests/test_native_device_overview.py
@@ -157,6 +157,30 @@ class NativeDeviceOverviewTests(unittest.TestCase):
         self.assertEqual(pack.pack_model, "AB3000X")
         self.assertEqual(pack.measurements["pack_type"].value, 5)
 
+    def test_confirmed_pack_types_are_resolved_without_false_precision(self):
+        expected_models = {
+            "250": "AB1000",
+            "300": "AB2000S / AB2000X",
+            "500": "SF2400Pro internal battery",
+        }
+        for pack_type, expected_model in expected_models.items():
+            with self.subTest(pack_type=pack_type):
+                main = MainDevice("main-secret", "System", model="SolarFlow 2400 Pro")
+                inventory = DeviceInventory(
+                    devices=(main,),
+                    packs=(BatteryPackIdentity(
+                        "pack-secret", main.system_id, pack_type=pack_type
+                    ),),
+                )
+                state = SimpleNamespace(
+                    packs=(observed_pack("pack-secret", main.system_id),),
+                    last_message_at=None,
+                )
+                pack = build_native_device_overview(
+                    inventory, {main.system_id: state}
+                )[0].packs[0]
+                self.assertEqual(pack.pack_model, expected_model)
+
     def test_only_serial_number_is_exposed_for_local_device_information(self):
         identity = NativeDeviceIdentity(
             ZendureTransport.CLOUD_MQTT,

--- a/tests/test_native_zendure_ha_integration.py
+++ b/tests/test_native_zendure_ha_integration.py
@@ -17,7 +17,7 @@ class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
         manifest = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )
-        self.assertEqual(manifest["version"], "5.0.0-rc05")
+        self.assertEqual(manifest["version"], "5.0.0-rc06")
         self.assertIn("paho-mqtt==2.1.0", manifest["requirements"])
 
     def test_options_flow_uses_a_password_field_and_never_suggests_token(self) -> None:
@@ -112,7 +112,8 @@ class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
 
     def test_pack_device_name_uses_parent_name_and_stable_position(self) -> None:
         sensor = (COMPONENT / "sensor.py").read_text(encoding="utf-8")
-        self.assertIn("parent.display_name", sensor)
+        self.assertIn("native_device_name(parent.display_name, parent.model)", sensor)
+        self.assertIn("native_device_name(item.display_name, item.model)", sensor)
         self.assertIn("enumerate(parent.packs, start=1)", sensor)
         self.assertIn('"de": "Batterie-Pack"', sensor)
         self.assertNotIn("public_id[-6:]", sensor)

--- a/tests/test_zendure_zensdk.py
+++ b/tests/test_zendure_zensdk.py
@@ -53,7 +53,12 @@ class Response:
         return self.data
 
 
-async def make_bootstrap(*, ip="192.168.1.44"):
+async def make_bootstrap(
+    *,
+    ip="192.168.1.44",
+    product_model="SolarFlow 2400 AC",
+    product_key="BC8B7F",
+):
     token = b64encode(b"https://api.example.com.app-key").decode()
 
     async def post(*_args, **_kwargs):
@@ -66,8 +71,8 @@ async def make_bootstrap(*, ip="192.168.1.44"):
                         {
                             "deviceKey": "device-real-1",
                             "snNumber": "serial-real-1",
-                            "productKey": "BC8B7F",
-                            "productModel": "SolarFlow 2400 AC",
+                            "productKey": product_key,
+                            "productModel": product_model,
                             "deviceName": "Garage",
                             "online": True,
                             "ip": ip,
@@ -105,6 +110,47 @@ class ZenSdkReadTests(unittest.IsolatedAsyncioTestCase):
             calls[0][1]["json"],
             {"sn": "serial-real-1", "properties": {"outputLimit": 301}, "id": 7},
         )
+
+    async def test_verified_zensdk_models_are_not_rejected_by_low_level_writer(self):
+        verified_models = (
+            ("SolarFlow 2400 Pro", "unknown-product"),
+            ("SolarFlow 2400 AC+", "unknown-product"),
+            ("SolarFlow 800 Pro", "R3mn8U"),
+            ("SolarFlow 800 Pro 2", "unknown-product"),
+        )
+        for product_model, product_key in verified_models:
+            with self.subTest(product_model=product_model):
+                data = await make_bootstrap(
+                    product_model=product_model, product_key=product_key
+                )
+                calls = []
+
+                async def post(url, **kwargs):
+                    calls.append((url, kwargs))
+                    return Response({"success": True}, 200)
+
+                result = await async_write_zensdk_property(
+                    data, "cloud_mqtt:device-real-1", "outputLimit", 301, 7, post
+                )
+                self.assertTrue(result.accepted)
+                self.assertEqual(len(calls), 1)
+
+    async def test_unknown_zensdk_model_is_rejected_without_network(self):
+        data = await make_bootstrap(
+            product_model="Future SolarFlow", product_key="unknown-product"
+        )
+        calls = []
+
+        async def post(*args, **kwargs):
+            calls.append((args, kwargs))
+            return Response({"success": True}, 200)
+
+        result = await async_write_zensdk_property(
+            data, "cloud_mqtt:device-real-1", "outputLimit", 301, 7, post
+        )
+        self.assertFalse(result.accepted)
+        self.assertEqual(result.result, "model_not_allowed")
+        self.assertEqual(calls, [])
 
     async def test_first_write_rejects_every_other_property_without_network(self):
         data = await make_bootstrap()


### PR DESCRIPTION
## Summary

- remove the obsolete low-level ZenSDK write restriction that still allowed only SolarFlow 2400 AC
- enforce the central verified model and property matrix for every ZenSDK write
- enable the already approved ZenSDK path for SolarFlow 2400 Pro, SolarFlow 2400 AC+, SolarFlow 800 Pro, and SolarFlow 800 Pro 2
- identify field-confirmed battery pack types from Discussion #456:
  - `250` → `AB1000`
  - `300` → `AB2000S / AB2000X` (the native value does not distinguish the two)
  - `500` → `SF2400Pro internal battery`
- give native devices and their packs an unambiguous `device name – model` label without changing their stable registry identifiers
- bump both version sources to `5.0.0-rc06`

## Why

The RC05 diagnostics from both the SF800Pro and SF2400Pro showed healthy ZenSDK data, inactive HEMS, and an enabled native control path. Commands nevertheless failed with `model_not_allowed`. The cause was a second hard-coded model check in the low-level writer that bypassed the newer central device matrix.

The latest screenshots also confirmed the pack-type mappings and showed that the virtual BSFAI control device and the physical SF800Pro could both appear as `Garten`. The physical device now includes its model in the display name while all identifiers remain stable.

## Validation

- 705 tests passed in the complete local discovery run
- 5 unrelated modules could not be imported locally because optional development dependencies are absent (`tzdata`, `pytest`, `voluptuous`)
- all focused ZenSDK, device-matrix, native-overview, Home Assistant integration, version-contract, and forecast tests pass
- Python compilation passes
- `git diff --check` passes

Field evidence: https://github.com/PalmManiac/battery-smartflow-ai/discussions/456#discussioncomment-18384927