### PR TITLE
Fix Cloud communication for native Zendure devices

### DIFF
--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -38,7 +38,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "5.0.0-rc10"
+INTEGRATION_VERSION = "5.0.0-rc11"
 
 # V5 native Zendure discovery is observation-only in the first development
 # build. The App Token is account discovery material and must never be copied

--- a/custom_components/battery_smartflow_ai/debug_exporter.py
+++ b/custom_components/battery_smartflow_ai/debug_exporter.py
@@ -103,14 +103,28 @@ def _anonymize_entity_ids(value):
     """
 
     aliases: dict[str, str] = {}
+    native_devices: dict[str, str] = {}
 
-    def anonymize(item):
+    def anonymize(item, *, key: str | None = None):
         if isinstance(item, dict):
-            return {key: anonymize(child) for key, child in item.items()}
+            return {
+                child_key: anonymize(child, key=child_key)
+                for child_key, child in item.items()
+            }
         if isinstance(item, list):
             return [anonymize(child) for child in item]
         if not isinstance(item, str):
             return item
+
+        if key == "native_zendure_selected_device":
+            transport, separator, device = item.partition(":")
+            if not separator:
+                transport, device = "native", item
+            if device not in native_devices:
+                native_devices[device] = (
+                    f"debug_device_{len(native_devices) + 1:02d}"
+                )
+            return f"{transport}:{native_devices[device]}"
 
         match = _ENTITY_ID_PATTERN.fullmatch(item)
         if match is None or match.group(1) not in _ENTITY_DOMAINS:

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": ["bleak-retry-connector>=3.9.0", "paho-mqtt==2.1.0"],
-  "version": "5.0.0-rc10"
+  "version": "5.0.0-rc11"
 }

--- a/custom_components/battery_smartflow_ai/native_zendure_runtime.py
+++ b/custom_components/battery_smartflow_ai/native_zendure_runtime.py
@@ -973,7 +973,12 @@ class NativeZendureRuntime:
                 self._get_json,
             )
             self._record_zensdk_cycle(zensdk)
-            self._transport = ZendureCloudMqttTransport(bootstrap)
+            self._transport = ZendureCloudMqttTransport(
+                bootstrap,
+                use_assigned_client_id=(
+                    self._configured_transport is ZendureTransport.CLOUD_MQTT
+                ),
+            )
             if self._local_mqtt_credentials is not None:
                 candidate = ZendureLocalMqttTransport(
                     bootstrap, self._local_mqtt_credentials
@@ -994,6 +999,14 @@ class NativeZendureRuntime:
                 self._transport,
                 initial_messages=zensdk.messages,
                 zensdk_attempts=zensdk.attempts,
+                completion_transport=(
+                    self._configured_transport.value
+                    if self._configured_transport in {
+                        ZendureTransport.CLOUD_MQTT,
+                        ZendureTransport.ZENSDK,
+                    }
+                    else None
+                ),
             )
             self._capture_complete = capture.complete
             self._capture_reason = capture.completion_reason

--- a/custom_components/battery_smartflow_ai/zendure_cloud_mqtt.py
+++ b/custom_components/battery_smartflow_ai/zendure_cloud_mqtt.py
@@ -140,9 +140,14 @@ class ZendureCloudMqttTransport:
         clock: Callable[[], datetime] | None = None,
         reconnect_delays: tuple[float, ...] = (1.0, 2.0, 5.0, 15.0, 30.0),
         max_messages: int = _MAX_RETAINED_MESSAGES,
+        use_assigned_client_id: bool = True,
     ) -> None:
         self._bootstrap = bootstrap
-        self._session_factory = session_factory or PahoReadOnlyMqttSession
+        self._session_factory = session_factory or (
+            PahoZendureCloudMqttSession
+            if use_assigned_client_id
+            else PahoReadOnlyMqttSession
+        )
         self._clock = clock or (lambda: datetime.now(timezone.utc))
         self._reconnect_delays = reconnect_delays
         self._messages: deque[CloudMqttMessage] = deque(maxlen=max_messages)
@@ -609,7 +614,7 @@ class PahoReadOnlyMqttSession:
         self._connect_packet_sent = False
         self._client = mqtt.Client(
             mqtt.CallbackAPIVersion.VERSION2,
-            client_id=_bsfai_client_id(credentials.client_id),
+            client_id=self._client_id(credentials),
             clean_session=False,
             protocol=mqtt.MQTTv31,
         )
@@ -619,6 +624,12 @@ class PahoReadOnlyMqttSession:
         self._on_connect: ConnectCallback | None = None
         self._on_disconnect: DisconnectCallback | None = None
         self._on_message: MessageCallback | None = None
+
+    @staticmethod
+    def _client_id(credentials: CloudMqttCredentials) -> str:
+        """Use a private identity for non-Zendure MQTT sessions."""
+
+        return _bsfai_client_id(credentials.client_id)
 
     @property
     def connection_phase(self) -> str:
@@ -791,6 +802,19 @@ def _bsfai_client_id(cloud_client_id: str) -> str:
 
     digest = hashlib.sha256(cloud_client_id.encode("utf-8")).hexdigest()[:16]
     return f"bsfai-{digest}"
+
+
+class PahoZendureCloudMqttSession(PahoReadOnlyMqttSession):
+    """Cloud session using the client identity assigned by Zendure.
+
+    Zendure accepts authentication with another client ID but does not route
+    device traffic to that session. Its assigned ID is therefore part of the
+    Cloud MQTT credentials, just like username and password.
+    """
+
+    @staticmethod
+    def _client_id(credentials: CloudMqttCredentials) -> str:
+        return credentials.client_id
 
 
 def _get_all_request(

--- a/custom_components/battery_smartflow_ai/zendure_initial_sync.py
+++ b/custom_components/battery_smartflow_ai/zendure_initial_sync.py
@@ -120,6 +120,7 @@ class ZendureInitialSyncRecorder:
         monotonic: Callable[[], float] = time.monotonic,
         initial_messages: tuple[CloudMqttMessage, ...] = (),
         zensdk_attempts: tuple[ZenSdkReadAttempt, ...] = (),
+        completion_transport: str | None = None,
     ) -> None:
         if quiet_period <= 0 or hard_timeout <= quiet_period:
             raise ValueError("hard_timeout must be greater than quiet_period")
@@ -134,6 +135,11 @@ class ZendureInitialSyncRecorder:
         self._seen_topics: set[str] = set()
         self._seen_properties: set[str] = set()
         self._seen_devices: set[str] = set()
+        self._completion_transport = completion_transport
+        self._completion_seen_devices: set[str] = set()
+        self._completion_seen_topics: set[str] = set()
+        self._completion_seen_properties: set[str] = set()
+        self._completion_last_novel = self._started_monotonic
         self._messages: list[CloudMqttMessage] = []
         self._zensdk_attempts = zensdk_attempts
         self._connection_events: list[dict[str, Any]] = []
@@ -179,10 +185,25 @@ class ZendureInitialSyncRecorder:
         if properties - self._seen_properties:
             novel = True
         self._seen_properties.update(properties)
+        completion_message = (
+            self._completion_transport is None
+            or message.transport == self._completion_transport
+        )
+        completion_novel = False
+        if completion_message:
+            completion_novel = message.topic not in self._completion_seen_topics
+            self._completion_seen_topics.add(message.topic)
+            if properties - self._completion_seen_properties:
+                completion_novel = True
+            self._completion_seen_properties.update(properties)
         if message.device_candidate_id is not None:
             self._seen_devices.add(message.device_candidate_id)
+            if completion_message:
+                self._completion_seen_devices.add(message.device_candidate_id)
         if novel:
             self._last_novel = self._monotonic()
+        if completion_novel:
+            self._completion_last_novel = self._monotonic()
 
     def completion(self) -> tuple[bool, str] | None:
         now = self._monotonic()
@@ -190,8 +211,11 @@ class ZendureInitialSyncRecorder:
             return False, "hard_timeout"
         all_devices_seen = bool(self._expected_devices) and set(
             self._expected_devices
-        ).issubset(self._seen_devices)
-        if all_devices_seen and now - self._last_novel >= self._quiet_period:
+        ).issubset(self._completion_seen_devices)
+        if (
+            all_devices_seen
+            and now - self._completion_last_novel >= self._quiet_period
+        ):
             return True, "initial_sync_quiet"
         return None
 
@@ -225,6 +249,7 @@ async def async_capture_initial_sync(
     monotonic: Callable[[], float] = time.monotonic,
     initial_messages: tuple[CloudMqttMessage, ...] = (),
     zensdk_attempts: tuple[ZenSdkReadAttempt, ...] = (),
+    completion_transport: str | None = None,
 ) -> InitialSyncCaptureResult:
     """Capture discovery and MQTT startup until structural traffic is quiet."""
 
@@ -236,6 +261,7 @@ async def async_capture_initial_sync(
         monotonic=monotonic,
         initial_messages=initial_messages,
         zensdk_attempts=zensdk_attempts,
+        completion_transport=completion_transport,
     )
     cursor = 0
     def observe_transport() -> None:

--- a/tests/test_debug_exporter.py
+++ b/tests/test_debug_exporter.py
@@ -95,6 +95,29 @@ class DebugExporterTests(unittest.TestCase):
         self.assertEqual(entities["price_copy"], entities["price"])
         self.assertEqual(entities["mode"], "select.debug_entity_02")
 
+    def test_export_anonymizes_selected_native_zendure_device(self) -> None:
+        package = self.package()
+        package.config = {
+            "runtime_settings": {
+                "native_zendure_selected_device": "cloud_mqtt:private-device-key"
+            }
+        }
+
+        result = export_debug_package(
+            package,
+            config_directory=self.config_directory,
+        )
+        text = result.path.read_text(encoding="utf-8")
+        data = json.loads(text)
+
+        self.assertNotIn("private-device-key", text)
+        self.assertEqual(
+            data["config"]["runtime_settings"][
+                "native_zendure_selected_device"
+            ],
+            "cloud_mqtt:debug_device_01",
+        )
+
     def test_filename_does_not_repeat_untrusted_version_text(self) -> None:
         result = export_debug_package(
             self.package(version="../4.4.0 test"),

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "5.0.0-rc10")
+        self.assertEqual(manifest_version, "5.0.0-rc11")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_energy_forecast_config.py
+++ b/tests/test_energy_forecast_config.py
@@ -51,8 +51,8 @@ class EnergyForecastConfigTests(unittest.TestCase):
     def test_rc_version_is_consistent(self):
         const = (COMPONENT / "const.py").read_text(encoding="utf-8")
         manifest = (COMPONENT / "manifest.json").read_text(encoding="utf-8")
-        self.assertIn('INTEGRATION_VERSION = "5.0.0-rc10"', const)
-        self.assertIn('"version": "5.0.0-rc10"', manifest)
+        self.assertIn('INTEGRATION_VERSION = "5.0.0-rc11"', const)
+        self.assertIn('"version": "5.0.0-rc11"', manifest)
         self.assertIn('"after_dependencies": ["energy"]', manifest)
         self.assertLess(
             manifest.index('"after_dependencies"'), manifest.index('"codeowners"')

--- a/tests/test_native_zendure_ha_integration.py
+++ b/tests/test_native_zendure_ha_integration.py
@@ -17,7 +17,7 @@ class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
         manifest = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )
-        self.assertEqual(manifest["version"], "5.0.0-rc10")
+        self.assertEqual(manifest["version"], "5.0.0-rc11")
         self.assertIn("paho-mqtt==2.1.0", manifest["requirements"])
 
     def test_options_flow_uses_a_password_field_and_never_suggests_token(self) -> None:

--- a/tests/test_zendure_cloud_mqtt.py
+++ b/tests/test_zendure_cloud_mqtt.py
@@ -15,6 +15,8 @@ from custom_components.battery_smartflow_ai.zendure_cloud import ZendureCloudCli
 from custom_components.battery_smartflow_ai.zendure_cloud_mqtt import (
     CloudMqttError,
     ConnectionState,
+    PahoReadOnlyMqttSession,
+    PahoZendureCloudMqttSession,
     ZendureCloudMqttTransport,
     _bsfai_client_id,
     _get_all_request,
@@ -93,6 +95,16 @@ class CloudMqttTransportTests(unittest.IsolatedAsyncioTestCase):
         session = FakeSession(credentials)
         self.sessions.append(session)
         return session
+
+    async def test_assigned_identity_is_limited_to_selected_cloud_mode(self):
+        cloud = ZendureCloudMqttTransport(self.data)
+        observer = ZendureCloudMqttTransport(
+            self.data,
+            use_assigned_client_id=False,
+        )
+
+        self.assertIs(cloud._session_factory, PahoZendureCloudMqttSession)
+        self.assertIs(observer._session_factory, PahoReadOnlyMqttSession)
 
     async def test_connects_and_subscribes_all_devices(self):
         transport = ZendureCloudMqttTransport(
@@ -365,6 +377,20 @@ class CloudMqttTransportTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotEqual(
             first,
             _bsfai_client_id("another-zendure-cloud-client"),
+        )
+
+    def test_zendure_cloud_uses_the_assigned_client_identity(self):
+        credentials = type(
+            "Credentials", (), {"client_id": "zendure-assigned-client"}
+        )()
+
+        self.assertEqual(
+            PahoZendureCloudMqttSession._client_id(credentials),
+            "zendure-assigned-client",
+        )
+        self.assertNotEqual(
+            PahoReadOnlyMqttSession._client_id(credentials),
+            "zendure-assigned-client",
         )
 
     def test_get_all_request_has_no_arbitrary_write_surface(self):

--- a/tests/test_zendure_initial_sync.py
+++ b/tests/test_zendure_initial_sync.py
@@ -92,6 +92,7 @@ def message(
     pack: str | None = None,
     payload_format: str = "json",
     raw: bytes | None = None,
+    transport: str = "cloud_mqtt",
 ):
     return CloudMqttMessage(
         received_at=at,
@@ -103,6 +104,7 @@ def message(
         pack_id=pack,
         known_topic=True,
         session_number=1,
+        transport=transport,
     )
 
 
@@ -213,6 +215,48 @@ class InitialSyncCaptureTests(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(result.complete)
         self.assertEqual(result.completion_reason, "hard_timeout")
         self.assertEqual(len(result.messages), 1)
+
+    async def test_cloud_completion_ignores_successful_zensdk_fallback(self):
+        recorder = self.recorder(
+            completion_transport="cloud_mqtt",
+            initial_messages=(
+                message(
+                    self.time.clock(),
+                    "cloud_mqtt:real-device-1",
+                    "real-device-1",
+                    {"properties": {"socLevel": 60}},
+                    transport="zensdk",
+                ),
+                message(
+                    self.time.clock(),
+                    "cloud_mqtt:real-device-2",
+                    "real-device-2",
+                    {"properties": {"socLevel": 50}},
+                    transport="zensdk",
+                ),
+            ),
+        )
+        self.time.advance(3)
+        self.assertIsNone(recorder.completion())
+
+        recorder.observe_message(
+            message(
+                self.time.clock(),
+                "cloud_mqtt:real-device-1",
+                "real-device-1",
+                {"properties": {"socLevel": 60}},
+            )
+        )
+        recorder.observe_message(
+            message(
+                self.time.clock(),
+                "cloud_mqtt:real-device-2",
+                "real-device-2",
+                {"properties": {"socLevel": 50}},
+            )
+        )
+        self.time.advance(2.1)
+        self.assertEqual(recorder.completion(), (True, "initial_sync_quiet"))
 
     async def test_export_has_raw_and_summary_with_complete_nested_properties(self):
         recorder = self.recorder()


### PR DESCRIPTION
The RC10 Cloud selector connected to Zendure's broker but received no device traffic because BSFAI replaced the account-assigned MQTT client ID with a private coexistence ID. Zendure accepts that session but routes device traffic only to the assigned identity.

This change uses Zendure's assigned client ID only when Cloud is explicitly selected. ZenSDK and Local operation keep BSFAI's separate observer identity, so passive Cloud observation cannot displace Z-HA. Initial sync now completes only from the selected Cloud or ZenSDK transport, and the general debug export anonymizes the selected native device key.

Because Zendure assigns one Cloud MQTT client identity per account, Z-HA and BSFAI cannot use that same Cloud session concurrently. Disable Z-HA while validating or operating BSFAI in Cloud mode.

Validation:
- 24 Cloud MQTT transport tests
- 16 initial-sync tests
- 32 native power-controller tests
- 10 source-fusion tests
- 5 Local MQTT tests
- 4 ZendureLegacy tests
- 11 Home Assistant integration tests
- 9 debug-export tests
- 6 debug integration-contract tests
- 5 energy forecast configuration tests
- 10 translation tests
- Python compile and `git diff --check`
- Full discovery: 726 tests passed; five unrelated modules could not import locally because `tzdata`, `pytest`, or `voluptuous` are unavailable in the local test runtime