### PR TITLE
Restore Cloud telemetry after Zendure error snapshots

### DIFF
--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -38,7 +38,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "5.0.0-rc11"
+INTEGRATION_VERSION = "5.0.0-rc12"
 
 # V5 native Zendure discovery is observation-only in the first development
 # build. The App Token is account discovery material and must never be copied

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": ["bleak-retry-connector>=3.9.0", "paho-mqtt==2.1.0"],
-  "version": "5.0.0-rc11"
+  "version": "5.0.0-rc12"
 }

--- a/custom_components/battery_smartflow_ai/zendure_normalizer.py
+++ b/custom_components/battery_smartflow_ai/zendure_normalizer.py
@@ -354,6 +354,12 @@ class ZendureCloudNormalizer:
         )
         payload = message.parsed_payload
         if isinstance(payload, Mapping):
+            self._apply_error_event(
+                self._device_values[system_id],
+                message.topic,
+                payload,
+                observed_at,
+            )
             properties = payload.get("properties")
             if isinstance(properties, Mapping):
                 self._apply_properties(
@@ -370,6 +376,35 @@ class ZendureCloudNormalizer:
         ):
             self._hems_activity[system_id].observe_energy(observed_at=observed_at)
         return self.snapshot(system_id, now=now or observed_at)
+
+    @staticmethod
+    def _apply_error_event(
+        values: dict[str, _Observed],
+        topic: str,
+        payload: Mapping[str, Any],
+        observed_at: datetime,
+    ) -> None:
+        """Translate the Cloud error snapshot into the explicit error flag.
+
+        ZenSDK-class devices may report a non-zero ``faultLevel`` during
+        healthy operation.  Cloud MQTT supplies the authoritative current
+        error state separately through ``event/error``: an empty data list
+        with ``offData=0`` means that no error is active.
+        """
+
+        if not topic.endswith("/event/error"):
+            return
+        data = payload.get("data")
+        off_data = payload.get("offData")
+        if not isinstance(data, list) or isinstance(off_data, bool):
+            return
+        if not isinstance(off_data, (int, float)):
+            return
+        values["is_error"] = _Observed(
+            int(bool(data) or float(off_data) != 0),
+            ValueValidity.VALID,
+            observed_at,
+        )
 
     def set_hems_monitoring(
         self,

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "5.0.0-rc11")
+        self.assertEqual(manifest_version, "5.0.0-rc12")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_energy_forecast_config.py
+++ b/tests/test_energy_forecast_config.py
@@ -51,8 +51,8 @@ class EnergyForecastConfigTests(unittest.TestCase):
     def test_rc_version_is_consistent(self):
         const = (COMPONENT / "const.py").read_text(encoding="utf-8")
         manifest = (COMPONENT / "manifest.json").read_text(encoding="utf-8")
-        self.assertIn('INTEGRATION_VERSION = "5.0.0-rc11"', const)
-        self.assertIn('"version": "5.0.0-rc11"', manifest)
+        self.assertIn('INTEGRATION_VERSION = "5.0.0-rc12"', const)
+        self.assertIn('"version": "5.0.0-rc12"', manifest)
         self.assertIn('"after_dependencies": ["energy"]', manifest)
         self.assertLess(
             manifest.index('"after_dependencies"'), manifest.index('"codeowners"')

--- a/tests/test_native_source_fusion.py
+++ b/tests/test_native_source_fusion.py
@@ -74,6 +74,23 @@ def report(
     )
 
 
+def error_event(at, *, data=None, off_data=0):
+    payload = {"offData": off_data, "eventId": 3, "data": data or []}
+    return CloudMqttMessage(
+        received_at=at,
+        topic="/product-1/device-1/event/error",
+        payload=json.dumps(payload).encode(),
+        parsed_payload=payload,
+        payload_format="json",
+        device_candidate_id="cloud_mqtt:device-1",
+        pack_id=None,
+        known_topic=False,
+        session_number=1,
+        transport="cloud_mqtt",
+        retained=False,
+    )
+
+
 class NativeSourceFusionTests(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
         self.now = datetime(2026, 9, 7, 12, 0, tzinfo=timezone.utc)
@@ -103,6 +120,33 @@ class NativeSourceFusionTests(unittest.IsolatedAsyncioTestCase):
         ).state
         self.assertEqual(state.hems_active.validity, ValueValidity.INVALID)
         self.assertIsNone(state.hems_active.value)
+
+    def test_cloud_error_snapshot_prevents_false_protection_conflict(self):
+        """Match the SF2400AC Cloud plus ZenSDK startup sequence."""
+        self.fusion.apply(
+            report(
+                self.now,
+                {"faultLevel": 2, "is_error": 0},
+                transport="zensdk",
+            )
+        )
+        conflict = self.fusion.apply(
+            report(
+                self.now + timedelta(milliseconds=1),
+                {"faultLevel": 2},
+                transport="cloud_mqtt",
+            )
+        ).state
+        self.assertEqual(
+            conflict.protection_active.validity,
+            ValueValidity.INVALID,
+        )
+
+        resolved = self.fusion.apply(
+            error_event(self.now + timedelta(milliseconds=2))
+        ).state
+        self.assertTrue(resolved.protection_active.valid)
+        self.assertFalse(resolved.protection_active.value)
 
     def test_small_soc_difference_is_allowed_but_large_conflict_blocks(self):
         self.fusion.apply(

--- a/tests/test_native_zendure_ha_integration.py
+++ b/tests/test_native_zendure_ha_integration.py
@@ -17,7 +17,7 @@ class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
         manifest = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )
-        self.assertEqual(manifest["version"], "5.0.0-rc11")
+        self.assertEqual(manifest["version"], "5.0.0-rc12")
         self.assertIn("paho-mqtt==2.1.0", manifest["requirements"])
 
     def test_options_flow_uses_a_password_field_and_never_suggests_token(self) -> None:

--- a/tests/test_zendure_normalizer.py
+++ b/tests/test_zendure_normalizer.py
@@ -232,6 +232,42 @@ class ZendureNormalizerTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(result.state.protection_active.valid)
         self.assertFalse(result.state.protection_active.value)
 
+    async def test_empty_cloud_error_event_clears_fault_level_fallback(self):
+        """The Cloud error snapshot is authoritative for ZenSDK devices."""
+        normalizer = ZendureCloudNormalizer(self.bootstrap)
+        initial = normalizer.apply(
+            report(self.at, {"properties": {"faultLevel": 2}})
+        )
+        self.assertTrue(initial.state.protection_active.value)
+
+        cleared = normalizer.apply(
+            report(
+                self.at + timedelta(milliseconds=1),
+                {"offData": 0, "eventId": 3, "data": []},
+                topic="event/error",
+            )
+        )
+
+        self.assertTrue(cleared.state.protection_active.valid)
+        self.assertFalse(cleared.state.protection_active.value)
+        self.assertEqual(
+            cleared.state.protection_active.observed_at,
+            self.at + timedelta(milliseconds=1),
+        )
+
+    async def test_populated_cloud_error_event_sets_explicit_error(self):
+        normalizer = ZendureCloudNormalizer(self.bootstrap)
+        result = normalizer.apply(
+            report(
+                self.at,
+                {"offData": 0, "eventId": 3, "data": [{"code": 17}]},
+                topic="event/error",
+            )
+        )
+
+        self.assertTrue(result.state.protection_active.valid)
+        self.assertTrue(result.state.protection_active.value)
+
     async def test_missing_invalid_unsupported_stale_and_offline_are_distinct(self):
         system_id = "cloud_mqtt:device-1"
         normalizer = ZendureCloudNormalizer(


### PR DESCRIPTION
## Summary
- interpret Zendure Cloud `event/error` snapshots as the authoritative current error state
- prevent the normal SF2400AC combination `faultLevel: 2` plus an empty error list from invalidating native telemetry
- retain fail-closed behavior when the Cloud error event contains data or a non-zero `offData`
- bump both packaged and runtime versions to `5.0.0-rc12`

## Validation
- 13 Zendure normalizer tests passed
- 11 native source-fusion tests passed
- 740 dependency-free tests passed; the four remaining discovery imports require optional local test packages (`pytest` and `voluptuous`)
- Python compilation passed
- all integration JSON files parsed successfully
- `git diff --check` passed