### PR TITLE
Add native SolarFlow 800 Plus support

### DIFF
--- a/custom_components/battery_smartflow_ai/ac_mode_options.py
+++ b/custom_components/battery_smartflow_ai/ac_mode_options.py
@@ -1,0 +1,48 @@
+"""Resolve semantic AC directions to select options exposed by integrations."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+import re
+
+
+_ALIASES = {
+    "input": frozenset(("input", "inputmode", "acinputmode")),
+    "output": frozenset(("output", "outputmode", "acoutputmode")),
+}
+
+
+def _normalized(value: object) -> str:
+    """Return a comparison-only representation of one option."""
+
+    return re.sub(r"[^a-z0-9]+", "", str(value or "").casefold())
+
+
+def canonical_ac_mode(value: object) -> str | None:
+    """Return ``input`` or ``output`` for a recognized option label."""
+
+    normalized = _normalized(value)
+    for mode, aliases in _ALIASES.items():
+        if normalized in aliases:
+            return mode
+    return None
+
+
+def resolve_ac_mode_option(
+    requested_mode: object,
+    options: Iterable[object],
+) -> str | None:
+    """Resolve a direction to the exact select option, failing on ambiguity."""
+
+    requested = canonical_ac_mode(requested_mode)
+    if requested is None:
+        return None
+
+    matches = [
+        str(option)
+        for option in options
+        if canonical_ac_mode(option) == requested
+    ]
+    if len(matches) != 1:
+        return None
+    return matches[0]

--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -38,7 +38,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "5.0.0-rc06"
+INTEGRATION_VERSION = "5.0.0-rc07"
 
 # V5 native Zendure discovery is observation-only in the first development
 # build. The App Token is account discovery material and must never be copied

--- a/custom_components/battery_smartflow_ai/coordinator.py
+++ b/custom_components/battery_smartflow_ai/coordinator.py
@@ -12,6 +12,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
 
+from .ac_mode_options import canonical_ac_mode, resolve_ac_mode_option
 from .ai_status import map_ai_status
 from .const import (
     DOMAIN,
@@ -2180,14 +2181,30 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         - update the cache only after a successful call
         """
 
-        requested_mode = str(mode or "")
-        current_mode = str(
-            self._state(self.entities.ac_mode) or ""
-        )
+        requested_mode = canonical_ac_mode(mode)
+        if requested_mode is None:
+            raise ValueError(f"Unsupported AC mode: {mode!r}")
 
-        cached_mode = str(
-            self._persist.get("last_set_mode") or ""
+        entity_state = self.hass.states.get(self.entities.ac_mode)
+        current_raw = str(entity_state.state if entity_state is not None else "")
+        current_mode = canonical_ac_mode(current_raw) or current_raw
+
+        options = (
+            entity_state.attributes.get("options")
+            if entity_state is not None
+            else None
         )
+        service_option = requested_mode
+        if isinstance(options, (list, tuple)) and options:
+            service_option = resolve_ac_mode_option(requested_mode, options)
+            if service_option is None:
+                raise ValueError(
+                    "AC mode select does not expose one unambiguous "
+                    f"{requested_mode!r} option: {options!r}"
+                )
+
+        cached_raw = str(self._persist.get("last_set_mode") or "")
+        cached_mode = canonical_ac_mode(cached_raw) or cached_raw
 
         self._persist["mode_write_requested"] = requested_mode
         self._persist["mode_write_entity_state"] = current_mode
@@ -2226,7 +2243,7 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "select_option",
             {
                 "entity_id": self.entities.ac_mode,
-                "option": requested_mode,
+                "option": service_option,
             },
             blocking=True,
         )

--- a/custom_components/battery_smartflow_ai/device_profiles.py
+++ b/custom_components/battery_smartflow_ai/device_profiles.py
@@ -352,6 +352,15 @@ SF800PRO_PROFILE = {
 }
 
 
+# SolarFlow 800 Plus is a ZenSDK device with the same confirmed AC limits as
+# the SF800Pro (1,000 W input / 800 W output).  Reuse the conservative 800 W
+# controller tuning until model-specific field evidence calls for divergence.
+SF800PLUS_PROFILE = {
+    **SF800PRO_PROFILE,
+    "label": "Zendure SF800Plus",
+}
+
+
 SF800PRO2_PROFILE = {
     # --- UI ---
     "label": "Zendure SF800Pro2",
@@ -795,6 +804,7 @@ HUB2000_PROFILE = {
 
 
 DEVICE_PROFILES = {
+    "SF800Plus": SF800PLUS_PROFILE,
     "SF800Pro": SF800PRO_PROFILE,
     "SF800Pro2": SF800PRO2_PROFILE,
     "SF2400AC": SF2400AC_PROFILE,

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": ["paho-mqtt==2.1.0"],
-  "version": "5.0.0-rc06"
+  "version": "5.0.0-rc07"
 }

--- a/custom_components/battery_smartflow_ai/zendure_device_matrix.py
+++ b/custom_components/battery_smartflow_ai/zendure_device_matrix.py
@@ -348,6 +348,13 @@ ZENDURE_DEVICE_MATRIX: Mapping[str, ZendureDeviceMatrixEntry] = MappingProxyType
                 zensdk_verified=True,
             ),
             _entry(
+                "SF800Plus",
+                "SolarFlow 800 Plus",
+                "solarFlow800Plus",
+                "SF800Plus",
+                zensdk_verified=True,
+            ),
+            _entry(
                 "SF800Pro",
                 "SolarFlow 800 Pro",
                 "solarFlow800Pro",

--- a/tests/test_ac_mode_options.py
+++ b/tests/test_ac_mode_options.py
@@ -1,0 +1,39 @@
+"""Tests for Home Assistant AC-mode select compatibility."""
+
+from __future__ import annotations
+
+import unittest
+
+from support import bootstrap
+
+
+bootstrap()
+
+from custom_components.battery_smartflow_ai.ac_mode_options import (  # noqa: E402
+    canonical_ac_mode,
+    resolve_ac_mode_option,
+)
+
+
+class AcModeOptionTests(unittest.TestCase):
+    def test_official_zha_options_are_preserved(self):
+        self.assertEqual(
+            resolve_ac_mode_option("input", ("input", "output")),
+            "input",
+        )
+
+    def test_descriptive_options_are_resolved_to_exact_service_value(self):
+        self.assertEqual(
+            resolve_ac_mode_option("input", ("Input mode", "Output mode")),
+            "Input mode",
+        )
+        self.assertEqual(canonical_ac_mode("AC Output Mode"), "output")
+
+    def test_unknown_and_ambiguous_options_fail_closed(self):
+        self.assertIsNone(resolve_ac_mode_option("input", ("charge", "discharge")))
+        self.assertIsNone(resolve_ac_mode_option("input", ("input", "Input mode")))
+        self.assertIsNone(resolve_ac_mode_option("idle", ("input", "output")))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "5.0.0-rc06")
+        self.assertEqual(manifest_version, "5.0.0-rc07")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_device_profiles.py
+++ b/tests/test_device_profiles.py
@@ -97,6 +97,16 @@ class MixDeviceProfileTests(unittest.TestCase):
 
 
 class TypedDeviceProfileTests(unittest.TestCase):
+    def test_sf800plus_uses_confirmed_limits_and_conservative_800w_tuning(self):
+        plus = DEVICE_PROFILES["SF800Plus"]
+        pro = DEVICE_PROFILES["SF800Pro"]
+
+        self.assertEqual(plus["MAX_INPUT_W"], 1000.0)
+        self.assertEqual(plus["MAX_OUTPUT_W"], 800.0)
+        self.assertEqual(plus["CHARGE_KP_UP"], pro["CHARGE_KP_UP"])
+        self.assertEqual(plus["DISCHARGE_KP_DOWN"], pro["DISCHARGE_KP_DOWN"])
+        self.assertEqual(plus["label"], "Zendure SF800Plus")
+
     def test_every_typed_profile_rebuilds_the_legacy_mapping_exactly(self) -> None:
         self.assertEqual(set(DEVICE_PROFILE_MODELS), set(DEVICE_PROFILES))
 

--- a/tests/test_energy_forecast_config.py
+++ b/tests/test_energy_forecast_config.py
@@ -51,8 +51,8 @@ class EnergyForecastConfigTests(unittest.TestCase):
     def test_rc_version_is_consistent(self):
         const = (COMPONENT / "const.py").read_text(encoding="utf-8")
         manifest = (COMPONENT / "manifest.json").read_text(encoding="utf-8")
-        self.assertIn('INTEGRATION_VERSION = "5.0.0-rc06"', const)
-        self.assertIn('"version": "5.0.0-rc06"', manifest)
+        self.assertIn('INTEGRATION_VERSION = "5.0.0-rc07"', const)
+        self.assertIn('"version": "5.0.0-rc07"', manifest)
         self.assertIn('"after_dependencies": ["energy"]', manifest)
         self.assertLess(
             manifest.index('"after_dependencies"'), manifest.index('"codeowners"')

--- a/tests/test_native_zendure_ha_integration.py
+++ b/tests/test_native_zendure_ha_integration.py
@@ -17,7 +17,7 @@ class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
         manifest = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )
-        self.assertEqual(manifest["version"], "5.0.0-rc06")
+        self.assertEqual(manifest["version"], "5.0.0-rc07")
         self.assertIn("paho-mqtt==2.1.0", manifest["requirements"])
 
     def test_options_flow_uses_a_password_field_and_never_suggests_token(self) -> None:

--- a/tests/test_zendure_device_matrix.py
+++ b/tests/test_zendure_device_matrix.py
@@ -47,6 +47,7 @@ class ZendureDeviceMatrixTests(unittest.TestCase):
                 "SF2400AC",
                 "SF2400Pro",
                 "SF2400AC+",
+                "SF800Plus",
                 "SF800Pro",
                 "SF800Pro2",
             )
@@ -69,6 +70,7 @@ class ZendureDeviceMatrixTests(unittest.TestCase):
             "SF2400AC": "SolarFlow 2400 AC",
             "SF2400Pro": "SolarFlow 2400 Pro",
             "SF2400AC+": "SolarFlow 2400 AC+",
+            "SF800Plus": "SolarFlow 800 Plus",
             "SF800Pro": "SolarFlow 800 Pro",
             "SF800Pro2": "SolarFlow 800 Pro 2",
         }

--- a/tests/test_zendure_zensdk.py
+++ b/tests/test_zendure_zensdk.py
@@ -115,6 +115,7 @@ class ZenSdkReadTests(unittest.IsolatedAsyncioTestCase):
         verified_models = (
             ("SolarFlow 2400 Pro", "unknown-product"),
             ("SolarFlow 2400 AC+", "unknown-product"),
+            ("SolarFlow 800 Plus", "unknown-product"),
             ("SolarFlow 800 Pro", "R3mn8U"),
             ("SolarFlow 800 Pro 2", "unknown-product"),
         )


### PR DESCRIPTION
## Summary

- add SolarFlow 800 Plus as an explicitly supported native ZenSDK device
- apply the confirmed 1,000 W AC-input and 800 W AC-output safety limits
- resolve both official `input`/`output` and descriptive `Input mode`/`Output mode` values in the legacy Z-HA select path
- prepare version `5.0.0-rc07` in both manifest and runtime constants

## Validation

- targeted profile, device-matrix, ZenSDK, AC-mode, packaging, and integration tests pass
- 723 tests execute successfully in the full unittest run
- 4 unrelated test modules cannot load locally because optional `pytest`/`voluptuous` packages are not installed
- `git diff --check` and Python compilation pass

Closes #430