### PR TITLE
Unify battery identification and reduce recorder load

### DIFF
--- a/custom_components/battery_smartflow_ai/native_capacity.py
+++ b/custom_components/battery_smartflow_ai/native_capacity.py
@@ -16,14 +16,71 @@ class NativeCapacity:
     reason: str
 
 
+@dataclass(frozen=True, slots=True)
+class NativePackProfile:
+    """One conservatively resolved battery model and nominal capacity."""
+
+    model: str
+    capacity_kwh: float
+    source: str
+
+
+def resolve_pack_profile(
+    serial: str | None,
+    pack_type: str | int | None,
+    parent_model: str | None = None,
+) -> NativePackProfile | None:
+    """Resolve serial evidence first, then field-confirmed pack-type fallback."""
+
+    normalized_serial = str(serial or "").strip().upper()
+    normalized_type = str(pack_type).strip() if pack_type is not None else ""
+    if len(normalized_serial) >= 4:
+        prefix = normalized_serial[0]
+        if prefix == "A":
+            return NativePackProfile(
+                "AIO2400" if normalized_serial[3] == "3" else "AB1000",
+                2.4 if normalized_serial[3] == "3" else 0.96,
+                "serial",
+            )
+        if prefix == "B":
+            return NativePackProfile(
+                "I8000" if normalized_type == "70" else "AB1000S",
+                8.0 if normalized_type == "70" else 0.96,
+                "serial_and_pack_type" if normalized_type == "70" else "serial",
+            )
+        if prefix == "C":
+            suffix = {"F": "S", "E": "X"}.get(normalized_serial[3], "")
+            return NativePackProfile(f"AB2000{suffix}", 1.92, "serial")
+        serial_profiles = {
+            "F": ("AB3000", 2.88),
+            "G": ("AB3000L", 2.88),
+            "J": ("I2400", 2.4),
+        }
+        if prefix in serial_profiles:
+            model, capacity = serial_profiles[prefix]
+            return NativePackProfile(model, capacity, "serial")
+
+    normalized_parent = "".join(
+        character for character in (parent_model or "").casefold()
+        if character.isalnum()
+    )
+    type_profiles = {
+        "70": ("I8000", 8.0),
+        "250": ("AB1000", 0.96),
+        "300": ("AB2000S / AB2000X", 1.92),
+        "500": ("I2400", 2.4),
+    }
+    if normalized_type == "5" and normalized_parent == "solarflow2400ac":
+        return NativePackProfile("AB3000X", 2.88, "pack_type_and_parent")
+    if normalized_type in type_profiles:
+        model, capacity = type_profiles[normalized_type]
+        return NativePackProfile(model, capacity, "pack_type")
+    return None
+
+
 def pack_capacity_kwh(serial: str | None, pack_type: str | None) -> float | None:
-    if not serial or len(serial) < 4:
-        return None
-    if serial[0] == "A":
-        return 2.4 if serial[3] == "3" else 0.96
-    if serial[0] == "B":
-        return 8.0 if str(pack_type) == "70" else 0.96
-    return {"C": 1.92, "F": 2.88, "G": 2.88, "J": 2.4}.get(serial[0])
+    profile = resolve_pack_profile(serial, pack_type)
+    return profile.capacity_kwh if profile is not None else None
 
 
 def native_capacity(state: NeutralDeviceState | None, expected_count: int | None = None) -> NativeCapacity:

--- a/custom_components/battery_smartflow_ai/native_device_overview.py
+++ b/custom_components/battery_smartflow_ai/native_device_overview.py
@@ -7,7 +7,7 @@ from datetime import datetime
 import hashlib
 from types import MappingProxyType
 from typing import Mapping
-from .native_capacity import native_capacity, pack_capacity_kwh
+from .native_capacity import native_capacity, pack_capacity_kwh, resolve_pack_profile
 from .native_statistics import derived_statistics
 from .zendure_device_matrix import resolve_zendure_device
 
@@ -99,7 +99,11 @@ def build_native_device_overview(
                     public_id=_public_id("PACK", pack_id),
                     parent_public_id=public_id,
                     serial_number=pack_identity.serial_number,
-                    pack_model=_pack_model(pack_identity.pack_type, device.model),
+                    pack_model=_pack_model(
+                        pack_identity.pack_type,
+                        device.model,
+                        pack_identity.serial_number or observed.serial_number,
+                    ),
                     firmware=observed.firmware,
                     measurements=MappingProxyType(
                         {
@@ -262,28 +266,20 @@ def _boolean_status(value):
     return _optional_value(("on" if value.value else "off") if value.valid else None)
 
 
-def _pack_model(value: str | None, parent_model: str | None) -> str | None:
+def _pack_model(
+    value: str | None,
+    parent_model: str | None,
+    serial_number: str | None = None,
+) -> str | None:
     """Resolve only verified pack models; never present a numeric code as one."""
 
     if value is None:
-        return None
+        profile = resolve_pack_profile(serial_number, None, parent_model)
+        return profile.model if profile is not None else None
     normalized = str(value).strip()
-    normalized_parent = "".join(
-        character for character in (parent_model or "").casefold()
-        if character.isalnum()
-    )
-    if normalized == "5" and normalized_parent == "solarflow2400ac":
-        return "AB3000X"
-    # Confirmed from multi-model field diagnostics in Discussion #456.  Type
-    # 300 is shared by AB2000S and AB2000X, so do not invent a distinction the
-    # native report does not provide.
-    confirmed_pack_types = {
-        "250": "AB1000",
-        "300": "AB2000S / AB2000X",
-        "500": "SF2400Pro internal battery",
-    }
-    if normalized in confirmed_pack_types:
-        return confirmed_pack_types[normalized]
+    profile = resolve_pack_profile(serial_number, normalized, parent_model)
+    if profile is not None:
+        return profile.model
     return normalized if normalized and not normalized.isdecimal() else None
 
 

--- a/custom_components/battery_smartflow_ai/sensor.py
+++ b/custom_components/battery_smartflow_ai/sensor.py
@@ -292,6 +292,7 @@ NATIVE_MAIN_SENSORS = (
         key="last_message", translation_key="native_hardware_last_message",
         source="last_message", device_class=SensorDeviceClass.TIMESTAMP,
         entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
     ),
 )
 
@@ -468,12 +469,14 @@ NATIVE_PACK_SENSORS = (
     NativeHardwareSensorDescription(
         key="fault_code", translation_key="native_hardware_fault_code",
         measurement_key="fault_code", entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
     ),
     NativeHardwareSensorDescription(
         key="protection_active",
         translation_key="native_hardware_protection_active",
         measurement_key="protection_active",
         entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
     ),
     NativeHardwareSensorDescription(
         key="firmware", translation_key="native_hardware_firmware",
@@ -483,6 +486,7 @@ NATIVE_PACK_SENSORS = (
         key="last_message", translation_key="native_hardware_last_message",
         source="last_message", device_class=SensorDeviceClass.TIMESTAMP,
         entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
     ),
 )
 
@@ -1683,6 +1687,7 @@ SENSORS += (
         device_class=SensorDeviceClass.TIMESTAMP,
         icon="mdi:clock-check-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
     ),
     ZendureSensorEntityDescription(
         key="native_zendure_last_capture",

--- a/tests/test_native_device_overview.py
+++ b/tests/test_native_device_overview.py
@@ -161,7 +161,7 @@ class NativeDeviceOverviewTests(unittest.TestCase):
         expected_models = {
             "250": "AB1000",
             "300": "AB2000S / AB2000X",
-            "500": "SF2400Pro internal battery",
+            "500": "I2400",
         }
         for pack_type, expected_model in expected_models.items():
             with self.subTest(pack_type=pack_type):

--- a/tests/test_native_pack_profiles.py
+++ b/tests/test_native_pack_profiles.py
@@ -1,0 +1,62 @@
+"""Verified native battery model and capacity resolution."""
+
+import unittest
+
+from support import bootstrap
+
+bootstrap()
+
+from custom_components.battery_smartflow_ai.native_capacity import (  # noqa: E402
+    pack_capacity_kwh,
+    resolve_pack_profile,
+)
+
+
+class NativePackProfileTests(unittest.TestCase):
+    def test_serial_profiles_resolve_model_and_capacity_together(self):
+        cases = {
+            ("A003-test", None): ("AIO2400", 2.4),
+            ("A000-test", None): ("AB1000", 0.96),
+            ("B000-test", None): ("AB1000S", 0.96),
+            ("B000-test", "70"): ("I8000", 8.0),
+            ("C00F-test", None): ("AB2000S", 1.92),
+            ("C00E-test", None): ("AB2000X", 1.92),
+            ("C00A-test", None): ("AB2000", 1.92),
+            ("F000-test", None): ("AB3000", 2.88),
+            ("G000-test", None): ("AB3000L", 2.88),
+            ("J02A-test", None): ("I2400", 2.4),
+        }
+        for (serial, pack_type), expected in cases.items():
+            with self.subTest(serial=serial, pack_type=pack_type):
+                profile = resolve_pack_profile(serial, pack_type)
+                self.assertIsNotNone(profile)
+                self.assertEqual((profile.model, profile.capacity_kwh), expected)
+                self.assertEqual(
+                    pack_capacity_kwh(serial, pack_type), expected[1]
+                )
+
+    def test_pack_type_fallback_handles_missing_or_short_serial(self):
+        cases = {
+            "70": ("I8000", 8.0),
+            "250": ("AB1000", 0.96),
+            "300": ("AB2000S / AB2000X", 1.92),
+            "500": ("I2400", 2.4),
+        }
+        for pack_type, expected in cases.items():
+            with self.subTest(pack_type=pack_type):
+                profile = resolve_pack_profile("", pack_type)
+                self.assertEqual((profile.model, profile.capacity_kwh), expected)
+
+        sf2400ac = resolve_pack_profile("", "5", "SolarFlow 2400 AC")
+        self.assertEqual(
+            (sf2400ac.model, sf2400ac.capacity_kwh), ("AB3000X", 2.88)
+        )
+
+    def test_unknown_or_ambiguous_evidence_does_not_guess(self):
+        self.assertIsNone(resolve_pack_profile(None, None))
+        self.assertIsNone(resolve_pack_profile("short", "999"))
+        self.assertIsNone(pack_capacity_kwh(None, "5"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_native_zendure_ha_integration.py
+++ b/tests/test_native_zendure_ha_integration.py
@@ -146,6 +146,31 @@ class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
             )
             self.assertEqual(precision, 2)
 
+    def test_high_frequency_and_optional_pack_diagnostics_default_disabled(self) -> None:
+        source = (COMPONENT / "sensor.py").read_text(encoding="utf-8")
+        self.assertEqual(
+            source.count(
+                'key="last_message", translation_key="native_hardware_last_message"'
+            ),
+            2,
+        )
+        self.assertGreaterEqual(
+            source.count("entity_registry_enabled_default=False"),
+            6,
+        )
+        pack_section = source.split("NATIVE_PACK_SENSORS = (", 1)[1].split(
+            "_SENSOR_DESCRIPTIONS", 1
+        )[0]
+        for key in ("fault_code", "protection_active", "last_message"):
+            start = pack_section.index(f'key="{key}"')
+            block = pack_section[start:start + 400]
+            self.assertIn("entity_registry_enabled_default=False", block)
+        global_last_message = source.index('key="native_zendure_last_message"')
+        self.assertIn(
+            "entity_registry_enabled_default=False",
+            source[global_last_message:global_last_message + 500],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- unify native battery model and nominal-capacity resolution in one conservative pack-profile resolver
- prefer the serial-number family when available and use field-confirmed `packType` values as safe fallbacks
- distinguish AB2000S and AB2000X when the serial number contains the known discriminator
- support AIO2400, AB1000, AB1000S, AB2000, AB2000S, AB2000X, AB3000, AB3000L, I2400, and I8000 profiles
- keep unknown or ambiguous packs unresolved instead of guessing
- default the high-frequency native last-reception timestamp sensors to disabled
- default pack-level fault code and protection sensors to disabled because current SF2400AC, SF800Pro, and SF2400Pro `packData` reports do not provide those values

## Recorder behavior

BSFAI continues to use the precise internal reception timestamp for freshness, offline detection, and command safety. Only the optional Home Assistant timestamp entities now default to disabled, avoiding a new Recorder row on every native update. Existing user-enabled entities are not forcibly changed.

## Field evidence

The serial-family mapping was recovered from the Zendure community battery identification logic posted in Discussion #456. The RC06 diagnostics also show that the tested ZenSDK pack payloads contain no pack-level `faultLevel` or protection field.

https://github.com/PalmManiac/battery-smartflow-ai/discussions/456#discussioncomment-18386602

## Validation

- dedicated pack-profile tests pass for serial families and `packType` fallbacks
- native device overview tests pass
- Home Assistant native entity contract tests pass
- 709 tests pass in complete local discovery
- 5 unrelated legacy test modules remain unavailable locally because optional development dependencies are missing (`tzdata`, `pytest`, `voluptuous`)
- Python compilation and `git diff --check` pass