### PR TITLE
Keep confirmed Cloud error state fresh

### DIFF
--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -38,7 +38,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "5.0.0-rc12"
+INTEGRATION_VERSION = "5.0.0-rc13"
 
 # V5 native Zendure discovery is observation-only in the first development
 # build. The App Token is account discovery material and must never be copied

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": ["bleak-retry-connector>=3.9.0", "paho-mqtt==2.1.0"],
-  "version": "5.0.0-rc12"
+  "version": "5.0.0-rc13"
 }

--- a/custom_components/battery_smartflow_ai/zendure_normalizer.py
+++ b/custom_components/battery_smartflow_ai/zendure_normalizer.py
@@ -360,6 +360,10 @@ class ZendureCloudNormalizer:
                 payload,
                 observed_at,
             )
+            self._refresh_confirmed_cloud_error_state(
+                self._device_values[system_id],
+                message,
+            )
             properties = payload.get("properties")
             if isinstance(properties, Mapping):
                 self._apply_properties(
@@ -405,6 +409,31 @@ class ZendureCloudNormalizer:
             ValueValidity.VALID,
             observed_at,
         )
+
+    @staticmethod
+    def _refresh_confirmed_cloud_error_state(
+        values: dict[str, _Observed],
+        message: CloudMqttMessage,
+    ) -> None:
+        """Keep a confirmed Cloud error snapshot fresh with device reports.
+
+        Zendure sends ``event/error`` as a state snapshot, not with every
+        report.  A subsequent inbound properties report confirms that the
+        device is still communicating on the same Cloud session, so the last
+        explicit error state remains current.  Outbound ``getAll`` requests
+        and retained data deliberately do not extend this safety window.
+        """
+
+        if (
+            message.transport != "cloud_mqtt"
+            or message.retained
+            or not message.topic.endswith("/properties/report")
+        ):
+            return
+        confirmed = values.get("is_error")
+        if confirmed is None or confirmed.validity is not ValueValidity.VALID:
+            return
+        confirmed.observed_at = message.received_at
 
     def set_hems_monitoring(
         self,

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "5.0.0-rc12")
+        self.assertEqual(manifest_version, "5.0.0-rc13")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_energy_forecast_config.py
+++ b/tests/test_energy_forecast_config.py
@@ -51,8 +51,8 @@ class EnergyForecastConfigTests(unittest.TestCase):
     def test_rc_version_is_consistent(self):
         const = (COMPONENT / "const.py").read_text(encoding="utf-8")
         manifest = (COMPONENT / "manifest.json").read_text(encoding="utf-8")
-        self.assertIn('INTEGRATION_VERSION = "5.0.0-rc12"', const)
-        self.assertIn('"version": "5.0.0-rc12"', manifest)
+        self.assertIn('INTEGRATION_VERSION = "5.0.0-rc13"', const)
+        self.assertIn('"version": "5.0.0-rc13"', manifest)
         self.assertIn('"after_dependencies": ["energy"]', manifest)
         self.assertLess(
             manifest.index('"after_dependencies"'), manifest.index('"codeowners"')

--- a/tests/test_native_zendure_ha_integration.py
+++ b/tests/test_native_zendure_ha_integration.py
@@ -17,7 +17,7 @@ class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
         manifest = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )
-        self.assertEqual(manifest["version"], "5.0.0-rc12")
+        self.assertEqual(manifest["version"], "5.0.0-rc13")
         self.assertIn("paho-mqtt==2.1.0", manifest["requirements"])
 
     def test_options_flow_uses_a_password_field_and_never_suggests_token(self) -> None:

--- a/tests/test_zendure_normalizer.py
+++ b/tests/test_zendure_normalizer.py
@@ -268,6 +268,55 @@ class ZendureNormalizerTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(result.state.protection_active.valid)
         self.assertTrue(result.state.protection_active.value)
 
+    async def test_cloud_device_report_refreshes_confirmed_error_state(self):
+        normalizer = ZendureCloudNormalizer(
+            self.bootstrap, stale_after_seconds=30
+        )
+        normalizer.apply(
+            report(
+                self.at,
+                {"offData": 0, "eventId": 3, "data": []},
+                topic="event/error",
+            )
+        )
+
+        refreshed_at = self.at + timedelta(seconds=31)
+        result = normalizer.apply(
+            report(
+                refreshed_at,
+                {"properties": {"electricLevel": 55}},
+            ),
+            now=refreshed_at,
+        )
+
+        self.assertTrue(result.state.protection_active.valid)
+        self.assertFalse(result.state.protection_active.value)
+        self.assertEqual(result.state.protection_active.observed_at, refreshed_at)
+
+    async def test_cloud_getall_echo_cannot_refresh_confirmed_error_state(self):
+        normalizer = ZendureCloudNormalizer(
+            self.bootstrap, stale_after_seconds=30
+        )
+        normalizer.apply(
+            report(
+                self.at,
+                {"offData": 0, "eventId": 3, "data": []},
+                topic="event/error",
+            )
+        )
+
+        after_window = self.at + timedelta(seconds=31)
+        result = normalizer.apply(
+            report(
+                after_window,
+                {"properties": ["getAll"]},
+                topic="properties/read",
+            ),
+            now=after_window,
+        )
+
+        self.assertFalse(result.state.protection_active.valid)
+
     async def test_missing_invalid_unsupported_stale_and_offline_are_distinct(self):
         system_id = "cloud_mqtt:device-1"
         normalizer = ZendureCloudNormalizer(


### PR DESCRIPTION
## Summary
- keep a confirmed Zendure Cloud error snapshot fresh while real inbound device reports continue
- prevent the normal SF2400AC no-error state from expiring after 30 seconds between `event/error` snapshots
- do not let BSFAI's own `getAll` requests or retained data extend the safety window
- preserve the fail-safe path when telemetry stops or a real Cloud error is reported
- bump the integration to `5.0.0-rc13`

## Validation
- 15 Zendure normalizer tests passed
- 11 native source-fusion tests passed
- 742 dependency-free tests passed; four test modules require optional local packages (`pytest` and `voluptuous`)
- Python compilation passed
- all integration JSON files parsed successfully
- `git diff --check` passed