### PR TITLE
Round native Cloud power commands to whole watts

### DIFF
--- a/custom_components/battery_smartflow_ai/const.py
+++ b/custom_components/battery_smartflow_ai/const.py
@@ -38,7 +38,7 @@ def virtual_device_model(language: str | None) -> str:
 
 INTEGRATION_MANUFACTURER = "PalmManiac"
 INTEGRATION_MODEL = "Home Assistant Integration"
-INTEGRATION_VERSION = "5.0.0-rc13"
+INTEGRATION_VERSION = "5.0.0-rc14"
 
 # V5 native Zendure discovery is observation-only in the first development
 # build. The App Token is account discovery material and must never be copied

--- a/custom_components/battery_smartflow_ai/manifest.json
+++ b/custom_components/battery_smartflow_ai/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/PalmManiac/battery-smartflow-ai/issues",
   "requirements": ["bleak-retry-connector>=3.9.0", "paho-mqtt==2.1.0"],
-  "version": "5.0.0-rc13"
+  "version": "5.0.0-rc14"
 }

--- a/custom_components/battery_smartflow_ai/zendure_cloud_mqtt_commands.py
+++ b/custom_components/battery_smartflow_ai/zendure_cloud_mqtt_commands.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import StrEnum
+import math
 from typing import Callable, Mapping, Protocol
 
 from .core.models import ZendureTransport
@@ -211,9 +212,9 @@ class ZendureCloudCommandAdapter:
 
 def _whole_watts(value: float) -> int:
     number = float(value)
-    if not number.is_integer() or number < 0:
+    if not math.isfinite(number) or number < 0:
         raise ValueError("invalid_power_value")
-    return int(number)
+    return int(round(number))
 
 
 def _soc_tenths(value: float | None) -> int:

--- a/tests/test_debug_integration_contract.py
+++ b/tests/test_debug_integration_contract.py
@@ -29,7 +29,7 @@ class DebugIntegrationContractTests(unittest.TestCase):
             and isinstance(node.value, ast.Constant)
         )
 
-        self.assertEqual(manifest_version, "5.0.0-rc13")
+        self.assertEqual(manifest_version, "5.0.0-rc14")
         self.assertEqual(runtime_version, manifest_version)
 
     def test_services_expose_only_supported_durations(self) -> None:

--- a/tests/test_energy_forecast_config.py
+++ b/tests/test_energy_forecast_config.py
@@ -51,8 +51,8 @@ class EnergyForecastConfigTests(unittest.TestCase):
     def test_rc_version_is_consistent(self):
         const = (COMPONENT / "const.py").read_text(encoding="utf-8")
         manifest = (COMPONENT / "manifest.json").read_text(encoding="utf-8")
-        self.assertIn('INTEGRATION_VERSION = "5.0.0-rc13"', const)
-        self.assertIn('"version": "5.0.0-rc13"', manifest)
+        self.assertIn('INTEGRATION_VERSION = "5.0.0-rc14"', const)
+        self.assertIn('"version": "5.0.0-rc14"', manifest)
         self.assertIn('"after_dependencies": ["energy"]', manifest)
         self.assertLess(
             manifest.index('"after_dependencies"'), manifest.index('"codeowners"')

--- a/tests/test_native_zendure_ha_integration.py
+++ b/tests/test_native_zendure_ha_integration.py
@@ -17,7 +17,7 @@ class NativeZendureHomeAssistantIntegrationTests(unittest.TestCase):
         manifest = json.loads(
             (COMPONENT / "manifest.json").read_text(encoding="utf-8")
         )
-        self.assertEqual(manifest["version"], "5.0.0-rc13")
+        self.assertEqual(manifest["version"], "5.0.0-rc14")
         self.assertIn("paho-mqtt==2.1.0", manifest["requirements"])
 
     def test_options_flow_uses_a_password_field_and_never_suggests_token(self) -> None:

--- a/tests/test_zendure_cloud_mqtt_commands.py
+++ b/tests/test_zendure_cloud_mqtt_commands.py
@@ -105,10 +105,29 @@ class CloudCommandMappingTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "model_not_approved"):
             map_cloud_command(envelope(command), unknown, first_message_id=1, timestamp=1)
 
-    def test_invalid_scaling_is_rejected(self):
+    def test_fractional_power_is_rounded_like_other_native_transports(self):
         fractional_power = DeviceCommand("output", output_limit_w=1.5, should_write_mode=False, should_write_input=False, should_write_output=True)
-        with self.assertRaisesRegex(ValueError, "invalid_power_value"):
-            map_cloud_command(envelope(fractional_power), self.data, first_message_id=1, timestamp=1)
+        *_, writes = map_cloud_command(
+            envelope(fractional_power), self.data, first_message_id=1, timestamp=1
+        )
+        self.assertEqual(
+            [(item.property_name, item.value) for item in writes],
+            [("smartMode", 1), ("acMode", 2), ("outputLimit", 2), ("inputLimit", 0)],
+        )
+
+    def test_negative_and_non_finite_power_are_rejected(self):
+        for value in (-1.0, float("nan"), float("inf")):
+            with self.subTest(value=value), self.assertRaisesRegex(
+                ValueError, "invalid_power_value"
+            ):
+                map_cloud_command(
+                    envelope(DeviceCommand(
+                        "output", output_limit_w=value,
+                        should_write_mode=False, should_write_input=False,
+                        should_write_output=True,
+                    )),
+                    self.data, first_message_id=1, timestamp=1,
+                )
 
     def test_execute_records_publish_then_fresh_readback(self):
         publisher = Publisher()
@@ -139,6 +158,24 @@ class CloudCommandMappingTests(unittest.TestCase):
         failed = failed_adapter.execute(command(30))
         self.assertEqual(failed.status, CloudCommandStatus.TRANSPORT_ERROR)
         self.assertEqual(failed.writes_sent, 0)
+
+    def test_fractional_follow_up_command_is_published(self):
+        publisher = Publisher()
+        adapter = ZendureCloudCommandAdapter(
+            self.data, publisher, NativeCommandVerificationManager()
+        )
+        first = adapter.execute(envelope(DeviceCommand(
+            "output", output_limit_w=300.0, should_write_mode=False,
+            should_write_input=False, should_write_output=True,
+        )))
+        follow_up = adapter.execute(envelope(DeviceCommand(
+            "output", output_limit_w=310.4, should_write_mode=False,
+            should_write_input=False, should_write_output=True,
+        )))
+
+        self.assertEqual(first.status, CloudCommandStatus.SENT)
+        self.assertEqual(follow_up.status, CloudCommandStatus.SENT)
+        self.assertEqual(publisher.calls[1][2][2].value, 310)
 
     def test_diagnostics_contain_no_route_or_credentials(self):
         verification = NativeCommandVerificationManager()


### PR DESCRIPTION
## Summary
- round finite, non-negative Cloud MQTT power commands to whole watts, matching ZenSDK and local MQTT behavior
- restore Cloud follow-up output-limit writes after the initial whole-watt command
- continue to reject negative and non-finite power values
- bump the integration to `5.0.0-rc14`

## Validation
- 10 Cloud MQTT command tests passed
- 15 Zendure normalizer tests passed
- 744 dependency-free tests passed; four test modules require optional local packages (`pytest` and `voluptuous`)
- Python compilation passed
- all integration JSON files parsed successfully
- `git diff --check` passed