### PR TITLE
Stabilize PV passthrough and modernize device links

### DIFF
--- a/custom_components/battery_smartflow_ai/automatic_strategy.py
+++ b/custom_components/battery_smartflow_ai/automatic_strategy.py
@@ -58,6 +58,23 @@ def forecast_supports_early_pv_passthrough(
     return float(remaining_today_kwh or 0.0) > free_capacity_kwh + 0.25
 
 
+def forecast_blocks_pv_passthrough_start(
+    *,
+    mppt_clips_without_output: bool,
+    already_active: bool,
+    battery_near_full: bool,
+    forecast_surplus_expected: bool,
+) -> bool:
+    """Use the forecast threshold only to gate a new passthrough phase."""
+
+    return bool(
+        mppt_clips_without_output
+        and not already_active
+        and not battery_near_full
+        and not forecast_surplus_expected
+    )
+
+
 def maintain_active_economic_discharge(
     *,
     automatic_mode_active: bool,

--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -38,7 +38,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "5.0.0-rc08"
+INTEGRATION_VERSION = "5.0.0-rc09"
 
 # V5 native Zendure discovery is observation-only in the first development
 # build. The App Token is account discovery material and must never be copied

--- a/custom_components/battery_smartflow_ai/coordinator.py
+++ b/custom_components/battery_smartflow_ai/coordinator.py
@@ -166,6 +166,7 @@ from .economics import (
 from .automatic_strategy import (
     AutomaticStrategy,
     economic_discharge_continuation_reason,
+    forecast_blocks_pv_passthrough_start,
     forecast_supports_early_pv_passthrough,
     maintain_active_economic_discharge,
 )
@@ -3410,11 +3411,18 @@ class ZendureSmartFlowCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 )
                 stop_reason = "full_battery_pv_passthrough"
 
-            elif (
-                mppt_clips_without_output
-                and not battery_near_full
-                and not forecast_surplus_expected
+            elif forecast_blocks_pv_passthrough_start(
+                mppt_clips_without_output=mppt_clips_without_output,
+                already_active=active,
+                battery_near_full=battery_near_full,
+                forecast_surplus_expected=forecast_surplus_expected,
             ):
+                # The forecast threshold is a start gate, not an exit signal.
+                # Remaining forecast and battery headroom converge while PV is
+                # charging, so using the same threshold to stop an already
+                # active passthrough created repeated five-minute mode cycles.
+                # Once active, the explicit PV/load/export/protection exits
+                # below provide the required release hysteresis.
                 active = False
                 export_counter = 0
                 target_w = 0.0

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": ["bleak-retry-connector>=3.9.0", "paho-mqtt==2.1.0"],
-  "version": "5.0.0-rc08"
+  "version": "5.0.0-rc09"
 }

--- a/custom_components/battery_smartflow_ai/sensor.py
+++ b/custom_components/battery_smartflow_ai/sensor.py
@@ -21,6 +21,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.helpers.entity import DeviceInfo
@@ -1711,15 +1712,28 @@ async def async_setup_entry(
     entry: ConfigEntry,
     add_entities: AddEntitiesCallback,
 ) -> None:
-    registry = er.async_get(hass)
+    entity_registry = er.async_get(hass)
     for key in RETIRED_DIAGNOSTIC_SENSOR_KEYS:
         unique_id = f"{DOMAIN}_{entry.entry_id}_{key}"
-        entity_id = registry.async_get_entity_id("sensor", DOMAIN, unique_id)
+        entity_id = entity_registry.async_get_entity_id("sensor", DOMAIN, unique_id)
         if entity_id is not None:
-            registry.async_remove(entity_id)
+            entity_registry.async_remove(entity_id)
 
     coordinator = hass.data[DOMAIN][entry.entry_id]
-    entities = [ZendureSmartFlowSensor(entry, coordinator, d) for d in SENSORS]
+    device_registry = dr.async_get(hass)
+    control_device = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, entry.entry_id)},
+    )
+    entities = [
+        ZendureSmartFlowSensor(
+            entry,
+            coordinator,
+            description,
+            control_device_id=control_device.id,
+        )
+        for description in SENSORS
+    ]
     add_entities(entities)
 
     known_native_entities: set[tuple[str, str, str]] = set()
@@ -1727,6 +1741,17 @@ async def async_setup_entry(
     def add_discovered_native_entities() -> None:
         discovered = []
         for system in coordinator.native_zendure.hardware_overview():
+            firmware = _measured_value(getattr(system, "firmware", None))
+            main_device = device_registry.async_get_or_create(
+                config_entry_id=entry.entry_id,
+                identifiers={native_main_device_identifier(system.public_id)},
+                name=native_device_name(system.display_name, system.model),
+                manufacturer="Zendure",
+                model=system.model or "Unknown Zendure system",
+                serial_number=system.serial_number,
+                sw_version=str(firmware) if firmware is not None else None,
+                via_device_id=control_device.id,
+            )
             for description in NATIVE_MAIN_SENSORS:
                 key = ("main", system.public_id, description.key)
                 if key not in known_native_entities:
@@ -1737,6 +1762,7 @@ async def async_setup_entry(
                         kind="main",
                         public_id=system.public_id,
                         parent_public_id=None,
+                        parent_device_id=control_device.id,
                         description=description,
                     ))
             for pack in system.packs:
@@ -1750,6 +1776,7 @@ async def async_setup_entry(
                             kind="pack",
                             public_id=pack.public_id,
                             parent_public_id=system.public_id,
+                            parent_device_id=main_device.id,
                             description=description,
                         ))
         if discovered:
@@ -1774,6 +1801,7 @@ class NativeZendureHardwareSensor(CoordinatorEntity, SensorEntity):
         kind: str,
         public_id: str,
         parent_public_id: str | None,
+        parent_device_id: str,
         description: NativeHardwareSensorDescription,
     ) -> None:
         super().__init__(coordinator)
@@ -1801,7 +1829,7 @@ class NativeZendureHardwareSensor(CoordinatorEntity, SensorEntity):
                 model=(item.model or "Unknown Zendure system") if item else None,
                 serial_number=item.serial_number if item else None,
                 sw_version=str(firmware) if firmware is not None else None,
-                via_device=(DOMAIN, entry.entry_id),
+                via_device_id=parent_device_id,
             )
         else:
             firmware = _measured_value(getattr(item, "firmware", None))
@@ -1829,7 +1857,7 @@ class NativeZendureHardwareSensor(CoordinatorEntity, SensorEntity):
                 model=(item.pack_model or "Unknown battery pack") if item else None,
                 serial_number=item.serial_number if item else None,
                 sw_version=str(firmware) if firmware is not None else None,
-                via_device=native_main_device_identifier(parent_public_id),
+                via_device_id=parent_device_id,
             )
 
     def _parent_system(self):
@@ -1964,7 +1992,14 @@ def _battery_pack_label(language: str | None) -> str:
 class ZendureSmartFlowSensor(CoordinatorEntity, SensorEntity):
     _attr_has_entity_name = True
 
-    def __init__(self, entry, coordinator, description):
+    def __init__(
+        self,
+        entry,
+        coordinator,
+        description,
+        *,
+        control_device_id: str,
+    ):
         super().__init__(coordinator)
         self.entity_description = description
         self._entry = entry
@@ -1990,7 +2025,7 @@ class ZendureSmartFlowSensor(CoordinatorEntity, SensorEntity):
                 manufacturer=INTEGRATION_MANUFACTURER,
                 model=virtual_device_model(coordinator.hass.config.language),
                 sw_version=INTEGRATION_VERSION,
-                via_device=(DOMAIN, entry.entry_id),
+                via_device_id=control_device_id,
             )
         else:
             self._attr_device_info = DeviceInfo(

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "5.0.0-rc08")
+        self.assertEqual(manifest_version, "5.0.0-rc09")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_economics_sensor_structure.py
+++ b/tests/test_economics_sensor_structure.py
@@ -84,7 +84,7 @@ def test_all_new_economics_sensors_use_the_virtual_device() -> None:
     source = SENSOR_PATH.read_text(encoding="utf-8")
     assert 'translation_key="economics_and_prices"' in source
     assert "model=virtual_device_model(coordinator.hass.config.language)" in source
-    assert 'via_device=(DOMAIN, entry.entry_id)' in source
+    assert "via_device_id=control_device_id" in source
     assert 'identifiers={(DOMAIN, f"{entry.entry_id}_economics")}' in source
 
 

--- a/tests/test_energy_forecast_config.py
+++ b/tests/test_energy_forecast_config.py
@@ -51,8 +51,8 @@ class EnergyForecastConfigTests(unittest.TestCase):
     def test_rc_version_is_consistent(self):
         const = (COMPONENT / "const.py").read_text(encoding="utf-8")
         manifest = (COMPONENT / "manifest.json").read_text(encoding="utf-8")
-        self.assertIn('INTEGRATION_VERSION = "5.0.0-rc08"', const)
-        self.assertIn('"version": "5.0.0-rc08"', manifest)
+        self.assertIn('INTEGRATION_VERSION = "5.0.0-rc09"', const)
+        self.assertIn('"version": "5.0.0-rc09"', manifest)
         self.assertIn('"after_dependencies": ["energy"]', manifest)
         self.assertLess(
             manifest.index('"after_dependencies"'), manifest.index('"codeowners"')

--- a/tests/test_native_zendure_ha_integration.py
+++ b/tests/test_native_zendure_ha_integration.py
@@ -17,7 +17,7 @@ class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
         manifest = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )
-        self.assertEqual(manifest["version"], "5.0.0-rc08")
+        self.assertEqual(manifest["version"], "5.0.0-rc09")
         self.assertIn("paho-mqtt==2.1.0", manifest["requirements"])
 
     def test_options_flow_uses_a_password_field_and_never_suggests_token(self) -> None:
@@ -93,9 +93,8 @@ class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
         )
         config = (COMPONENT / "config_flow.py").read_text(encoding="utf-8")
         self.assertIn("class NativeZendureHardwareSensor", sensor)
-        self.assertIn(
-            "via_device=native_main_device_identifier(parent_public_id)", sensor
-        )
+        self.assertIn("via_device_id=parent_device_id", sensor)
+        self.assertNotIn("via_device=native_main_device_identifier", sensor)
         self.assertIn('return DOMAIN, f"native_zendure_{public_id}"', identity)
         self.assertIn("coordinator.native_zendure.hardware_overview()", sensor)
         self.assertIn("coordinator.async_add_listener", sensor)

--- a/tests/test_passthrough_forecast_hysteresis.py
+++ b/tests/test_passthrough_forecast_hysteresis.py
@@ -1,0 +1,49 @@
+"""Regression coverage for stable SF800Pro PV passthrough."""
+
+from __future__ import annotations
+
+import unittest
+
+from support import bootstrap
+
+bootstrap()
+
+from custom_components.battery_smartflow_ai.automatic_strategy import (  # noqa: E402
+    forecast_blocks_pv_passthrough_start,
+)
+
+
+class PassthroughForecastHysteresisTests(unittest.TestCase):
+    def test_active_passthrough_survives_forecast_start_threshold(self):
+        self.assertFalse(
+            forecast_blocks_pv_passthrough_start(
+                mppt_clips_without_output=True,
+                already_active=True,
+                battery_near_full=False,
+                forecast_surplus_expected=False,
+            )
+        )
+
+    def test_forecast_threshold_still_blocks_new_passthrough(self):
+        self.assertTrue(
+            forecast_blocks_pv_passthrough_start(
+                mppt_clips_without_output=True,
+                already_active=False,
+                battery_near_full=False,
+                forecast_surplus_expected=False,
+            )
+        )
+
+    def test_near_full_passthrough_is_not_blocked_by_forecast(self):
+        self.assertFalse(
+            forecast_blocks_pv_passthrough_start(
+                mppt_clips_without_output=True,
+                already_active=False,
+                battery_near_full=True,
+                forecast_surplus_expected=False,
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_v470_backward_compatibility.py
+++ b/tests/test_v470_backward_compatibility.py
@@ -179,7 +179,7 @@ class EntityRegistryCompatibilityTests(unittest.TestCase):
             self.assertIn("(DOMAIN, entry.entry_id)", source)
 
         self.assertIn('identifiers={(DOMAIN, f"{entry.entry_id}_economics")}', sensor)
-        self.assertIn("via_device=(DOMAIN, entry.entry_id)", sensor)
+        self.assertIn("via_device_id=control_device_id", sensor)
 
 
 bootstrap()


### PR DESCRIPTION
## Summary

- keep an active SF800Pro PV passthrough stable when forecast headroom crosses its start threshold
- retain the existing PV, load, export and protection exits and the immediate near-full passthrough path
- replace deprecated Home Assistant `via_device` relationships with registered `via_device_id` links for virtual devices, Zendure systems and battery packs
- prepare `5.0.0-rc09`

## Field evidence

Discussion #456 showed repeated five-minute passthrough cycles while remaining PV forecast and battery headroom converged. The same logs confirmed that the continuous near-full passthrough was correct.

## Validation

- 85 focused regulation, profile, translation, upgrade and device-registry regression tests
- dedicated passthrough forecast-hysteresis tests
- Python compile, JSON and clean-diff checks

Refs #79